### PR TITLE
PyDM 2.0 and Ophyd Metadata

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,13 +94,21 @@ def motor():
 
 class RichSignal(Signal):
 
-    def describe(self):
-        return {self.name: {'enum_strs': ('a', 'b', 'c'),
-                            'precision': 2,
-                            'units': 'urad',
-                            'dtype': 'number',
-                            'shape': []}}
+    def __init__(self, *args, metadata=None, **kwargs):
+        metadata = metadata or dict()
+        metadata.update({'enum_strs': ('a', 'b', 'c'),
+                         'severity': 0,
+                         'precision': 2,
+                         'lower_ctrl_limit': -100,
+                         'upper_ctrl_limit': 100,
+                         'units': 'urad'})
+        super().__init__(*args, metadata=metadata, **kwargs)
 
+    def describe(self):
+        """Add metadata to description"""
+        desc = super().describe()
+        desc[self.name].update(self._metadata)
+        return desc
 
 class DeadSignal(Signal):
     subscribable = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,11 +113,8 @@ class RichSignal(Signal):
 class DeadSignal(Signal):
     subscribable = False
 
-    def subscribe(self, *args, **kwargs):
-        if self.subscribable:
-            pass
-        else:
-            raise TimeoutError("Timeout on subscribe")
+    def wait_for_connection(self, *args, **kwargs):
+        raise TimeoutError("Timeout on wait_for_connection")
 
     def get(self, *args, **kwargs):
         raise TimeoutError("Timeout on get")

--- a/typhon/display.py
+++ b/typhon/display.py
@@ -5,7 +5,7 @@ import os.path
 from pydm import Display
 from pydm.utilities.display_loading import load_py_file
 
-from qtpy.QtCore import Property, Slot, Q_ENUMS
+from qtpy.QtCore import Property, Q_ENUMS
 from qtpy.QtWidgets import QHBoxLayout, QWidget
 
 from .utils import (ui_dir, TyphonBase, clear_layout,
@@ -249,7 +249,12 @@ class TyphonDeviceDisplay(TyphonBase, TyphonDesignerMixin, DisplayTypes):
         display.add_device(device, macros=macros)
         return display
 
-    @Slot(object)
-    def _tx(self, value):
+    def _receive_data(self, data=None, introspection=None, *args, **kwargs):
         """Receive information from happi channel"""
-        self.add_device(value['obj'], macros=value['md'])
+        # Store any of the default PyDM information
+        super()._receive_data(data=data, introspection=introspection,
+                              *args, **kwargs)
+        data = data or {}
+        # If we have a device add it
+        if data.get('object') and data['object'] not in self.devices:
+            self.add_device(data['object'], macros=data.get('metadata', {}))

--- a/typhon/plugins/core.py
+++ b/typhon/plugins/core.py
@@ -1,22 +1,10 @@
-"""
-Module Docstring
-"""
-############
-# Standard #
-############
 import logging
 
-###############
-# Third Party #
-###############
 import numpy as np
 from ophyd.utils.epics_pvs import _type_map
 from pydm.data_plugins.plugin import PyDMPlugin, PyDMConnection
 from qtpy.QtCore import Slot, Qt
 
-##########
-# Module #
-##########
 from ..utils import raise_to_operator
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This is a draft for updating the plugins to be compatible with PyDM 2.0 while also taking advantage of the new `SUB_META` options in Ophyd. This passes will the `master` of both projects. What this doesn't do:

1. This does not work with `Signal`. We depend on the fact that we will receive a connection callback eventually from the signal. For a raw software `Signal` this will never come. We will also never see a value callback if you initialize like `Signal(value=1, ...)`
2. This does not replace the logic where we use the base `ca` plugin for `EpicsSignal`
3. This does not allow a user to subscribe to `SUB_SETPOINT` and `SUB_SETPOINT_META`. The logic would need to watch for `sig://my_signal@SUB_SETPOINT` (exact syntax pending)