### PR TITLE
ENH: New typhos cli functionality

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
       - happi >=1.3.0
       - numpy
       - ophyd >=1.2.0
+      - pcdsutils
       - pyqtgraph
       - pydm >=1.6.0
       - qdarkstyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ qtpy
 pyqtgraph
 ophyd
 numpydoc
+pcdsutils

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,3 +46,20 @@ def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
     assert dev_display.force_template == 'test.ui'
     qapp.setStyleSheet(style)
     os.remove('test.qss')
+
+
+@pytest.mark.parametrize('klass, name', [
+    ("ophyd.sim.SynAxis[]", "device"),
+    ("ophyd.sim.SynAxis[{'name':'foo'}]", "foo")
+])
+def test_cli_class(monkeypatch, qapp, qtbot, klass, name):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    window = typhos_cli([klass])
+    qtbot.addWidget(window)
+    assert window.isVisible()
+    assert name == window.centralWidget().devices[0].name
+
+
+def test_cli_class_invalid(qtbot):
+    window = typhos_cli(["non.Valid.ClassName[]"])
+    assert window is None

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -8,6 +8,8 @@ from pydm.utilities.display_loading import load_py_file
 from qtpy.QtCore import Property, Slot, Q_ENUMS
 from qtpy.QtWidgets import QHBoxLayout, QWidget
 
+import pcdsutils
+
 from .utils import (ui_dir, TyphosBase, clear_layout, reload_widget_stylesheet)
 from .widgets import TyphosDesignerMixin
 
@@ -246,6 +248,39 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, DisplayTypes):
             display.force_template = template
         # Add the device
         display.add_device(device, macros=macros)
+        return display
+
+    @classmethod
+    def from_class(cls, klass, *, template=None, macros=None, **kwargs):
+        """
+        Create a new TyphosDeviceDisplay from a Device class
+
+        Loads the signals in to the appropriate positions and sets the title to
+        a cleaned version of the device name
+
+        Parameters
+        ----------
+        klass : str or class
+        template :str, optional
+            Set the ``display_template``
+        macros: dict, optional
+            Macro substitutions to be placed in template
+        kwargs : dict
+            Extra arguments are used at device instantiation
+
+        Returns
+        -------
+        TyphosDeviceDisplay
+        """
+        try:
+            obj = pcdsutils.utils.get_instance_by_name(klass, **kwargs)
+        except Exception:
+            logger.exception('Failed to generate TyphosDeviceDisplay from '
+                             'device %s', obj)
+            return None
+        display = TyphosDeviceDisplay.from_device(
+            obj, template=template, macros=macros
+        )
         return display
 
     @Slot(object)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
ENH: Add option at typhos.cli to allow for users to pass a class and args.
ENH: Added TyphosDeviceDisplay.from_class to allow a display to be created via a class and args/kwargs.
BLD: Added dependency for pcdsutils.
TST: Added tests for the new cli functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
@klauer mentioned that it would be really useful for engineers and users in general to be able to quickly check a screen for a particular device.
Now the `typhos` command line interface allow that by passing a class and kwargs in the following format:
```bash
$ typhos "package.ClassName[{"arg1":"val1",...}]"
```
The command line interface still support Happi entries and they can be mixed together.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests added for `typhos.cli`.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
argparse help was expanded to also describe the possibility to load from a class.

## Dependencies
This PR depends on https://github.com/pcdshub/pcdsutils/pull/4