### PR TITLE
ENH: Add context menu to switch template.

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -94,17 +94,15 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
         -------
         QMenu
         """
-        def switch_template(fname):
-            self.force_template = fname
-
         menu = QMenu(parent=self)
 
         for display_name, filename in self.templates.items():
             action = menu.addAction(display_name)
-            def switch_template():
+
+            def switch_template(*, filename=filename):
                 self.force_template = filename
+
             action.triggered.connect(switch_template)
-                                                       filename))
 
         return menu
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -101,7 +101,9 @@ class TyphosDeviceDisplay(TyphosBase, TyphosDesignerMixin, _DisplayTypes):
 
         for display_name, filename in self.templates.items():
             action = menu.addAction(display_name)
-            action.triggered.connect(functools.partial(switch_template,
+            def switch_template():
+                self.force_template = filename
+            action.triggered.connect(switch_template)
                                                        filename))
 
         return menu


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Provide users a way to change the current `template` in use via a Context Menu.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As we move ahead with the development of Templates and even the ability to specify templates based on the class hierarchy of devices it is desirable to have the option to pick which template best fits the need for a certain task.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

## Screenshots (if appropriate):
![template_switch](https://user-images.githubusercontent.com/8185425/76133772-a8e98780-5fce-11ea-9860-75565d21ddfb.gif)
