### PR TITLE
ENH: entirely rework display loading mechanism, add display switcher

### DIFF
--- a/tests/plugins/test_core.py
+++ b/tests/plugins/test_core.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+import pydm.utilities
 from ophyd import Signal
 from pydm.widgets import PyDMLineEdit
 from qtpy.QtWidgets import QWidget
@@ -21,7 +22,7 @@ def test_signal_connection(qapp, qtbot):
     # In PyDM > 1.5.0 this will not be neccesary as the widget will be
     # connected after we set the channel name
     if not hasattr(listener, 'connect'):
-        qapp.establish_widget_connections(widget)
+        pydm.utilities.establish_widget_connections(widget)
     # Check that our widget receives the initial value
     qapp.processEvents()
     assert widget._write_access

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -3,7 +3,7 @@ import os.path
 import pytest
 
 from pydm import Display
-from typhos import TyphosDeviceDisplay
+import typhos.display
 from typhos.utils import clean_attr
 
 from .conftest import show_widget
@@ -11,14 +11,24 @@ from .conftest import show_widget
 
 @pytest.fixture(scope='function')
 def display(qtbot):
-    display = TyphosDeviceDisplay()
+    display = typhos.display.TyphosDeviceDisplay()
     qtbot.addWidget(display)
     return display
 
 
+@pytest.fixture(scope='function', params=[False, True])
+def show_switcher(request):
+    return request.param
+
+
+@show_widget
+def test_device_title(device, motor, show_switcher, qtbot):
+    title = typhos.display.TyphosDisplayTitle(show_switcher=show_switcher)
+
+
 @show_widget
 def test_device_display(device, motor, qtbot):
-    panel = TyphosDeviceDisplay.from_device(motor)
+    panel = typhos.display.TyphosDeviceDisplay.from_device(motor)
     panel_main = panel._main_widget
     qtbot.addWidget(panel)
     # We have all our signals
@@ -77,7 +87,7 @@ def test_display_force_template(display):
     assert display.current_template == 'tst.ui'
 
 def test_display_with_channel(client, qtbot):
-    panel = TyphosDeviceDisplay()
+    panel = typhos.display.TyphosDeviceDisplay()
     qtbot.addWidget(panel)
     panel.channel = 'happi://test_motor'
     assert panel.channel == 'happi://test_motor'

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -6,6 +6,7 @@ from pydm import Display
 import typhos.display
 from typhos.utils import clean_attr
 
+from . import conftest
 from .conftest import show_widget
 
 
@@ -109,10 +110,9 @@ def test_display_device_name_property(motor, display):
     assert display.device_name == motor.name
 
 
-def test_display_with_py_file(display):
-    py_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                           'utils/display.py')
-    display.templates['detailed_screen'] = py_file
+def test_display_with_py_file(display, motor):
+    py_file = str(conftest.MODULE_PATH / 'utils' / 'display.py')
+    display.add_device(motor, macros={'detailed_screen': py_file})
     display.load_best_template()
     assert isinstance(display._main_widget, Display)
     assert getattr(display._main_widget, 'is_from_test_file', False)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -42,14 +42,12 @@ def test_device_display(device, motor, qtbot):
     device.name ='test'
     panel.add_device(device)
     panel_main = panel._main_widget
-    assert panel_main.ui.name_label.text() == 'test'
     # We have all our signals
     shown_read_sigs = list(panel_main.read_panel.layout().signals.keys())
-    assert all([clean_attr(sig) in shown_read_sigs
-                for sig in device.read_attrs])
+    assert all(clean_attr(sig) in shown_read_sigs for sig in device.read_attrs)
     shown_cfg_sigs = list(panel_main.config_panel.layout().signals.keys())
-    assert all([clean_attr(sig) in shown_cfg_sigs
-                for sig in device.configuration_attrs])
+    assert all(clean_attr(sig) in shown_cfg_sigs
+               for sig in device.configuration_attrs)
     return panel
 
 
@@ -57,19 +55,22 @@ def test_display_without_md(motor, display):
     # Add a generic motor
     display.add_device(motor)
     assert display.devices[0] == motor
-    assert display.current_template == display.templates['detailed_screen']
+    assert display.current_template == display.templates['detailed_screen'][0]
 
 
 def test_display_with_md(motor, display):
-    display.load_template(macros={'detailed_screen': 'tst.ui'})
-    assert display.current_template == 'tst.ui'
-    assert display.templates['detailed_screen'] == 'tst.ui'
+    display.add_device(
+        motor, macros={'detailed_screen': 'engineering_screen.ui'})
+    display.load_best_template()
+    assert display.current_template.name == 'engineering_screen.ui'
+    assert display.templates['detailed_screen'][0].name == 'engineering_screen.ui'
 
 
-def test_display_type_change(display):
+def test_display_type_change(motor, display):
     # Changing template type changes template
+    display.add_device(motor)
     display.display_type = display.embedded_screen
-    assert display.current_template == display.templates['embedded_screen']
+    assert display.current_template == display.templates['embedded_screen'][0]
 
 
 def test_display_modified_templates(display, motor):
@@ -77,14 +78,16 @@ def test_display_modified_templates(display, motor):
     eng_ui = display.templates['engineering_screen']
     display.templates['embedded_screen'] = eng_ui
     display.display_type = display.embedded_screen
-    assert display.current_template == eng_ui
+    assert display.current_template == eng_ui[0]
 
 
-def test_display_force_template(display):
+def test_display_force_template(display, motor):
     # Check that we use the forced template
