### PR TITLE
ENH: Use exponential displayFormat if EGU requires it.

### DIFF
--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -23,6 +23,8 @@ from pyqtgraph.parametertree import parameterTypes as ptypes
 
 logger = logging.getLogger(__name__)
 
+EXPONENTIAL_UNITS = ['mtorr', 'torr', 'kpa', 'pa']
+
 
 class TogglePanel(QWidget):
     """
@@ -110,6 +112,23 @@ class TyphosLineEdit(PyDMLineEdit):
     def sizeHint(self):
         return QSize(100, 30)
 
+    def unit_changed(self, new_unit):
+        """
+        Callback invoked when the Channel has new unit value.
+        This callback also triggers an update_format_string call so the
+        new unit value is considered if ```showUnits``` is set.
+
+        Parameters
+        ----------
+        new_unit : str
+            The new unit
+        """
+        if self._unit != new_unit:
+            super().unit_changed(new_unit)
+            if new_unit.lower() in EXPONENTIAL_UNITS \
+                    and self.displayFormat == PyDMLabel.DisplayFormat.Default:
+                self.displayFormat = PyDMLabel.DisplayFormat.Exponential
+
 
 class TyphosLabel(PyDMLabel):
     """
@@ -125,6 +144,23 @@ class TyphosLabel(PyDMLabel):
 
     def sizeHint(self):
         return QSize(100, 30)
+
+    def unit_changed(self, new_unit):
+        """
+        Callback invoked when the Channel has new unit value.
+        This callback also triggers an update_format_string call so the
+        new unit value is considered if ```showUnits``` is set.
+
+        Parameters
+        ----------
+        new_unit : str
+            The new unit
+        """
+        if self._unit != new_unit:
+            super().unit_changed(new_unit)
+            if new_unit.lower() in EXPONENTIAL_UNITS \
+                    and self.displayFormat == PyDMLabel.DisplayFormat.Default:
+                self.displayFormat = PyDMLabel.DisplayFormat.Exponential
 
 
 class TyphosSidebarItem(ptypes.ParameterItem):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR tries to be a bit smart on using an adequate displayFormat depending on the kind of information we are displaying. This was caught by @slacAdpai while testing an expert screen generated via `Typhos` in which the displayed value did not match the display at the `pcdswidgets` readback. That was due to the `displayFormat` that was set to be `Exponential` in one and `Default` at the other. With this PR we try to be a bit smart at the autogeneration and rely at the EGU information coming from the control system to switch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Engineers and scientists would like to properly see the value of the readings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally
