### PR TITLE
ENH: rework how device templates are found

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ from typhos.utils import (use_stylesheet, clean_name, grab_kind,
                           TyphosBase, raise_to_operator, load_suite,
                           saved_template, no_device_lazy_load)
 
+
 class NestedDevice(Device):
     phi = Cpt(Device)
 
@@ -106,7 +107,7 @@ def test_load_suite(qtbot, happi_cfg):
 
 def test_load_suite_with_bad_py_file():
     with pytest.raises(AttributeError):
-        suite = load_suite(typhos.utils.__file__)
+        load_suite(typhos.utils.__file__)
 
 
 def test_no_device_lazy_load():
@@ -129,3 +130,53 @@ def test_no_device_lazy_load():
     assert Device.lazy_wait_for_connection is old_val
     assert dev.lazy_wait_for_connection is old_val
     assert dev.c.lazy_wait_for_connection is old_val
+
+
+class Class1:
+    ...
+
+
+Class1.full_name = Class1.__module__ + '.' + Class1.__name__
+
+
+@pytest.mark.parametrize(
+    'cls, view_type, expected, create',
+    [pytest.param(
+        Class1, 'detailed',
+        # Expected
+        ['Class1.detailed.ui'],
+        # Create these:
+        ['foo.bar.ui', 'Class1.detailed.ui'],
+     ),
+     pytest.param(
+         Class1, 'detailed',
+         # Expected
+         [Class1.full_name + '.detailed.ui', 'Class1.detailed.ui', 'Class1.ui'],
+         # Create these:
+         ['a.ui', Class1.full_name + '.detailed.ui', 'Class1.detailed.ui', 'Class1.ui'],
+     ),
+     pytest.param(
+         Class1, 'detailed',
+         # Expected
+         [Class1.full_name + '.detailed.ui', 'Class1.detailed.ui'],
+         # Create these:
+         [Class1.full_name + '.detailed.ui', 'b.ui', 'Class1.detailed.ui'],
+     ),
+     pytest.param(
+        Class1, 'detailed',
+         # Expected
+         ['Class1.ui'],
+         # Create these:
+         ['Class1.ui', 'c.ui', 'Class1.engineering.ui'],
+     ),
+     ]
+)
+def test_path_search(tmpdir, cls, view_type, create, expected):
+    for to_create in create:
+        file = tmpdir.join(to_create)
+        file.write('')
+
+    results = typhos.utils.find_best_template_for_class(
+        cls, view_type, paths=[tmpdir])
+
+    assert list(r.name for r in results) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -169,6 +169,13 @@ Class1.full_name = Class1.__module__ + '.' + Class1.__name__
          # Create these:
          ['Class1.ui', 'c.ui', 'Class1.engineering.ui'],
      ),
+     pytest.param(
+        Class1, 'detailed',
+         # Expected
+         ['Class1.py', 'Class1.ui'],
+         # Create these:
+         ['Class1.ui', 'Class1.py', 'c.ui', 'Class1.engineering.ui'],
+     ),
      ]
 )
 def test_path_search(tmpdir, cls, view_type, create, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,7 +176,7 @@ def test_path_search(tmpdir, cls, view_type, create, expected):
         file = tmpdir.join(to_create)
         file.write('')
 
-    results = typhos.utils.find_best_template_for_class(
+    results = typhos.utils.find_templates_for_class(
         cls, view_type, paths=[tmpdir])
 
     assert list(r.name for r in results) == expected

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -71,7 +71,6 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
             templ.name: os.path.join(ui_dir, templ.name + '.ui')
             for templ in self.TemplateEnum
         }
-        print(self.templates)
 
         # Set this to None first so we don't render
         super().__init__(parent=parent)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -250,7 +250,22 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
 
         cls = device.__class__
         for display_type in DisplayTypes:
-            utils.find_templates_for_class(cls, display_type.name, )
+            # TODO display_type names make me sad
+            view = display_type.name
+            if view.endswith('_screen'):
+                view = view.split('_screen')[0]
+
+            # TODO paths
+            filenames = utils.find_templates_for_class(cls, view, [ui_dir])
+            for filename in filenames:
+                old_template = self.templates.get(display_type, None)
+                if not old_template or pathlib.Path(old_template) != filename:
+                    # Only get the first one for now, though this could be used to
+                    # get alternate screen options
+                    self.templates[display_type] = filename
+                    logger.debug('Found new template %s for %s (was %s)',
+                                 display_type, filename, old_template)
+                break
 
     @classmethod
     def from_device(cls, device, template=None, macros=None):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -128,25 +128,20 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
         macros: dict, optional
             Macro substitutions to be made in the file
         """
-        # If we are not fully initialized yet do not try and add anything to
-        # the layout. This will happen if the QApplication has a stylesheet
-        # that forces a template, prior to the creation of this display
         if self.layout() is None:
-            logger.debug("Widget not initialized, do not load template")
+            # If we are not fully initialized yet do not try and add anything
+            # to the layout. This will happen if the QApplication has a
+            # stylesheet that forces a template prior to the creation of this
+            # display
             return
+
         # Clear anything that exists in the current layout
         if self._main_widget:
             logger.debug("Clearing existing layout ...")
             clear_layout(self.layout())
 
         # Assemble our macros
-        self._last_macros = macros or self._last_macros
-        for display_type in self.templates:
-            value = self._last_macros.get(display_type)
-            if value:
-                logger.debug("Found new template %r for %r",
-                             value, display_type)
-                self.templates[display_type] = value
+        self._update_macros(macros)
 
         try:
             self._load_template(self.current_template)
@@ -156,6 +151,15 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
         finally:
             self.layout().addWidget(self._main_widget)
             reload_widget_stylesheet(self)
+
+    def _update_macros(self, macros):
+        self._last_macros = macros or self._last_macros
+        for display_type in self.templates:
+            value = self._last_macros.get(display_type)
+            if value:
+                logger.debug("Found new template %r for %r",
+                             value, display_type)
+                self.templates[display_type] = value
 
     def _load_template(self, filename):
         logger.debug("Loading %s", filename)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -249,6 +249,8 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
             return
 
         cls = device.__class__
+        logger.debug('Searching for templates for %s', cls.__name__)
+
         for display_type in DisplayTypes:
             # TODO display_type names make me sad
             view = display_type.name
@@ -262,7 +264,7 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
                 if not old_template or pathlib.Path(old_template) != filename:
                     # Only get the first one for now, though this could be used to
                     # get alternate screen options
-                    self.templates[display_type] = filename
+                    self.templates[display_type.name] = filename
                     logger.debug('Found new template %s for %s (was %s)',
                                  display_type, filename, old_template)
                 break

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 import os.path
+import pathlib
 
 from qtpy.QtCore import Q_ENUMS, Property, Slot
 from qtpy.QtWidgets import QHBoxLayout, QWidget

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -483,6 +483,8 @@ def find_templates_for_class(cls, view_type, paths, *, extensions=None,
 
     if not extensions:
         extensions = ['.py', '.ui']
+    elif isinstance(extensions, str):
+        extensions = [extensions]
 
     paths = remove_duplicate_items(
         [pathlib.Path(p).expanduser().resolve() for p in paths]

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -420,6 +420,15 @@ def no_device_lazy_load():
         Device.lazy_wait_for_connection = old_val
 
 
+def pyqt_class_from_enum(enum):
+    '''
+    Create an inheritable base class from a Python Enum, which can also be used
+    for Q_ENUMS.
+    '''
+    enum_dict = {item.name: item.value for item in list(enum)}
+    return type(enum.__name__, (object, ), enum_dict)
+
+
 def _get_template_filenames_for_class(class_, view_type, *, extension='.ui',
                                       include_mro=True):
     '''

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -4,6 +4,7 @@ Utility functions for typhos
 import contextlib
 import collections
 import importlib.util
+import inspect
 ############
 # Standard #
 ############
@@ -476,6 +477,9 @@ def find_templates_for_class(cls, view_type, paths, *, extension='.ui',
     path : pathlib.Path
         A matching path, ordered from most-to-least specific.
     '''
+    if not inspect.isclass(cls):
+        cls = type(cls)
+
     paths = remove_duplicate_items(
         [pathlib.Path(p).expanduser().resolve() for p in paths]
     )

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -443,8 +443,8 @@ def remove_duplicate_items(list_):
     return cls(sorted(set(list_), key=list_.index))
 
 
-def find_best_template_for_class(cls, view_type, paths, *, extension='.ui',
-                                 include_mro=True):
+def find_templates_for_class(cls, view_type, paths, *, extension='.ui',
+                             include_mro=True):
     '''
     Given a class `cls` and a view type (such as 'detailed'), search `paths`
     for potential templates to show.

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -418,3 +418,62 @@ def no_device_lazy_load():
         yield
     finally:
         Device.lazy_wait_for_connection = old_val
+
+
+def _get_template_filenames_for_class(class_, view_type, *, extension='.ui',
+                                      include_mro=True):
+    '''
+    Yields all possible template filenames that can be used for the class, in
+    order of priority, including those in the class MRO.
+    '''
+    for cls in class_.mro():
+        module = cls.__module__
+        name = cls.__name__
+        yield f'{module}.{name}.{view_type}{extension}'
+        yield f'{name}.{view_type}{extension}'
+        yield f'{name}{extension}'
+
+        if not include_mro:
+            break
+
+
+def remove_duplicate_items(list_):
+    'Return a de-duplicated list/tuple of items in `list_`, retaining order'
+    cls = type(list_)
+    return cls(sorted(set(list_), key=list_.index))
+
+
+def find_best_template_for_class(cls, view_type, paths, *, extension='.ui',
+                                 include_mro=True):
+    '''
+    Given a class `cls` and a view type (such as 'detailed'), search `paths`
+    for potential templates to show.
+
+    Parameters
+    ----------
+    cls : class
+        Search for templates with this class name
+    view_type : {'detailed', 'engineering', 'embedded'}
+        The view type
+    paths : iterable
+        Iterable of paths to be expanded, de-duplicated, and searched
+    extension : str, optional
+        The template filename extension (default is ``'.ui'``)
+    include_mro : bool, optional
+        Include superclasses - those in the MRO - of ``cls`` as well
+
+    Yields
+    ------
+    path : pathlib.Path
+        A matching path, ordered from most-to-least specific.
+    '''
+    paths = remove_duplicate_items(
+        [pathlib.Path(p).expanduser().resolve() for p in paths]
+    )
+
+    for candidate_filename in _get_template_filenames_for_class(
+            cls, view_type, extension=extension, include_mro=include_mro):
+        for path in paths:
+            for match in path.glob(candidate_filename):
+                if match.is_file():
+                    yield match


### PR DESCRIPTION
Working toward closing #248 

- [x] Search paths for either .ui or .py files, with .py taking precedence
- [x] Test with simple `FakeEpicsMotor`
- [ ] `ui_dir` is set to `typhos/ui`: extend this to multiple directories as in `PYDM_DISPLAYS_PATH` (or perhaps just repurposing it?)

cc @ZLLentz 