### PR TITLE
REF/FIX: plot rework + background connections

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,11 +1,7 @@
 """
 Module Docstring
 """
-import logging
-
 import pytest
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QColor
 
 from ophyd import EpicsSignal, Signal
 from typhos import register_signal
@@ -20,7 +16,8 @@ def sim_signal():
     register_signal(sim_sig)
     return sim_sig
 
-def test_add_signal(qtbot,sim_signal):
+
+def test_add_signal(qtbot, sim_signal):
     # Create Signals
     epics_sig = EpicsSignal('Tst:This')
     # Create empty plot
@@ -40,7 +37,7 @@ def test_curve_methods(qtbot, sim_signal):
     qtbot.addWidget(ttp)
     ttp.add_curve('sig://' + sim_signal.name, name=sim_signal.name)
     # Check that our signal is stored in the mapping
-    assert 'sig://' + sim_signal.name in ttp.channel_map
+    assert 'sig://' + sim_signal.name in ttp.channel_to_curve
     # Check that our curve is live
     assert len(ttp.timechart.chart.curves) == 1
     # Try and add again
@@ -50,18 +47,21 @@ def test_curve_methods(qtbot, sim_signal):
     ttp.remove_curve(channel_from_signal(sim_signal))
     assert len(ttp.timechart.chart.curves) == 0
 
+
 def test_curve_creation_button(qtbot, sim_signal):
     ttp = TyphosTimePlot()
     qtbot.addWidget(ttp)
     ttp.add_available_signal(sim_signal, 'Sim Signal')
     ttp.creation_requested()
     # Check that our signal is stored in the mapping
-    assert channel_from_signal(sim_signal) in ttp.channel_map
+    assert channel_from_signal(sim_signal) in ttp.channel_to_curve
     assert len(ttp.timechart.chart.curves) == 1
+
 
 def test_device_plot(motor, qtbot):
     dtp = TyphosTimePlot.from_device(motor)
     qtbot.addWidget(dtp)
+
     # Add the hint
     assert len(dtp.timechart.chart.curves) == 1
     # Added all the signals

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,6 +1,8 @@
 """
 Module Docstring
 """
+import time
+
 import pytest
 
 from ophyd import EpicsSignal, Signal
@@ -58,9 +60,15 @@ def test_curve_creation_button(qtbot, sim_signal):
     assert len(ttp.timechart.chart.curves) == 1
 
 
-def test_device_plot(motor, qtbot):
+def test_device_plot(motor, qapp, qtbot):
     dtp = TyphosTimePlot.from_device(motor)
     qtbot.addWidget(dtp)
+
+    # Update happens in a background thread
+    t0 = time.time()
+    while time.time() - t0 < 1:
+        qapp.processEvents()
+        time.sleep(0.1)
 
     # Add the hint
     assert len(dtp.timechart.chart.curves) == 1

--- a/typhos/tools/plot.py
+++ b/typhos/tools/plot.py
@@ -25,6 +25,9 @@ class TyphosTimePlot(utils.TyphosBase):
     ----------
     parent: QWidget
     """
+
+    hint_limit = 20
+
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         # Setup layout
@@ -43,8 +46,14 @@ class TyphosTimePlot(utils.TyphosBase):
         # Add timechart
         self.timechart = TimeChartDisplay(show_pv_add_panel=False)
         self.layout().addWidget(self.timechart)
-        self.channel_map = self.timechart.channel_map
         self._device_threads = {}
+
+    @property
+    def channel_to_curve(self):
+        """
+        A dictionary of channel_name to curve
+        """
+        return dict(self.timechart.channel_map)
 
     def add_available_signal(self, signal, name):
         """
@@ -141,6 +150,12 @@ class TyphosTimePlot(utils.TyphosBase):
 
         # Add to list of available signal
         self.add_available_signal(signal, name)
