### PR TITLE
FIX: Too Many Files and Subdevices depth

### DIFF
--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -56,7 +56,8 @@ class DeviceParameter(SidebarParameter):
                 # If that device has children, make sure they are also
                 # displayed further in the tree
                 if subdevice._sub_devices:
-                    children.append(DeviceParameter(subdevice, subdevices=False))
+                    children.append(
+                        DeviceParameter(subdevice, subdevices=False))
                 # Otherwise just make a regular parameter out of it
                 else:
                     child_name = clean_name(subdevice,

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -56,7 +56,7 @@ class DeviceParameter(SidebarParameter):
                 # If that device has children, make sure they are also
                 # displayed further in the tree
                 if subdevice._sub_devices:
-                    children.append(DeviceParameter(subdevice))
+                    children.append(DeviceParameter(subdevice, subdevices=False))
                 # Otherwise just make a regular parameter out of it
                 else:
                     child_name = clean_name(subdevice,

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -205,12 +205,15 @@ def random_color():
 
 
 class TyphosLoading(QLabel):
+    loading_gif = None
     """Simple widget that displays a loading GIF"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._icon_size = QSize(32, 32)
-        loading_path = os.path.join(ui_dir, 'loading.gif')
-        self._animation = QMovie(loading_path)
+        if TyphosLoading.loading_gif is None:
+            loading_path = os.path.join(ui_dir, 'loading.gif')
+            TyphosLoading.loading_gif = QMovie(loading_path)
+        self._animation = TyphosLoading.loading_gif
         self._animation.setScaledSize(self._icon_size)
         self.setMovie(self._animation)
         self._animation.start()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- I made the stupid mistake of trusting QMovie to close the file, which it clearly doesn't do. Now we cache the loading GIF in the class. This fix the `Too many open files`... sorry @ZLLentz for wasting your time...
- There is no point of showing up all the subdevices in a device tree (e.g. Area Detector with its dozen of subdevices). So we limit it to 1 subdevice level.