-    display.force_template = 'tst.ui'
-    assert display.force_template == 'tst.ui'
-    assert display.current_template == 'tst.ui'
+    display.add_device(motor)
+    display.force_template = display.templates['engineering_screen'][0]
+    assert display.force_template.name == 'engineering_screen.ui'
+    assert display.current_template.name == 'engineering_screen.ui'
+
 
 def test_display_with_channel(client, qtbot):
     panel = typhos.display.TyphosDeviceDisplay()
@@ -110,6 +113,6 @@ def test_display_with_py_file(display):
     py_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                            'utils/display.py')
     display.templates['detailed_screen'] = py_file
-    display.load_template()
+    display.load_best_template()
     assert isinstance(display._main_widget, Display)
     assert getattr(display._main_widget, 'is_from_test_file', False)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,6 +1,7 @@
 import random
 
 import numpy as np
+import pydm.utilities
 from qtpy.QtWidgets import QWidget
 
 from ophyd import Kind
@@ -104,7 +105,7 @@ def test_typhos_panel(qapp, client, qtbot):
     assert panel.channel == 'happi://test_device'
     # Reset channel and no smoke comes out
     panel.channel = 'happi://test_motor'
-    qapp.establish_widget_connections(panel)
+    pydm.utilities.establish_widget_connections(panel)
     # Check we have our device
     assert len(panel.devices) == 1
     device = panel.devices[0]
@@ -132,7 +133,7 @@ def test_typhos_panel_sorting(qapp, client, qtbot):
     # Sort by name
     panel.sortBy = panel.SignalOrder.byName
     panel.channel = 'happi://test_motor'
-    qapp.establish_widget_connections(panel)
+    pydm.utilities.establish_widget_connections(panel)
     sorted_names = sorted(panel.devices[0].component_names)
     sig_layout = panel.layout().layout()
     assert list(panel.layout().signals.keys()) == sorted_names

--- a/typhos/designer.py
+++ b/typhos/designer.py
@@ -2,7 +2,8 @@ import logging
 
 from pydm.widgets.qtplugin_base import qtplugin_factory
 
-from .display import TyphosDeviceDisplay, TyphosDisplaySwitcher
+from .display import (TyphosDeviceDisplay, TyphosDisplaySwitcher,
+                      TyphosDisplayTitle)
 from .func import TyphosMethodButton
 from .positioner import TyphosPositionerWidget
 from .signal import TyphosSignalPanel
@@ -21,3 +22,5 @@ TyphosPositionerWidgetPlugin = qtplugin_factory(TyphosPositionerWidget,
                                                 group=group_name)
 TyphosDisplaySwitcher = qtplugin_factory(TyphosDisplaySwitcher,
                                          group=group_name)
+TyphosDisplayTitlePlugin = qtplugin_factory(TyphosDisplayTitle,
+                                            group=group_name)

--- a/typhos/designer.py
+++ b/typhos/designer.py
@@ -2,7 +2,7 @@ import logging
 
 from pydm.widgets.qtplugin_base import qtplugin_factory
 
-from .display import TyphosDeviceDisplay
+from .display import TyphosDeviceDisplay, TyphosDisplaySwitcher
 from .func import TyphosMethodButton
 from .positioner import TyphosPositionerWidget
 from .signal import TyphosSignalPanel
@@ -19,3 +19,5 @@ TyphosMethodButtonPlugin = qtplugin_factory(TyphosMethodButton,
                                             group=group_name)
 TyphosPositionerWidgetPlugin = qtplugin_factory(TyphosPositionerWidget,
                                                 group=group_name)
+TyphosDisplaySwitcher = qtplugin_factory(TyphosDisplaySwitcher,
+                                         group=group_name)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -9,6 +9,7 @@ from qtpy.QtCore import Q_ENUMS, Property, Slot, Qt
 import pcdsutils
 import pcdsutils.qt
 import pydm.display
+import pydm.exception
 import pydm.utilities
 
 from . import utils
@@ -419,10 +420,16 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         else:
             try:
                 self._load_template(template)
-            except Exception:
+            except Exception as ex:
                 logger.exception("Unable to load file %r", template)
-                self._main_widget = QtWidgets.QWidget()
-                self._current_template = None
+                # If we have a previously defined template
+                if self._current_template is not None:
+                    # Fallback to it so users have a choice
+                    self._load_template(self._current_template)
+                    pydm.exception.raise_to_operator(ex)
+                else:
+                    self._main_widget = QtWidgets.QWidget()
+                    self._current_template = None
 
         self.layout().addWidget(self._main_widget)
         utils.reload_widget_stylesheet(self)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -457,16 +457,16 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
         self._main_widget = main = loader(str(filename), macros=self._macros)
 
-        # Add device to all children widgets
-        if not self.devices:
-            return
+        self._main_widget = main = loader(str(filename), macros=self._macros)
 
+        # Notify child widgets of: this device dispay + the device
+        device = self.device
         designer = main.findChildren(widgets.TyphosDesignerMixin) or []
         bases = main.findChildren(utils.TyphosBase) or []
 
-        device, = self.devices
         for widget in set(bases + designer):
-            widget.add_device(device)
+            if device and hasattr(widget, 'add_device'):
+                widget.add_device(device)
 
             if hasattr(widget, 'set_device_display'):
                 widget.set_device_display(self)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -143,8 +143,6 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self._show_switcher = show_switcher
         super().__init__(parent=parent)
 
