### PR TITLE
REF: define SignalRO in only one place

### DIFF
--- a/examples/panel.py
+++ b/examples/panel.py
@@ -2,24 +2,7 @@
 import sys
 import numpy as np
 from ophyd import Device, Component as Cpt, Signal
-try:
-    from ophyd.sim import SignalRO
-except ImportError:
-    from ophyd.utils import ReadOnlyError
-
-    class SignalRO(ophyd.sim.Signal):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._metadata.update(
-                connected=True,
-                write_access=False,
-            )
-
-        def put(self, value, *, timestamp=None, force=False):
-            raise ReadOnlyError("The signal {} is readonly.".format(self.name))
-
-        def set(self, value, *, timestamp=None, force=False):
-            raise ReadOnlyError("The signal {} is readonly.".format(self.name))
+from typhos.utils import SignalRO
 from qtpy.QtWidgets import QApplication
 import typhos
 

--- a/examples/panel.py
+++ b/examples/panel.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     app = QApplication(sys.argv)
     typhos.use_stylesheet()
     # Create my panel
-    panel = typhos.TyphonSignalPanel.from_device(sample)
+    panel = typhos.TyphosSignalPanel.from_device(sample)
     panel.sortBy = panel.byName
     # Execute
     panel.show()

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -3,28 +3,8 @@ from unittest.mock import Mock
 import pytest
 from ophyd import Component as Cpt, Signal
 from ophyd.sim import SynAxis
-try:
-    from ophyd.sim import SignalRO
-except ImportError:
-    import ophyd.sim
-    from ophyd.utils import ReadOnlyError
-
-    class SignalRO(ophyd.sim.Signal):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._metadata.update(
-                connected=True,
-                write_access=False,
-            )
-
-        def put(self, value, *, timestamp=None, force=False):
-            raise ReadOnlyError("The signal {} is readonly.".format(self.name))
-
-        def set(self, value, *, timestamp=None, force=False):
-            raise ReadOnlyError("The signal {} is readonly.".format(self.name))
-
-
 from typhos.positioner import TyphosPositionerWidget
+from typhos.utils import SignalRO
 
 from .conftest import show_widget
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -20,25 +20,8 @@ import traceback
 ############
 from ophyd import Kind, Device
 from ophyd.signal import EpicsSignalBase, EpicsSignalRO
-try:
-    from ophyd.sim import SignalRO
-except ImportError:
-    import ophyd.sim
-    from ophyd.utils import ReadOnlyError
-
-    class SignalRO(ophyd.sim.Signal):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._metadata.update(
-                connected=True,
-                write_access=False,
-            )
-
-        def put(self, value, *, timestamp=None, force=False):
-            raise ReadOnlyError("The signal {} is readonly.".format(self.name))
-
-        def set(self, value, *, timestamp=None, force=False):
-            raise ReadOnlyError("The signal {} is readonly.".format(self.name))
+import ophyd.sim
+from ophyd.utils import ReadOnlyError
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QColor, QPainter, QMovie
 from qtpy.QtWidgets import (QApplication, QStyle, QStyleOption, QStyleFactory,
@@ -52,6 +35,19 @@ logger = logging.getLogger(__name__)
 ui_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'ui')
 GrabKindItem = collections.namedtuple('GrabKindItem',
                                       ('attr', 'component', 'signal'))
+
+
+class SignalRO(ophyd.sim.SynSignalRO):
+    def __init__(self, value=0, *args, **kwargs):
+        self._value = value
+        super().__init__(*args, **kwargs)
+        self._metadata.update(
+            connected=True,
+            write_access=False,
+        )
+
+    def get(self):
+        return self._value
 
 
 def channel_from_signal(signal):


### PR DESCRIPTION
Seems the right way since we now assume ophyd 1.4

Upstream patch to fix write_access issue: https://github.com/bluesky/ophyd/pull/813