+
+        if len(self.channel_to_curve) >= self.hint_limit:
+            logger.debug('Too many hinted signals (at limit of %d)',
+                         self.hint_limit)
+            return
+
         if signal.name in signal.root.hints.get('fields', []):
             self.add_curve(utils.channel_from_signal(signal), name=name)
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -614,7 +614,7 @@ def subscription_context_device(device, callback, event_type=None, run=True, *,
 
 class _ConnectionStatus:
     def __init__(self, signals, callback):
-        self.signals = set()
+        self.signals = signals
         self.connected = set()
         self.callback = callback
         self.lock = threading.Lock()

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -10,7 +10,9 @@ import os
 import pathlib
 import random
 import re
+import threading
 
+from qtpy import QtCore
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QColor, QMovie, QPainter
 from qtpy.QtWidgets import (QApplication, QLabel, QStyle, QStyleFactory,
@@ -517,3 +519,191 @@ def find_file_in_paths(filename, *, paths=None):
         for match in path.glob(filename):
             if match.is_file():
                 yield match
+
+
+@contextlib.contextmanager
+def subscription_context(*objects, callback, event_type=None, run=True):
+    '''
+    [Context manager] Subscribe to a specific event from all objects
+
+    Unsubscribes all signals before exiting
+
+    Parameters
+    ----------
+    *objects : ophyd.OphydObj
+        Ophyd objects (signals) to monitor
+    callback : callable
+        Callback to run, with same signature as that of
+        :meth:``ophyd.OphydObj.subscribe``
+    event_type : str, optional
+        The event type to subscribe to
+    run : bool, optional
+        Run the previously cached subscription immediately
+    '''
+    obj_to_cid = {}
+    try:
+        for obj in objects:
+            obj_to_cid[obj] = obj.subscribe(callback, event_type=event_type,
+                                            run=run)
+        yield dict(obj_to_cid)
+    finally:
+        for obj, cid in obj_to_cid.items():
+            obj.unsubscribe(cid)
+
+
+def get_all_signals_from_device(device, include_lazy=False, filter_by=None):
+    '''
+    Get all signals in a given device
+
+    Parameters
+    ----------
+    device : ophyd.Device
+        ophyd Device to monitor
+    include_lazy : bool, optional
+        Include lazy signals as well
+    filter_by : callable, optional
+        Filter signals, with signature ``callable(ophyd.Device.ComponentWalk)``
+    '''
+    if not filter_by:
+        def filter_by(walk):
+            return True
+
+    def _get_signals():
+        return [
+            walk.item
+            for walk in device.walk_signals(include_lazy=include_lazy)
+            if filter_by(walk)
+        ]
+
+    if not include_lazy:
+        return _get_signals()
+
+    with no_device_lazy_load():
+        return _get_signals()
+
+
+@contextlib.contextmanager
+def subscription_context_device(device, callback, event_type=None, run=True, *,
+                                include_lazy=False, filter_by=None):
+    '''
+    [Context manager] Subscribe to ``event_type`` from signals in ``device``
+
+    Unsubscribes all signals before exiting
+
+    Parameters
+    ----------
+    device : ophyd.Device
+        ophyd Device to monitor
+    callback : callable
+        Callback to run, with same signature as that of
+        :meth:``ophyd.OphydObj.subscribe``
+    event_type : str, optional
+        The event type to subscribe to
+    run : bool, optional
+        Run the previously cached subscription immediately
+    include_lazy : bool, optional
+        Include lazy signals as well
+    filter_by : callable, optional
+        Filter signals, with signature ``callable(ophyd.Device.ComponentWalk)``
+    '''
+    signals = get_all_signals_from_device(device, include_lazy=include_lazy)
+    with subscription_context(*signals, callback=callback,
+                              event_type=event_type, run=run) as obj_to_cid:
+        yield obj_to_cid
+
+
+class _ConnectionStatus:
+    def __init__(self, signals, callback):
+        self.signals = set()
+        self.connected = set()
+        self.callback = callback
+        self.lock = threading.Lock()
+
+    def _connection_callback(self, *, obj, connected, **kwargs):
+        run_callback = False
+        with self.lock:
+            if connected and obj not in self.connected:
+                self.connected.add(obj)
+                run_callback = True
+            elif not connected and obj in self.connected:
+                self.connected.remove(obj)
+                run_callback = True
+
+        if run_callback:
+            logger.debug(
+                'Connection update: %r (obj=%s connected=%s kwargs=%r)',
+                self, obj.name, connected, kwargs)
+            self.callback(obj=obj, connected=connected, **kwargs)
+
+    def __repr__(self):
+        return (
+            f'<{self.__class__.__name__} connected={len(self.connected)} '
+            f'signals={len(self.signals)}>'
+        )
+
+
+@contextlib.contextmanager
+def connection_status_monitor(*signals, callback):
+    '''
+    [Context manager] Monitor connection status from a number of signals
+
+    Filters out any other metadata updates, only calling once
+    connected/disconnected
+
+    Parameters
+    ----------
+    *signals : ophyd.OphydObj
+        Signals to monitor
+    callback : callable
+        Callback to run, with same signature as that of
+        :meth:``ophyd.OphydObj.subscribe``. ``obj`` and ``connected`` are
+        guaranteed kwargs.
+    '''
+
+    status = _ConnectionStatus(signals=signals, callback=callback)
+
+    with subscription_context(*signals, callback=status._connection_callback,
+                              event_type='meta', run=True
+                              ) as status.obj_to_cid:
+        yield status
+
+
+class DeviceConnectionMonitorThread(QtCore.QThread):
+    '''
+    Monitor connection status in a background thread
+
+    Parameters
+    ----------
+    device : ophyd.Device
+        The device to grab signals from
+    include_lazy : bool, optional
+        Include lazy signals as well
+
+    Attributes
+    ----------
+    connection_update : QtCore.Signal
+        Connection update signal with signature::
+
+            (signal, connected, metadata_dict)
+    '''
+
+    connection_update = QtCore.Signal(object, bool, dict)
+
+    def __init__(self, device, include_lazy=False):
+        super().__init__()
+        self.device = device
+        self.include_lazy = include_lazy
+        self._update_event = threading.Event()
+
+    def callback(self, obj, connected, **kwargs):
+        self._update_event.set()
+        self.connection_update.emit(obj, connected, kwargs)
+
+    def run(self):
+        signals = get_all_signals_from_device(
+            self.device, include_lazy=self.include_lazy)
+
+        with connection_status_monitor(*signals, callback=self.callback):
+            while not self.isInterruptionRequested():
+                self._update_event.clear()
+                self._update_event.wait(timeout=0.5)

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -620,20 +620,17 @@ class _ConnectionStatus:
         self.lock = threading.Lock()
 
     def _connection_callback(self, *, obj, connected, **kwargs):
-        run_callback = False
         with self.lock:
             if connected and obj not in self.connected:
                 self.connected.add(obj)
-                run_callback = True
             elif not connected and obj in self.connected:
                 self.connected.remove(obj)
-                run_callback = True
+            else:
+                return
 
-        if run_callback:
-            logger.debug(
-                'Connection update: %r (obj=%s connected=%s kwargs=%r)',
-                self, obj.name, connected, kwargs)
-            self.callback(obj=obj, connected=connected, **kwargs)
+        logger.debug('Connection update: %r (obj=%s connected=%s kwargs=%r)',
+                     self, obj.name, connected, kwargs)
+        self.callback(obj=obj, connected=connected, **kwargs)
 
     def __repr__(self):
         return (


### PR DESCRIPTION
Closes #194

* Adds a suite of utilities for dealing with ophyd subscriptions in a temporary sort of way (with context managers)
* Adds a QThread wrapper that emits events for connections
* Hacks on some signal-handling to see if a `Signal` might not emit a connection callback (because ophyd is busted)
* Limits number of channels automatically added as hints
* Uses fully-qualified names (root.name + `dotted_name`) for signals added to the plot

What else, @hhslepicka, do we need here?