-        self.grid_layout = QtWidgets.QGridLayout()
-
         self.label = QtWidgets.QLabel(title)
         self.switcher = TyphosDisplaySwitcher()
         self.underline = QtWidgets.QFrame()
@@ -152,12 +150,13 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self.underline.setFrameShadow(self.underline.Plain)
         self.underline.setLineWidth(10)
 
+        self.grid_layout = QtWidgets.QGridLayout()
         self.grid_layout.addWidget(self.label, 0, 0)
         self.grid_layout.addWidget(self.switcher, 0, 1, Qt.AlignRight)
         self.grid_layout.addWidget(self.underline, 1, 0, 0, 2)
-
         self.setLayout(self.grid_layout)
 
+        # Set the property:
         self.show_switcher = show_switcher
 
     @Property(bool)
@@ -420,9 +419,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         return ret
 
     def _load_template(self, filename):
-        if filename == self._current_template:
-            return
-
         if filename.suffix == '.py':
             logger.debug('Load Python template: %r', filename)
             loader = pydm.display.load_py_file

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -281,7 +281,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         layout = QtWidgets.QHBoxLayout()
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)
-        self.load_best_template()
 
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.contextMenuEvent = self.open_context_menu
@@ -310,7 +309,14 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                 action = menu.addAction(os.path.split(filename)[-1])
                 action.triggered.connect(switch_template)
 
+        base_menu.addSeparator()
+        refresh_action = base_menu.addAction("Refresh Templates")
+        refresh_action.triggered.connect(self._refresh_templates)
+
         return base_menu
+
+    def _refresh_templates(self):
+        self.load_best_template(use_cache=False)
 
     def open_context_menu(self, ev):
         """
@@ -384,14 +390,14 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         logger.warning("No templates available for display type: %s",
                        self._display_type)
 
-    def load_best_template(self):
+    def load_best_template(self, use_cache=True):
         """
         Load a new template
 
         Parameters
         ----------
-        template: str
-            Absolute path to template location
+        use_cache: bool
+            Whether or not to use the cached search. Default is True.
         """
         if self.layout() is None:
             # If we are not fully initialized yet do not try and add anything
@@ -400,7 +406,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             # display
             return
 
-        if not self._searched:
+        if not self._searched or not use_cache:
             self.search_for_templates()
 
         # Clear anything that exists in the current layout

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -435,8 +435,15 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             except KeyError:
                 ...
             else:
-                value = pathlib.Path(value)
-                ret[display_type] = list(utils.find_file_in_paths(value))
+                if not value:
+                    continue
+                try:
+                    value = pathlib.Path(value)
+                except ValueError as ex:
+                    logger.debug('Invalid path specified in macro: %s=%s',
+                                 display_type, value, exc_info=ex)
+                else:
+                    ret[display_type] = list(utils.find_file_in_paths(value))
 
         return ret
 
@@ -448,7 +455,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             logger.debug('Load UI template: %r', filename)
             loader = pydm.display.load_ui_file
 
-        self._main_widget = main = loader(filename, macros=self._macros)
+        self._main_widget = main = loader(str(filename), macros=self._macros)
 
         # Add device to all children widgets
         if not self.devices:

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -153,7 +153,7 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self.underline.setLineWidth(10)
 
         self.grid_layout.addWidget(self.label, 0, 0)
-        self.grid_layout.addWidget(self.switcher, 0, 1)
+        self.grid_layout.addWidget(self.switcher, 0, 1, Qt.AlignRight)
         self.grid_layout.addWidget(self.underline, 1, 0, 0, 2)
 
         self.setLayout(self.grid_layout)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -163,14 +163,14 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self.switcher.setVisible(self._show_switcher)
 
     def add_device(self, device):
-        if not self.text:
+        if not self.label.text():
             self.label.setText(device.name)
 
     locals().update(**pcdsutils.qt.forward_properties(
         locals_dict=locals(),
         attr_name='label',
         cls=QtWidgets.QLabel,
-        superclasses=[QtWidgets.QFrame]
+        superclasses=[QtWidgets.QFrame],
     ))
 
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -166,7 +166,7 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self.grid_layout = QtWidgets.QGridLayout()
         self.grid_layout.addWidget(self.label, 0, 0)
         self.grid_layout.addWidget(self.switcher, 0, 1, Qt.AlignRight)
-        self.grid_layout.addWidget(self.underline, 1, 0, 0, 2)
+        self.grid_layout.addWidget(self.underline, 1, 0, 1, 2)
         self.setLayout(self.grid_layout)
 
         # Set the property:

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -176,9 +176,10 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         attr_name='label',
         cls=QtWidgets.QLabel,
         superclasses=[QtWidgets.QFrame],
-        condition=('margin', 'alignment', 'spacing', 'pixmap', 'text',
-                   'textFormat', 'wordWrap', 'indent', 'openExternalLinks',
-                   'textInteractionFlags', 'buddy'),
+        condition=('alignment', 'buddy', 'font', 'indent', 'margin',
+                   'openExternalLinks', 'pixmap', 'spacing', 'text',
+                   'textFormat', 'textInteractionFlags', 'wordWrap',
+                   ),
     ))
 
     # Make designable properties from the grid_layout

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1,9 +1,7 @@
-import copy
 import enum
 import logging
 import os.path
 import pathlib
-import functools
 
 from qtpy import QtWidgets, QtCore
 from qtpy.QtCore import Q_ENUMS, Property, Slot, Qt
@@ -205,8 +203,6 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     ))
 
 
-
-
 class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                           _DisplayTypes):
     """
