### PR TITLE
ENH: add setpoint history context menu entry

### DIFF
--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -109,6 +109,13 @@ class TyphosLineEdit(PyDMLineEdit):
     def sizeHint(self):
         return QSize(100, 30)
 
+    @property
+    def setpoint_history(self):
+        """
+        History of setpoints, as a dictionary of {setpoint: timestamp}
+        """
+        return dict(self._setpoint_history)
+
     @Property(int, designable=True)
     def setpointHistoryCount(self):
         """

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -161,11 +161,11 @@ class TyphosLineEdit(PyDMLineEdit):
         history_menu.setFont(font)
 
         max_len = max(len(value)
-                      for value, timestamp in self._setpoint_history) or 1
+                      for value, timestamp in self._setpoint_history)
 
         # Pad values such that timestamp lines up:
         # (Value)     @ (Timestamp)
-        action_format = '{value:<%d} @ {timestamp}' % max_len
+        action_format = '{value:<%d} @ {timestamp}' % (max_len + 1)
 
         for value, timestamp in reversed(self._setpoint_history):
             timestamp = timestamp.strftime('%m/%d %H:%M')


### PR DESCRIPTION
Closes #226

Originally this started as a drop-down for setpoint line edits, but I think it might fit more neatly in the context menu as pydm already modifies it:

<img width="531" alt="image" src="https://user-images.githubusercontent.com/5139267/79265812-86f3e800-7e4b-11ea-94c0-729557298a83.png">

Functionality:
* Records entries as the user adds them to the item, along with a timestamp.
* Displays history in context menu
* Limits history to a designable Property value (0 to disable entirely)
* Tweaks the menu font to allow for visual alignment of timestamp/value