### PR TITLE
FIX: restore missing show signals tags

### DIFF
--- a/typhos/ui/detailed_positioner.ui
+++ b/typhos/ui/detailed_positioner.ui
@@ -349,6 +349,9 @@
              <property name="showConfig" stdset="0">
               <bool>false</bool>
              </property>
+             <property name="showOmitted" stdset="0">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
           </layout>

--- a/typhos/ui/detailed_screen.ui
+++ b/typhos/ui/detailed_screen.ui
@@ -282,6 +282,9 @@
              <property name="showConfig" stdset="0">
               <bool>false</bool>
              </property>
+             <property name="showOmitted" stdset="0">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
           </layout>

--- a/typhos/ui/embedded_screen.ui
+++ b/typhos/ui/embedded_screen.ui
@@ -151,6 +151,9 @@
     Panel of Signals for Device
     </string>
      </property>
+     <property name="showHints" stdset="0">
+      <bool>true</bool>
+     </property>
      <property name="showNormal" stdset="0">
       <bool>true</bool>
      </property>

--- a/typhos/ui/engineering_screen.ui
+++ b/typhos/ui/engineering_screen.ui
@@ -121,6 +121,12 @@
     Panel of Signals for Device
     </string>
          </property>
+         <property name="showHints" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="showNormal" stdset="0">
+          <bool>true</bool>
+         </property>
          <property name="showConfig" stdset="0">
           <bool>false</bool>
          </property>
@@ -195,6 +201,9 @@
          <property name="showNormal" stdset="0">
           <bool>false</bool>
          </property>
+         <property name="showConfig" stdset="0">
+          <bool>true</bool>
+         </property>
          <property name="showOmitted" stdset="0">
           <bool>false</bool>
          </property>
@@ -268,6 +277,9 @@
          </property>
          <property name="showConfig" stdset="0">
           <bool>false</bool>
+         </property>
+         <property name="showOmitted" stdset="0">
+          <bool>true</bool>
          </property>
          <property name="sortBy" stdset="0">
           <enum>TyphosSignalPanel::byName</enum>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In most of the default templates, some of the `TyphosSignalPanel` instances were missing various kind show tags, mostly for omitted signals but in some cases other types were missing as well. These properties had checkboxes in designer but I have observed that the `typhos` screens are being loaded without the omitted signals. I unchecked and rechecked the boxes and pressed save.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Maybe this will make the omitted signals come back? Probably not.