@@ -394,7 +390,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             try:
                 self._load_template(template)
             except Exception:
-                logger.exception("Unable to load file %r", self.current_template)
+                logger.exception("Unable to load file %r", template)
                 self._main_widget = QtWidgets.QWidget()
                 self._current_template = None
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -309,14 +309,15 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                 action = menu.addAction(os.path.split(filename)[-1])
                 action.triggered.connect(switch_template)
 
+        def refresh_templates():
+            self.search_for_templates()
+            self.load_best_template()
+
         base_menu.addSeparator()
         refresh_action = base_menu.addAction("Refresh Templates")
-        refresh_action.triggered.connect(self._refresh_templates)
+        refresh_action.triggered.connect(refresh_templates)
 
         return base_menu
-
-    def _refresh_templates(self):
-        self.load_best_template(use_cache=False)
 
     def open_context_menu(self, ev):
         """
@@ -390,14 +391,9 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         logger.warning("No templates available for display type: %s",
                        self._display_type)
 
-    def load_best_template(self, use_cache=True):
+    def load_best_template(self):
         """
         Load a new template
-
-        Parameters
-        ----------
-        use_cache: bool
-            Whether or not to use the cached search. Default is True.
         """
         if self.layout() is None:
             # If we are not fully initialized yet do not try and add anything
@@ -406,7 +402,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             # display
             return
 
-        if not self._searched or not use_cache:
+        if not self._searched:
             self.search_for_templates()
 
         # Clear anything that exists in the current layout

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -11,6 +11,7 @@ from qtpy.QtCore import Q_ENUMS, Property, Slot, Qt
 import pcdsutils
 from pydm import Display
 from pydm.utilities.display_loading import load_py_file
+from pydm.utilities import IconFont
 from typhos import utils
 
 from . import utils
@@ -37,13 +38,14 @@ DEFAULT_TEMPLATES = {
 class TyphosDisplaySwitcherButton(QtWidgets.QPushButton):
     template_selected = QtCore.Signal(object)
 
-    def __init__(self, label, templates, parent=None):
-        super().__init__(label, parent=parent)
+    def __init__(self, icon, templates, parent=None):
+        super().__init__(parent=parent)
 
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.contextMenuEvent = self.open_context_menu
         self.templates = templates
         self.clicked.connect(self._select_first_template)
+        self.setIcon(icon)
 
     def _select_first_template(self):
         try:
@@ -72,6 +74,10 @@ class TyphosDisplaySwitcher(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     """
     Title bar for a Typhos Device Display
     """
+    icons = {'embedded_screen': 'compress',
+             'detailed_screen': 'braille',
+             'engineering_screen': 'cogs'
+             }
 
     def __init__(self, parent=None, **kwargs):
         # Intialize background variable
@@ -99,15 +105,12 @@ class TyphosDisplaySwitcher(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
             return
 
         for template_type, templates in self.device_display.templates.items():
-            label = {'embedded_screen': 'E',
-                     'detailed_screen': 'D',
-                     'engineering_screen': 'N',
-                     }[template_type]
-            button = TyphosDisplaySwitcherButton(label, templates)
+            icon = IconFont().icon(self.icons[template_type])
+            button = TyphosDisplaySwitcherButton(icon, templates)
             button.template_selected.connect(self._template_selected)
             layout.addWidget(button, 0, Qt.AlignRight)
 
-            friendly_name = template_type.replace('_', ' ').capitalize()
+            friendly_name = template_type.replace('_', ' ')
             button.setToolTip(f'Switch to {friendly_name}')
 
     def _template_selected(self, template):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -259,6 +259,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                  display_type='detailed_screen',
                  **kwargs):
         # Intialize background variable
+        self._current_template = None
         self._forced_template = ''
         self._macros = dict()
         self._main_widget = None

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -457,8 +457,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
         self._main_widget = main = loader(str(filename), macros=self._macros)
 
-        self._main_widget = main = loader(str(filename), macros=self._macros)
-
         # Notify child widgets of: this device dispay + the device
         device = self.device
         designer = main.findChildren(widgets.TyphosDesignerMixin) or []

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -3,7 +3,7 @@ import logging
 import os.path
 import pathlib
 
-from qtpy import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore, QtGui
 from qtpy.QtCore import Q_ENUMS, Property, Slot, Qt
 
 import pcdsutils
@@ -141,8 +141,15 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self._show_switcher = show_switcher
         super().__init__(parent=parent)
 
+        font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.TitleFont)
+        font.setPointSizeF(14.0)
+        font.setBold(True)
+
         self.label = QtWidgets.QLabel(title)
+        self.label.setFont(font)
+
         self.switcher = TyphosDisplaySwitcher()
+
         self.underline = QtWidgets.QFrame()
         self.underline.setFrameShape(self.underline.HLine)
         self.underline.setFrameShadow(self.underline.Plain)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -5,7 +5,7 @@ import os.path
 import pathlib
 import functools
 
-from qtpy import QtWidgets, QtCore, QtDesigner
+from qtpy import QtWidgets, QtCore
 from qtpy.QtCore import Q_ENUMS, Property, Slot, Qt
 
 import pcdsutils
@@ -153,11 +153,6 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
 
         self.show_switcher = show_switcher
 
-        if pydm.utilities.is_qt_designer():
-            form = QtDesigner.QDesignerFormWindowInterface.findFormWindow(self)
-            if form:
-                form.cursor().setProperty('text', '${name}')
-
     @Property(bool)
     def show_switcher(self):
         return self._show_switcher
@@ -168,7 +163,8 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self.switcher.setVisible(self._show_switcher)
 
     def add_device(self, device):
-        ...
+        if not self.text:
+            self.label.setText(device.name)
 
     locals().update(**pcdsutils.qt.forward_properties(
         locals_dict=locals(),

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -143,13 +143,20 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self._show_switcher = show_switcher
         super().__init__(parent=parent)
 
-        layout = QtWidgets.QHBoxLayout(self)
-        self.setLayout(layout)
+        self.grid_layout = QtWidgets.QGridLayout()
 
         self.label = QtWidgets.QLabel(title)
         self.switcher = TyphosDisplaySwitcher()
-        layout.addWidget(self.label)
-        layout.addWidget(self.switcher)
+        self.underline = QtWidgets.QFrame()
+        self.underline.setFrameShape(self.underline.HLine)
+        self.underline.setFrameShadow(self.underline.Plain)
+        self.underline.setLineWidth(10)
+
+        self.grid_layout.addWidget(self.label, 0, 0)
+        self.grid_layout.addWidget(self.switcher, 0, 1)
+        self.grid_layout.addWidget(self.underline, 1, 0, 0, 2)
+
+        self.setLayout(self.grid_layout)
 
         self.show_switcher = show_switcher
 
@@ -166,12 +173,39 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         if not self.label.text():
             self.label.setText(device.name)
 
+    # Make designable properties from the title label available here as well
     locals().update(**pcdsutils.qt.forward_properties(
         locals_dict=locals(),
         attr_name='label',
         cls=QtWidgets.QLabel,
         superclasses=[QtWidgets.QFrame],
+        condition=('margin', 'alignment', 'spacing', 'pixmap', 'text',
+                   'textFormat', 'wordWrap', 'indent', 'openExternalLinks',
+                   'textInteractionFlags', 'buddy'),
     ))
+
+    # Make designable properties from the grid_layout
+    locals().update(**pcdsutils.qt.forward_properties(
+        locals_dict=locals(),
+        attr_name='grid_layout',
+        cls=QtWidgets.QHBoxLayout,
+        superclasses=[QtWidgets.QFrame],
+        prefix='layout_',
+        condition=('margin', 'spacing'),
+        )
+    )
+
+    # Make designable properties from the underline
+    locals().update(**pcdsutils.qt.forward_properties(
+        locals_dict=locals(),
+        attr_name='underline',
+        cls=QtWidgets.QFrame,
+        superclasses=[QtWidgets.QFrame],
+        prefix='underline_',
+        condition=('palette', 'styleSheet', 'lineWidth', 'midLineWidth'),
+    ))
+
+
 
 
 class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -322,7 +322,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         if filename == self._current_template:
             return
 
-        logger.debug("Loading %s", filename)
         # Support Python files
         if filename.suffix == '.py':
             logger.debug('Load Python template: %r', filename)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -5,7 +5,7 @@ import os.path
 import pathlib
 import functools
 
-from qtpy import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore, QtDesigner
 from qtpy.QtCore import Q_ENUMS, Property, Slot, Qt
 
 import pcdsutils
@@ -153,6 +153,11 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
 
         self.show_switcher = show_switcher
 
+        if pydm.utilities.is_qt_designer():
+            form = QtDesigner.QDesignerFormWindowInterface.findFormWindow(self)
+            if form:
+                form.cursor().setProperty('text', '${name}')
+
     @Property(bool)
     def show_switcher(self):
         return self._show_switcher
@@ -161,6 +166,9 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     def show_switcher(self, value):
         self._show_switcher = bool(value)
         self.switcher.setVisible(self._show_switcher)
+
+    def add_device(self, device):
+        ...
 
     locals().update(**pcdsutils.qt.forward_properties(
         locals_dict=locals(),

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -84,28 +84,28 @@ class TyphosSuite(TyphosBase):
 
     def __init__(self, parent=None, *, pin=False):
         super().__init__(parent=parent)
-        # Setup parameter tree
+
         self._tree = ParameterTree(parent=self, showHeader=False)
         self._tree.setAlternatingRowColors(False)
         self._save_action = ptypes.ActionParameter(name='Save Suite')
         self._tree.addParameters(self._save_action)
         self._save_action.sigActivated.connect(self.save)
 
-        # Setup layout
         self._bar = pcdsutils.qt.QPopBar(title='Suite', parent=self,
                                          widget=self._tree, pin=pin)
-
-        self.setLayout(QtWidgets.QHBoxLayout())
-        self.layout().setSpacing(1)
-        self.layout().setContentsMargins(0, 0, 0, 0)
 
         self._content_frame = QtWidgets.QFrame(self)
         self._content_frame.setObjectName("content")
         self._content_frame.setFrameShape(QtWidgets.QFrame.StyledPanel)
         self._content_frame.setLayout(QtWidgets.QHBoxLayout())
 
-        self.layout().addWidget(self._bar)
-        self.layout().addWidget(self._content_frame)
+        # Horizontal box layout: [PopBar] [Content Frame]
+        layout = QtWidgets.QHBoxLayout()
+        self.setLayout(layout)
+        layout.setSpacing(1)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._bar)
+        layout.addWidget(self._content_frame)
 
         self.embedded_dock = None
 

--- a/typhos/ui/detailed_positioner.ui
+++ b/typhos/ui/detailed_positioner.ui
@@ -21,75 +21,9 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
-    <layout class="QHBoxLayout" name="button_layout_2" stretch="1,0">
-     <property name="spacing">
-      <number>2</number>
-     </property>
-     <property name="leftMargin">
-      <number>10</number>
-     </property>
-     <property name="topMargin">
-      <number>2</number>
-     </property>
-     <property name="rightMargin">
-      <number>2</number>
-     </property>
-     <property name="bottomMargin">
-      <number>0</number>
-     </property>
-     <item alignment="Qt::AlignLeft">
-      <widget class="QLabel" name="name_label_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <family>Sans Serif</family>
-         <pointsize>20</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-         <kerning>true</kerning>
-        </font>
-       </property>
-       <property name="text">
-        <string>${name}</string>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher_2">
-       <property name="toolTip">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QFrame" name="underline">
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::HLine</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>10</number>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
      </property>
     </widget>
    </item>
@@ -381,11 +315,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplaySwitcher</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhos.signal</header>
@@ -394,6 +323,11 @@
    <class>TyphosPositionerWidget</class>
    <extends>QWidget</extends>
    <header>typhos.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/typhos/ui/detailed_positioner.ui
+++ b/typhos/ui/detailed_positioner.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>320</width>
-    <height>455</height>
+    <width>341</width>
+    <height>513</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,42 +19,60 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,3">
-   <property name="spacing">
-    <number>10</number>
-   </property>
-   <property name="sizeConstraint">
-    <enum>QLayout::SetDefaultConstraint</enum>
-   </property>
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
-    <widget class="QLabel" name="name_label">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>20</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+    <layout class="QHBoxLayout" name="button_layout_2" stretch="1,0">
+     <property name="spacing">
+      <number>2</number>
      </property>
-     <property name="text">
-      <string>${name}</string>
+     <property name="leftMargin">
+      <number>10</number>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
+     <property name="topMargin">
+      <number>2</number>
      </property>
-    </widget>
+     <property name="rightMargin">
+      <number>2</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item alignment="Qt::AlignLeft">
+      <widget class="QLabel" name="name_label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <family>Sans Serif</family>
+         <pointsize>20</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+         <kerning>true</kerning>
+        </font>
+       </property>
+       <property name="text">
+        <string>${name}</string>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QFrame" name="underline">
@@ -159,8 +177,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>298</width>
-            <height>222</height>
+            <width>305</width>
+            <height>215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -236,8 +254,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>298</width>
-            <height>222</height>
+            <width>305</width>
+            <height>215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -313,8 +331,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>298</width>
-            <height>222</height>
+            <width>305</width>
+            <height>215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout">
@@ -362,6 +380,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>TyphosDisplaySwitcher</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
   <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>

--- a/typhos/ui/detailed_screen.ui
+++ b/typhos/ui/detailed_screen.ui
@@ -19,42 +19,60 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,3">
-   <property name="spacing">
-    <number>10</number>
-   </property>
-   <property name="sizeConstraint">
-    <enum>QLayout::SetDefaultConstraint</enum>
-   </property>
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QLabel" name="name_label">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>20</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+    <layout class="QHBoxLayout" name="button_layout_2" stretch="1,0">
+     <property name="spacing">
+      <number>2</number>
      </property>
-     <property name="text">
-      <string>${name}</string>
+     <property name="leftMargin">
+      <number>10</number>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
+     <property name="topMargin">
+      <number>2</number>
      </property>
-    </widget>
+     <property name="rightMargin">
+      <number>2</number>
+     </property>
+     <property name="bottomMargin">
+      <number>2</number>
+     </property>
+     <item alignment="Qt::AlignLeft">
+      <widget class="QLabel" name="name_label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <family>Sans Serif</family>
+         <pointsize>20</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+         <kerning>true</kerning>
+        </font>
+       </property>
+       <property name="text">
+        <string>${name}</string>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QFrame" name="underline">
@@ -169,8 +187,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>373</width>
-            <height>232</height>
+            <width>359</width>
+            <height>215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -246,8 +264,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>373</width>
-            <height>232</height>
+            <width>359</width>
+            <height>215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout">
@@ -295,6 +313,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>TyphosDisplaySwitcher</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
   <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>

--- a/typhos/ui/detailed_screen.ui
+++ b/typhos/ui/detailed_screen.ui
@@ -25,6 +25,9 @@
      <property name="toolTip">
       <string/>
      </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
     </widget>
    </item>
    <item>

--- a/typhos/ui/detailed_screen.ui
+++ b/typhos/ui/detailed_screen.ui
@@ -21,75 +21,9 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <layout class="QHBoxLayout" name="button_layout_2" stretch="1,0">
-     <property name="spacing">
-      <number>2</number>
-     </property>
-     <property name="leftMargin">
-      <number>10</number>
-     </property>
-     <property name="topMargin">
-      <number>2</number>
-     </property>
-     <property name="rightMargin">
-      <number>2</number>
-     </property>
-     <property name="bottomMargin">
-      <number>2</number>
-     </property>
-     <item alignment="Qt::AlignLeft">
-      <widget class="QLabel" name="name_label_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <family>Sans Serif</family>
-         <pointsize>20</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-         <kerning>true</kerning>
-        </font>
-       </property>
-       <property name="text">
-        <string>${name}</string>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher_2">
-       <property name="toolTip">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QFrame" name="underline">
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::HLine</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>10</number>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
      </property>
     </widget>
    </item>
@@ -314,14 +248,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplaySwitcher</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhos.signal</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/typhos/ui/embedded_positioner.ui
+++ b/typhos/ui/embedded_positioner.ui
@@ -43,7 +43,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,0,2">
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,2">
    <property name="spacing">
     <number>3</number>
    </property>
@@ -63,75 +63,9 @@
     <number>5</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="button_layout" stretch="1,0">
-     <property name="spacing">
-      <number>2</number>
-     </property>
-     <property name="leftMargin">
-      <number>10</number>
-     </property>
-     <property name="topMargin">
-      <number>2</number>
-     </property>
-     <property name="rightMargin">
-      <number>2</number>
-     </property>
-     <property name="bottomMargin">
-      <number>2</number>
-     </property>
-     <item alignment="Qt::AlignLeft">
-      <widget class="QLabel" name="name_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <family>Sans Serif</family>
-         <pointsize>20</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-         <kerning>true</kerning>
-        </font>
-       </property>
-       <property name="text">
-        <string>${name}</string>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
-       <property name="toolTip">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QFrame" name="underline">
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::HLine</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>10</number>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
      </property>
     </widget>
    </item>
@@ -165,14 +99,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplaySwitcher</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosPositionerWidget</class>
    <extends>QWidget</extends>
    <header>typhos.positioner</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/typhos/ui/embedded_positioner.ui
+++ b/typhos/ui/embedded_positioner.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>303</width>
-    <height>194</height>
+    <width>327</width>
+    <height>225</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -108,17 +108,11 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
+       <property name="toolTip">
+        <string/>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
      </item>
     </layout>
    </item>
@@ -170,6 +164,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>TyphosDisplaySwitcher</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
   <customwidget>
    <class>TyphosPositionerWidget</class>
    <extends>QWidget</extends>

--- a/typhos/ui/embedded_screen.ui
+++ b/typhos/ui/embedded_screen.ui
@@ -43,7 +43,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,2,1">
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,2,1">
    <property name="spacing">
     <number>3</number>
    </property>
@@ -63,75 +63,9 @@
     <number>5</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="button_layout" stretch="1,0">
-     <property name="spacing">
-      <number>2</number>
-     </property>
-     <property name="leftMargin">
-      <number>10</number>
-     </property>
-     <property name="topMargin">
-      <number>2</number>
-     </property>
-     <property name="rightMargin">
-      <number>2</number>
-     </property>
-     <property name="bottomMargin">
-      <number>2</number>
-     </property>
-     <item alignment="Qt::AlignLeft">
-      <widget class="QLabel" name="name_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <family>Sans Serif</family>
-         <pointsize>20</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-         <kerning>true</kerning>
-        </font>
-       </property>
-       <property name="text">
-        <string>${name}</string>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
-       <property name="toolTip">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QFrame" name="underline">
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::HLine</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>10</number>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
      </property>
     </widget>
    </item>
@@ -173,14 +107,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplaySwitcher</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhos.signal</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/typhos/ui/embedded_screen.ui
+++ b/typhos/ui/embedded_screen.ui
@@ -89,6 +89,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::MinimumExpanding</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>

--- a/typhos/ui/embedded_screen.ui
+++ b/typhos/ui/embedded_screen.ui
@@ -108,17 +108,11 @@
       </widget>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
+       <property name="toolTip">
+        <string/>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
      </item>
     </layout>
    </item>
@@ -178,6 +172,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>TyphosDisplaySwitcher</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
   <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>

--- a/typhos/ui/embedded_screen.ui
+++ b/typhos/ui/embedded_screen.ui
@@ -22,12 +22,6 @@
     <height>150</height>
    </size>
   </property>
-  <property name="maximumSize">
-   <size>
-    <width>600</width>
-    <height>300</height>
-   </size>
-  </property>
   <property name="sizeIncrement">
    <size>
     <width>1</width>

--- a/typhos/ui/engineering_screen.ui
+++ b/typhos/ui/engineering_screen.ui
@@ -21,58 +21,11 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="button_layout" stretch="1,0">
-     <property name="spacing">
-      <number>2</number>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
      </property>
-     <property name="leftMargin">
-      <number>10</number>
-     </property>
-     <property name="topMargin">
-      <number>2</number>
-     </property>
-     <property name="rightMargin">
-      <number>2</number>
-     </property>
-     <property name="bottomMargin">
-      <number>2</number>
-     </property>
-     <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-      <widget class="QLabel" name="name_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="font">
-        <font>
-         <family>Sans Serif</family>
-         <pointsize>20</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-         <kerning>true</kerning>
-        </font>
-       </property>
-       <property name="text">
-        <string>${name}</string>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
-       <property name="toolTip">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="signal_layout" stretch="1,0,1,0,1">
@@ -294,14 +247,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosDisplaySwitcher</class>
-   <extends>QFrame</extends>
-   <header>typhos.display</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>
    <header>typhos.signal</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/typhos/ui/engineering_screen.ui
+++ b/typhos/ui/engineering_screen.ui
@@ -19,61 +19,60 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,0,1">
-   <property name="spacing">
-    <number>10</number>
-   </property>
-   <property name="sizeConstraint">
-    <enum>QLayout::SetDefaultConstraint</enum>
-   </property>
-   <property name="leftMargin">
-    <number>5</number>
-   </property>
-   <property name="topMargin">
-    <number>5</number>
-   </property>
-   <property name="rightMargin">
-    <number>5</number>
-   </property>
-   <property name="bottomMargin">
-    <number>5</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="name_label">
-     <property name="font">
-      <font>
-       <family>Sans Serif</family>
-       <pointsize>20</pointsize>
-       <weight>75</weight>
-       <bold>true</bold>
-      </font>
+    <layout class="QHBoxLayout" name="button_layout" stretch="1,0">
+     <property name="spacing">
+      <number>2</number>
      </property>
-     <property name="text">
-      <string>${name}</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="underline">
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="styleSheet">
-      <string notr="true"/>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::HLine</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
+     <property name="leftMargin">
       <number>10</number>
      </property>
-    </widget>
+     <property name="topMargin">
+      <number>2</number>
+     </property>
+     <property name="rightMargin">
+      <number>2</number>
+     </property>
+     <property name="bottomMargin">
+      <number>2</number>
+     </property>
+     <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+      <widget class="QLabel" name="name_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <family>Sans Serif</family>
+         <pointsize>20</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+         <kerning>true</kerning>
+        </font>
+       </property>
+       <property name="text">
+        <string>${name}</string>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="signal_layout" stretch="1,0,1,0,1">
@@ -294,6 +293,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>TyphosDisplaySwitcher</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
   <customwidget>
    <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -22,7 +22,8 @@ from ophyd.signal import EpicsSignalBase, EpicsSignalRO
 from pydm.exception import raise_to_operator  # noqa
 
 logger = logging.getLogger(__name__)
-ui_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'ui')
+MODULE_PATH = pathlib.Path(__file__).parent.resolve()
+ui_dir = MODULE_PATH / 'ui'
 GrabKindItem = collections.namedtuple('GrabKindItem',
                                       ('attr', 'component', 'signal'))
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -481,3 +481,39 @@ def find_templates_for_class(cls, view_type, paths, *, extensions=None,
                 for match in path.glob(candidate_filename + extension):
                     if match.is_file():
                         yield match
+
+
+def find_file_in_paths(filename, *, paths=None):
+    '''
+    Search for filename ``filename`` in the list of paths ``paths``
+
+    Parameters
+    ----------
+    filename : str or pathlib.Path
+        The filename
+    paths : list or iterable, optional
+        List of paths to search. Defaults to DISPLAY_PATHS.
+
+    Yields
+    ------
+    All filenames that match in the given paths
+    '''
+    if paths is None:
+        paths = DISPLAY_PATHS
+
+    if isinstance(filename, pathlib.Path):
+        if filename.is_absolute():
+            if filename.exists():
+                yield filename
+            return
+
+        filename = filename.name
+
+    paths = remove_duplicate_items(
+        [pathlib.Path(p).expanduser().resolve() for p in paths]
+    )
+
+    for path in paths:
+        for match in path.glob(filename):
+            if match.is_file():
+                yield match

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -6,7 +6,7 @@ import contextlib
 import importlib.util
 import inspect
 import logging
-import os.path
+import os
 import pathlib
 import random
 import re
@@ -26,6 +26,19 @@ MODULE_PATH = pathlib.Path(__file__).parent.resolve()
 ui_dir = MODULE_PATH / 'ui'
 GrabKindItem = collections.namedtuple('GrabKindItem',
                                       ('attr', 'component', 'signal'))
+
+
+def _get_display_paths():
+    'Get all display paths based on PYDM_DISPLAY_PATHS + typhos built-ins'
+    paths = os.environ.get('PYDM_DISPLAYS_PATH', '')
+    for path in paths.split(os.pathsep):
+        path = pathlib.Path(path).resolve()
+        if path.exists() and path.is_dir():
+            yield path
+    yield ui_dir
+
+
+DISPLAY_PATHS = list(_get_display_paths())
 
 
 class SignalRO(ophyd.sim.SynSignalRO):


### PR DESCRIPTION
Having quick access to switching displays I think will be a useful thing:

<img width="303" alt="image" src="https://user-images.githubusercontent.com/5139267/76449878-16f4cc80-638a-11ea-82a5-fdee17f9f0a5.png">

Left-click for a quick swap to the "best" embedded/engineering/detailed display.
Right-click to choose a specific embedded/engineering/detailed display.

<img width="408" alt="image" src="https://user-images.githubusercontent.com/5139267/76455412-f2e9b900-6392-11ea-84f5-4a2c29c112de.png">

Alternatively, the display context menu was tweaked a bit:

<img width="353" alt="image" src="https://user-images.githubusercontent.com/5139267/76450119-85d22580-638a-11ea-9bb2-ff676bfcdd17.png">

I think we can do better widget/style/etc. wise, so consider this a proof-of-concept.

This PR also entirely reworks how displays are searched for and loaded.

TODO
- [x] Update paths to search to include the pydm display path
- [x] Fix tests
- [x] Make buttons nicer or change them entirely based on feedback (@hhslepicka @ZLLentz?)
- [x] Include the switcher in the remaining default templates
- [x] Add icons
- [x] Fix pydm deprecation warning for display loading
- [ ] Rename positioner templates such that positioner class MRO will pick these templates by default