### PR TITLE
Automated Template Switching

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,11 +1,11 @@
 import os.path
 
 import pytest
+from qtpy.QtCore import QSize
 
 from pydm import Display
 from typhon import TyphonDeviceDisplay
 from typhon.utils import clean_attr
-
 from .conftest import show_widget
 
 
@@ -48,10 +48,16 @@ def test_display_with_md(motor, display):
     assert display.templates['detailed_screen'] == 'tst.ui'
 
 
-def test_display_type_change(display):
-    # Changing template type changes template
-    display.display_type = display.embedded_screen
-    assert display.current_template == display.templates['embedded_screen']
+def test_display_enlarge_to_engineering(display):
+    display.resize(display.engineering_size + QSize(100, 100))
+    assert display.display_type == display.engineering_screen
+    assert display.current_template == display.engineering_template
+
+
+def test_display_shrink_to_embedded_size(display):
+    display.resize(display._embedded_size - QSize(50, 50))
+    assert display.display_type == display.embedded_screen
+    assert display.current_template == display.embedded_template
 
 
 def test_display_modified_templates(display, motor):
@@ -111,11 +117,3 @@ def test_display_template_property_setters(display, display_type):
     attr = display_type.name.replace('screen', 'template')
     setattr(display, attr, 'tst.ui')
     assert display.templates[display_type.name] == 'tst.ui'
-
-
-def test_display_template_change(display):
-    display.display_type = display.embedded_screen
-    new_template = display.templates['engineering_screen']
-    display.embedded_template = new_template
-    assert display.current_template == new_template
-    assert display._main_widget.ui_filename() == new_template

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -81,6 +81,7 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
         self.layout().setContentsMargins(0, 0, 0, 0)
         # Load template
         self.load_template()
+        self._embedded_height = 150
 
     @property
     def current_template(self):
@@ -117,6 +118,34 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
         if getattr(self, 'devices', []):
             return self.devices[0].name
         return ''
+
+    @Property(str)
+    def embedded_template(self):
+        """Embedded template"""
+        return self.templates[self.TemplateEnum.embedded_screen.name]
+
+    @embedded_template.setter
+    def embedded_template(self, template):
+        self._set_template(self.TemplateEnum.embedded_screen.name, template)
+
+    @Property(str)
+    def detailed_template(self):
+        """Detailed template"""
+        return self.templates[self.TemplateEnum.detailed_screen.name]
+
+    @detailed_template.setter
+    def detailed_template(self, template):
+        self._set_template(self.TemplateEnum.detailed_screen.name, template)
+
+    @Property(str)
+    def engineering_template(self):
+        """Engineering template"""
+        return self.templates[self.TemplateEnum.engineering_screen.name]
+
+    @engineering_template.setter
+    def engineering_template(self, template):
+        return self._set_template(self.TemplateEnum.engineering_screen.name,
+                                  template)
 
     def load_template(self, macros=None):
         """
@@ -253,3 +282,13 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
     def _tx(self, value):
         """Receive information from happi channel"""
         self.add_device(value['obj'], macros=value['md'])
+
+    def _set_template(self, template_type, value):
+        """Helper function for template type setters"""
+        # Add our new template if valid and is different than the current
+        if value and self.templates[template_type] != value:
+            self.templates[template_type] = value
+            # If we are currently using the old template we will need to
+            # redraw with the new one
+            if self.TemplateEnum(self._display_type).name == template_type:
+                self.load_template()

--- a/typhon/ui/embedded_screen.ui
+++ b/typhon/ui/embedded_screen.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>150</height>
+    <width>301</width>
+    <height>147</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,14 +18,14 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>300</width>
-    <height>150</height>
+    <width>0</width>
+    <height>0</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>600</width>
-    <height>300</height>
+    <width>1000000</width>
+    <height>1000000</height>
    </size>
   </property>
   <property name="sizeIncrement">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The idea was that Typhon would select the correct template based on the size of the widget. This would look really smooth in the docking system. You launch a full display and you get the detailed view. If you tile a bunch they automatically go to the embedded mode, or you can pop it out and expand it to get the engineering screen.

![embedded_size](https://user-images.githubusercontent.com/25753048/63365645-df123300-c32c-11e9-8543-d3f5e6ba6270.gif)

The main issue is some flashing as you get close to a border between templates. The template flips which causes a resize, which causes a template flip which... 💀  I tried adding some hysteresis but didn't get far. 

* This example looks fine, but in the test suite it looks as if multiple templates are being loaded on the same widget? (Investigate with `python run_tests.py tests/test_display --show-ui`)
* I think adding something in the context menu to flip which template you are using could be a worthwhile solution that might be better in the long term.


