### PR TITLE
FIX: Force ophyd.Device to always be lazy_wait_for_connection=False'

### DIFF
--- a/typhos/__init__.py
+++ b/typhos/__init__.py
@@ -16,3 +16,6 @@ from .plugins import register_signal
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+from ophyd import Device
+Device.lazy_wait_for_connection = False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Without setting `lazy_wait_for_connection=False` a device that has components which are classified as `lazy` will result in a blocking call when we try to read the `configuration_attrs` and other information as well.
Since on the UI we need to have the asynchronous behavior of the connection, which is different at an interactive shell usage, it is in our best interest to patch the Device class to have `lazy_wait_for_connection=False` by default. That allows us to introspect the inner components and assemble the screen as well as subscribe to callback for proper generation of the UI when this device and its signals connect.
