### PR TITLE
ENH: Composite signal panel + configuration drop-down + filtering

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,9 +1,7 @@
-import os.path
-
 import pytest
 
-from pydm import Display
 import typhos.display
+from pydm import Display
 from typhos.utils import clean_attr
 
 from . import conftest
@@ -24,13 +22,14 @@ def show_switcher(request):
 
 @show_widget
 def test_device_title(device, motor, show_switcher, qtbot):
-    title = typhos.display.TyphosDisplayTitle(show_switcher=show_switcher)
+    typhos.display.TyphosDisplayTitle(show_switcher=show_switcher)
 
 
 @show_widget
 def test_device_display(device, motor, qtbot):
-    panel = typhos.display.TyphosDeviceDisplay.from_device(motor)
-    panel_main = panel._main_widget
+    panel = typhos.display.TyphosDeviceDisplay.from_device(
+        motor, composite_heuristics=False)
+    panel_main = panel.display_widget
     qtbot.addWidget(panel)
     # We have all our signals
     shown_read_sigs = list(panel_main.read_panel.layout().signals.keys())
@@ -40,9 +39,9 @@ def test_device_display(device, motor, qtbot):
     assert all([clean_attr(sig) in shown_cfg_sigs
                 for sig in motor.configuration_attrs])
     # Check that we can add multiple devices
-    device.name ='test'
+    device.name = 'test'
     panel.add_device(device)
-    panel_main = panel._main_widget
+    panel_main = panel.display_widget
     # We have all our signals
     shown_read_sigs = list(panel_main.read_panel.layout().signals.keys())
     assert all(clean_attr(sig) in shown_read_sigs for sig in device.read_attrs)
@@ -60,11 +59,12 @@ def test_display_without_md(motor, display):
 
 
 def test_display_with_md(motor, display):
+    screen = 'engineering_screen.ui'
     display.add_device(
-        motor, macros={'detailed_screen': 'engineering_screen.ui'})
+        motor, macros={'detailed_screen': screen})
     display.load_best_template()
-    assert display.current_template.name == 'engineering_screen.ui'
-    assert display.templates['detailed_screen'][0].name == 'engineering_screen.ui'
+    assert display.current_template.name == screen
+    assert display.templates['detailed_screen'][0].name == screen
 
 
 def test_display_type_change(motor, display):
@@ -114,5 +114,5 @@ def test_display_with_py_file(display, motor):
     py_file = str(conftest.MODULE_PATH / 'utils' / 'display.py')
     display.add_device(motor, macros={'detailed_screen': py_file})
     display.load_best_template()
-    assert isinstance(display._main_widget, Display)
-    assert getattr(display._main_widget, 'is_from_test_file', False)
+    assert isinstance(display.display_widget, Display)
+    assert getattr(display.display_widget, 'is_from_test_file', False)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,10 +1,9 @@
 import random
 
 import numpy as np
-import pydm.utilities
 from qtpy.QtWidgets import QWidget
 
-from ophyd import Kind
+import pydm.utilities
 from ophyd.signal import Signal
 from ophyd.sim import (FakeEpicsSignal, FakeEpicsSignalRO, SynSignal,
                        SynSignalRO)
@@ -120,6 +119,7 @@ def test_typhos_panel(qapp, client, qtbot):
     assert len(panel.layout().signals) == num_hints
     panel.showNormal = True
     panel.showHints = False
+    print(panel.layout().signals)
     assert len(panel.layout().signals) == num_read - num_hints
     panel.showHints = True
     assert len(panel.layout().signals) == num_read
@@ -135,7 +135,7 @@ def test_typhos_panel_sorting(qapp, client, qtbot):
     panel.channel = 'happi://test_motor'
     pydm.utilities.establish_widget_connections(panel)
     sorted_names = sorted(panel.devices[0].component_names)
-    sig_layout = panel.layout().layout()
+    _ = panel.layout().layout()
     assert list(panel.layout().signals.keys()) == sorted_names
     # Sort by kind
     panel.sortBy = panel.SignalOrder.byKind

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -14,6 +14,7 @@ from typhos.widgets import ImageDialogButton, WaveformDialogButton
 from .conftest import DeadSignal, RichSignal, show_widget
 
 
+@show_widget
 def test_panel_creation(qtbot):
     standard = FakeEpicsSignal('Tst:Pv')
     read_and_write = FakeEpicsSignal('Tst:Read', write_pv='Tst:Write')
@@ -41,15 +42,23 @@ def test_panel_creation(qtbot):
     qtbot.addWidget(widget)
     widget.setLayout(panel)
     assert len(panel.signals) == 6
+    panel._dump_layout()
+
+    def widget_at(row, col):
+        return panel.layout().itemAtPosition(row, col).widget()
+
     # Check read-only channels do not have write widgets
-    panel.layout().itemAtPosition(2, 1).layout().count() == 1
-    panel.layout().itemAtPosition(4, 1).layout().count() == 1
+    assert widget_at(2, 1) is widget_at(2, 2)
+    assert widget_at(4, 1) is widget_at(4, 2)
+
     # Array widget has only a button, even when writable
-    assert panel.layout().itemAtPosition(5, 1).layout().count() == 1
+    assert widget_at(5, 1) is widget_at(5, 2)
+
     # Check write widgets are present
-    panel.layout().itemAtPosition(0, 1).layout().count() == 2
-    panel.layout().itemAtPosition(1, 1).layout().count() == 2
-    panel.layout().itemAtPosition(3, 1).layout().count() == 2
+    assert widget_at(0, 1) is not widget_at(0, 2)
+    assert widget_at(1, 1) is not widget_at(1, 2)
+    assert widget_at(3, 1) is not widget_at(3, 2)
+    return widget
 
 
 def test_panel_add_enum(qtbot):
@@ -61,12 +70,14 @@ def test_panel_add_enum(qtbot):
     # Create an enum signal
     syn_sig = RichSignal(name='Syn:Enum', value=1)
     # Add our signals to the panel
-    loc1 = panel.add_signal(syn_sig, "Sim Enum PV")
+    row = panel.add_signal(syn_sig, "Sim Enum PV")
     # Check our signal was added a QCombobox
     # Assume it is the last item in the button layout
-    but_layout = panel.layout().itemAtPosition(loc1, 1)
-    assert isinstance(but_layout.itemAt(but_layout.count()-1).widget(),
-                      PyDMEnumComboBox)
+
+    def widget_at(row, col):
+        return panel.layout().itemAtPosition(row, col).widget()
+
+    assert isinstance(widget_at(row, 2), PyDMEnumComboBox)
 
 
 def test_add_dead_signal(qtbot):
@@ -84,12 +95,18 @@ def test_add_pv(qtbot):
     widget = QWidget()
     qtbot.addWidget(widget)
     widget.setLayout(panel)
-    panel.add_pv('Tst:A', 'Read Only')
+    row = panel.add_pv('Tst:A', 'Read Only')
     assert 'Read Only' in panel.signals
-    assert panel.layout().itemAtPosition(0, 1).count() == 1
-    panel.add_pv('Tst:A', "Write", write_pv='Tst:B')
+
+    def widget_at(row, col):
+        return panel.layout().itemAtPosition(row, col).widget()
+
+    # Check read-only spans setpoint/readback cols
+    assert widget_at(row, 1) is widget_at(row, 2)
+
+    row = panel.add_pv('Tst:A', "Write", write_pv='Tst:B')
     # Since it is not connected, it should show just the loading widget
-    assert panel.layout().itemAtPosition(1, 1).count() == 1
+    assert widget_at(row, 1) is widget_at(row, 2)
 
 
 @show_widget

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -8,7 +8,7 @@ from ophyd.signal import Signal
 from ophyd.sim import (FakeEpicsSignal, FakeEpicsSignalRO, SynSignal,
                        SynSignalRO)
 from pydm.widgets import PyDMEnumComboBox
-from typhos.signal import SignalPanel, TyphosSignalPanel, signal_widget
+from typhos.signal import SignalPanel, TyphosSignalPanel, create_signal_widget
 from typhos.widgets import ImageDialogButton, WaveformDialogButton
 
 from .conftest import DeadSignal, RichSignal, show_widget
@@ -148,7 +148,7 @@ def test_typhos_panel_sorting(qapp, client, qtbot):
 @show_widget
 def test_signal_widget_waveform(qtbot):
     signal = Signal(name='test_wave', value=np.zeros((4, )))
-    widget = signal_widget(signal)
+    widget = create_signal_widget(signal)
     qtbot.addWidget(widget)
     assert isinstance(widget, WaveformDialogButton)
     return widget
@@ -157,7 +157,7 @@ def test_signal_widget_waveform(qtbot):
 @show_widget
 def test_signal_widget_image(qtbot):
     signal = Signal(name='test_img', value=np.zeros((400, 540)))
-    widget = signal_widget(signal)
+    widget = create_signal_widget(signal)
     qtbot.addWidget(widget)
     assert isinstance(widget, ImageDialogButton)
     return widget

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -8,10 +8,9 @@ from pyqtgraph.parametertree import ParameterTree
 from pyqtgraph.parametertree import parameterTypes as ptypes
 from qtpy import QtWidgets
 
-import typhos.suite
 from typhos.display import TyphosDeviceDisplay
 from typhos.suite import DeviceParameter, TyphosSuite
-from typhos.utils import clean_name, save_suite
+from typhos.utils import save_suite
 
 from .conftest import show_widget
 
@@ -22,6 +21,7 @@ def suite(qtbot, device):
     qtbot.addWidget(suite)
     return suite
 
+
 @show_widget
 def test_suite_with_child_devices(suite, device):
     assert device in suite.devices
@@ -30,6 +30,7 @@ def test_suite_with_child_devices(suite, device):
     child_displays = device_group.childs[0].childs
     assert len(child_displays) == len(device._sub_devices)
     return suite
+
 
 def test_suite_without_children(device, qtbot):
     childless = TyphosSuite.from_device(device, children=False)
@@ -50,9 +51,11 @@ def test_suite_get_subdisplay_by_device(suite, device):
     display = suite.get_subdisplay(device)
     assert device in display.devices
 
+
 def test_suite_subdisplay_parentage(suite, device):
     display = suite.get_subdisplay(device)
     assert display in suite.findChildren(TyphosDeviceDisplay)
+
 
 def test_suite_get_subdisplay_by_name(suite, device):
     display = suite.get_subdisplay(device.name)
@@ -156,7 +159,8 @@ def test_suite_save(suite, monkeypatch):
     suite.save()
     assert tfile.exists()
     devices = [device.name for device in suite.devices]
-    assert str(devices) in open(str(tfile), 'r').read()
+    with open(str(tfile), 'r') as f:
+        assert str(devices) in f.read()
     os.remove(str(tfile))
 
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -163,6 +163,10 @@ class TyphosDisplayConfigButton(TyphosToolButton):
             line_edit.setPlaceholderText('/ '.join(filters))
 
         line_edit.editingFinished.connect(text_filter_updated)
+        line_edit.setObjectName('menu_action')
+
+        action = base_menu.addAction('Filter by name:')
+        action.setEnabled(False)
 
         action = QtWidgets.QWidgetAction(self)
         action.setDefaultWidget(line_edit)
@@ -181,6 +185,7 @@ class TyphosDisplayConfigButton(TyphosToolButton):
         Kind filter > Show hinted
                       ...
                       Show only hinted
+        Filter by name
         """
         base_menu = QtWidgets.QMenu(parent=self)
 
@@ -199,8 +204,8 @@ class TyphosDisplayConfigButton(TyphosToolButton):
         filter_menu.addSeparator()
         self.create_kind_filter_menu(panels, filter_menu, only=True)
 
-        name_menu = base_menu.addMenu("&Name filter")
-        self.create_name_filter_menu(panels, name_menu)
+        base_menu.addSeparator()
+        self.create_name_filter_menu(panels, base_menu)
 
         return base_menu
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -343,17 +343,16 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
     @Property(bool)
     def composite_heuristics(self):
-        """Allow composite screen to be chosen by heuristics?"""
+        """Allow composite screen to be suggested first by heuristics?"""
         return self._composite_heuristics
 
     @composite_heuristics.setter
     def composite_heuristics(self, composite_heuristics):
-        # Switch between using the scroll area layout or
         self._composite_heuristics = bool(composite_heuristics)
 
     @Property(bool)
     def scrollable(self):
-        """..."""
+        """Place the display in a scrollable area?"""
         return self._scrollable
 
     @scrollable.setter

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -506,6 +506,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         layout = QtWidgets.QHBoxLayout()
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._scroll_area)
 
         self.setContextMenuPolicy(Qt.DefaultContextMenu)
         self.contextMenuEvent = self.open_context_menu
@@ -653,17 +654,18 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         logger.warning("No templates available for display type: %s",
                        self._display_type)
 
-    def _clear_layout(self):
+    def _remove_display(self):
         """
-        Clear the layout in preparation for another template setting
+        Remove the display widget, readying for a new template
         """
-        # Clear anything that exists in the current layout
-        layout = self.layout()
-        layout.removeWidget(self._scroll_area)
-        utils.clear_layout(layout)
-        self._scroll_area.takeWidget()
+        display_widget = self._display_widget
+        if display_widget:
+            if self._scroll_area.widget():
+                self._scroll_area.takeWidget()
+            self.layout().removeWidget(display_widget)
+            display_widget.deleteLater()
+
         self._display_widget = None
-        layout.addWidget(self._scroll_area)
 
     def load_best_template(self):
         """
@@ -679,7 +681,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         if not self._searched:
             self.search_for_templates()
 
-        self._clear_layout()
+        self._remove_display()
 
         template = (self._forced_template or
                     self.get_best_template(self._display_type, self.macros))

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -215,6 +215,18 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
 
         super().mousePressEvent(event)
 
+    def set_device_display(self, display):
+        self.device_display = display
+
+        def toggle_display():
+            ...
+            # widget = display.display_widget
+            # TODO: not the right widget; intent is to hide the signal panel
+            # this title is buddies with
+            # if widget:
+            #     widget.setVisible(not widget.isVisible())
+        self.toggle_requested.connect(toggle_display)
+
     # Make designable properties from the title label available here as well
     locals().update(**pcdsutils.qt.forward_properties(
         locals_dict=locals(),
@@ -316,6 +328,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         # self._scroll_area.setObjectName(self.objectName() + '_scroll_area')
         self._scroll_area.setFrameShape(QtWidgets.QFrame.StyledPanel)
         self._scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
+        self._scroll_area.setWidgetResizable(True)
 
         super().__init__(parent=parent)
 
@@ -358,7 +371,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         widget.setParent(None)
         if self._scrollable:
             self._scroll_area.setWidget(widget)
-            self._scroll_area.setWidgetResizable(True)
         else:
             self.layout().addWidget(widget)
 
@@ -523,6 +535,13 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         self._move_display_to_layout(self._display_widget)
 
         utils.reload_widget_stylesheet(self)
+
+    @property
+    def display_widget(self):
+        """
+        The widget from the display itself
+        """
+        return self._display_widget
 
     @staticmethod
     def _get_templates_from_macros(macros):
@@ -715,7 +734,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         return composite
 
     @classmethod
-    def from_device(cls, device, template=None, macros=None):
+    def from_device(cls, device, template=None, macros=None, **kwargs):
         """
         Create a new TyphosDeviceDisplay from a Device
 
@@ -730,8 +749,10 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             Set the ``display_template``
         macros: dict, optional
             Macro substitutions to be placed in template
+        **kwargs
+            Passed to the class init
         """
-        display = cls()
+        display = cls(**kwargs)
         # Reset the template if provided
         if template:
             display.force_template = template
@@ -754,7 +775,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             Set the ``display_template``
         macros: dict, optional
             Macro substitutions to be placed in template
-        kwargs : dict
+        **kwargs
             Extra arguments are used at device instantiation
 
         Returns

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -61,6 +61,10 @@ class TyphosDisplaySwitcherButton(QtWidgets.QPushButton):
         self.setMinimumSize(32, 32)
 
     def _select_first_template(self):
+        if self.templates is None:
+            logger.warning('set_device_display not called on %s', self)
+            return
+
         try:
             template = self.templates[0]
         except IndexError:
@@ -83,7 +87,8 @@ class TyphosDisplaySwitcherButton(QtWidgets.QPushButton):
 
     def open_context_menu(self, ev):
         menu = self.generate_context_menu()
-        menu.exec_(self.mapToGlobal(ev.pos()))
+        if menu:
+            menu.exec_(self.mapToGlobal(ev.pos()))
 
 
 class TyphosDisplaySwitcher(QtWidgets.QFrame, widgets.TyphosDesignerMixin):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -155,6 +155,8 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     """
     Standardized Typhos Device Display title
     """
+    toggle_requested = QtCore.Signal()
+
     def __init__(self, title='${name}', *, show_switcher=True,
                  show_underline=True, parent=None):
         self._show_underline = show_underline
@@ -206,6 +208,12 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     def show_underline(self, value):
         self._show_underline = bool(value)
         self.underline.setVisible(self._show_underline)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.toggle_requested.emit()
+
+        super().mousePressEvent(event)
 
     # Make designable properties from the title label available here as well
     locals().update(**pcdsutils.qt.forward_properties(

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -315,6 +315,24 @@ class TyphosDisplaySwitcher(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         ...
 
 
+class TyphosTitleLabel(QtWidgets.QLabel):
+    toggle_requested = QtCore.Signal()
+
+    def __init__(self, text, parent=None):
+        super().__init__(text, parent=parent)
+
+        font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.TitleFont)
+        font.setPointSizeF(14.0)
+        font.setBold(True)
+        self.setFont(font)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.toggle_requested.emit()
+
+        super().mousePressEvent(event)
+
+
 class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     """
     Standardized Typhos Device Display title
@@ -327,12 +345,7 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self._show_switcher = show_switcher
         super().__init__(parent=parent)
 
-        font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.TitleFont)
-        font.setPointSizeF(14.0)
-        font.setBold(True)
-
-        self.label = QtWidgets.QLabel(title)
-        self.label.setFont(font)
+        self.label = TyphosTitleLabel(title)
 
         self.switcher = TyphosDisplaySwitcher()
 
@@ -374,22 +387,16 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self._show_underline = bool(value)
         self.underline.setVisible(self._show_underline)
 
-    def mousePressEvent(self, event):
-        if event.button() == Qt.LeftButton:
-            self.toggle_requested.emit()
-
-        super().mousePressEvent(event)
-
     def set_device_display(self, display):
         self.device_display = display
 
         def toggle_display():
-            ...
-            # widget = display.display_widget
-            # TODO: not the right widget; intent is to hide the signal panel
-            # this title is buddies with
-            # if widget:
-            #     widget.setVisible(not widget.isVisible())
+            widget = display.display_widget
+            panels = widget.findChildren(signal.TyphosSignalPanel) or []
+            visible = all(panel.isVisible() for panel in panels)
+            for panel in panels:
+                panel.setVisible(not visible)
+
         self.toggle_requested.connect(toggle_display)
 
     # Make designable properties from the title label available here as well

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -181,6 +181,7 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self.grid_layout.addWidget(self.label, 0, 0)
         self.grid_layout.addWidget(self.switcher, 0, 1, Qt.AlignRight)
         self.grid_layout.addWidget(self.underline, 1, 0, 1, 2)
+        self.grid_layout.setSizeConstraint(self.grid_layout.SetMinimumSize)
         self.setLayout(self.grid_layout)
 
         # Set the property:

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -58,7 +58,7 @@ class TyphosDisplaySwitcherButton(QtWidgets.QPushButton):
         self.templates = None
         self.clicked.connect(self._select_first_template)
         self.setIcon(icon)
-        self.setMinimumSize(32, 32)
+        self.setMinimumSize(24, 24)
 
     def _select_first_template(self):
         if self.templates is None:

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -155,7 +155,9 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     """
     Standardized Typhos Device Display title
     """
-    def __init__(self, title='${name}', *, show_switcher=True, parent=None):
+    def __init__(self, title='${name}', *, show_switcher=True,
+                 show_underline=True, parent=None):
+        self._show_underline = show_underline
         self._show_switcher = show_switcher
         super().__init__(parent=parent)
 
@@ -181,6 +183,7 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
 
         # Set the property:
         self.show_switcher = show_switcher
+        self.show_underline = show_underline
 
     @Property(bool)
     def show_switcher(self):
@@ -194,6 +197,15 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     def add_device(self, device):
         if not self.label.text():
             self.label.setText(device.name)
+
+    @QtCore.Property(bool)
+    def show_underline(self):
+        return self._show_underline
+
+    @show_underline.setter
+    def show_underline(self, value):
+        self._show_underline = bool(value)
+        self.underline.setVisible(self._show_underline)
 
     # Make designable properties from the title label available here as well
     locals().update(**pcdsutils.qt.forward_properties(

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -492,6 +492,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         layout.removeWidget(self._scroll_area)
         utils.clear_layout(layout)
         self._scroll_area.takeWidget()
+        self._display_widget = None
         layout.addWidget(self._scroll_area)
 
     def load_best_template(self):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -3,8 +3,8 @@ import logging
 import os.path
 import pathlib
 
-from qtpy import QtWidgets, QtCore, QtGui
-from qtpy.QtCore import Q_ENUMS, Property, Slot, Qt
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Q_ENUMS, Property, Qt, Slot
 
 import pcdsutils
 import pcdsutils.qt
@@ -12,8 +12,7 @@ import pydm.display
 import pydm.exception
 import pydm.utilities
 
-from . import utils
-from . import widgets
+from . import utils, widgets
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +31,10 @@ DEFAULT_TEMPLATES = {
     name: [(utils.ui_dir / f'{name}.ui').resolve()]
     for name in DisplayTypes.names
 }
+
+DEFAULT_TEMPLATES['detailed_screen'].append(
+    (utils.ui_dir / f'detailed_tree.ui').resolve()
+)
 
 
 def normalize_display_type(display_type):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -139,6 +139,35 @@ class TyphosDisplayConfigButton(TyphosToolButton):
                                       for panel in panels))
             action.triggered.connect(selected)
 
+    def create_name_filter_menu(self, panels, base_menu):
+        """
+        Create the name-based filtering menu
+
+        Parameters
+        ----------
+        base_menu : QMenu
+            The menu to add actions to
+        """
+        def text_filter_updated():
+            text = line_edit.text().strip()
+            for panel in panels:
+                panel.nameFilter = text
+
+        line_edit = QtWidgets.QLineEdit()
+
+        filters = list(set(panel.nameFilter for panel in panels
+                           if panel.nameFilter))
+        if len(filters) == 1:
+            line_edit.setText(filters[0])
+        else:
+            line_edit.setPlaceholderText('/ '.join(filters))
+
+        line_edit.editingFinished.connect(text_filter_updated)
+
+        action = QtWidgets.QWidgetAction(self)
+        action.setDefaultWidget(line_edit)
+        base_menu.addAction(action)
+
     def generate_context_menu(self):
         """
         Generates the custom context menu
@@ -169,6 +198,9 @@ class TyphosDisplayConfigButton(TyphosToolButton):
         self.create_kind_filter_menu(panels, filter_menu, only=False)
         filter_menu.addSeparator()
         self.create_kind_filter_menu(panels, filter_menu, only=True)
+
+        name_menu = base_menu.addMenu("&Name filter")
+        self.create_name_filter_menu(panels, name_menu)
 
         return base_menu
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -325,7 +325,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
         self._scroll_area = QtWidgets.QScrollArea()
         self._scroll_area.setAlignment(Qt.AlignTop)
-        # self._scroll_area.setObjectName(self.objectName() + '_scroll_area')
+        self._scroll_area.setObjectName('_scroll_area')
         self._scroll_area.setFrameShape(QtWidgets.QFrame.StyledPanel)
         self._scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
         self._scroll_area.setWidgetResizable(True)
@@ -528,6 +528,9 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                 else:
                     widget = QtWidgets.QWidget()
                     template = None
+
+        if widget:
+            widget.setObjectName('display_widget')
 
         self._display_widget = widget
         self._current_template = template

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -318,8 +318,8 @@ class TyphosDisplaySwitcher(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
 class TyphosTitleLabel(QtWidgets.QLabel):
     toggle_requested = QtCore.Signal()
 
-    def __init__(self, text, parent=None):
-        super().__init__(text, parent=parent)
+    def __init__(self, text):
+        super().__init__(text)
 
         font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.TitleFont)
         font.setPointSizeF(14.0)
@@ -346,7 +346,6 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         super().__init__(parent=parent)
 
         self.label = TyphosTitleLabel(title)
-
         self.switcher = TyphosDisplaySwitcher()
 
         self.underline = QtWidgets.QFrame()
@@ -397,7 +396,7 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
             for panel in panels:
                 panel.setVisible(not visible)
 
-        self.toggle_requested.connect(toggle_display)
+        self.label.toggle_requested.connect(toggle_display)
 
     # Make designable properties from the title label available here as well
     locals().update(**pcdsutils.qt.forward_properties(

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -164,6 +164,9 @@ class SignalPanel(QtWidgets.QGridLayout):
         print('-' * (64 * self._NUM_COLS), file=file)
 
     def _add_devices_cb(self, name, row, signal):
+        if name not in self.signals:
+            return
+
         # Create the read-only signal
         read = create_signal_widget(signal, read_only=True)
         # Create the write signal
@@ -345,6 +348,8 @@ class SignalPanel(QtWidgets.QGridLayout):
         sorter = _get_signal_sorter(order)
         for (label, signal, cpt) in sorted(set(signals), key=sorter):
             self.add_signal(signal, label, tooltip=cpt.doc)
+
+        self.setSizeConstraint(self.SetMinimumSize)
 
     def add_device(self, device):
         self._devices.append(device)

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -239,17 +239,14 @@ class SignalPanel(QtWidgets.QGridLayout):
 
         logger.debug("Adding signal %s", name)
 
-        # Add to the layout
-
-        # Create label
         label = QtWidgets.QLabel()
         label.setText(name)
+        label.setObjectName('signal_row_label')
         if tooltip is not None:
             label.setToolTip(tooltip)
 
         row = self.add_row(label, TyphosLoading())
 
-        # Store signal
         self.signals[name] = dict(read=None, write=None, row=row,
                                   signal=signal)
 

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -130,6 +130,13 @@ class SignalPanel(QtWidgets.QGridLayout):
             for name, sig in signals.items():
                 self.add_signal(sig, name)
 
+    @property
+    def row_count(self):
+        """
+        The number of filled-in rows
+        """
+        return self._row_count
+
     def _add_devices_cb(self, name, row, signal):
         # Create the read-only signal
         read = create_signal_widget(signal, read_only=True)
@@ -235,11 +242,19 @@ class SignalPanel(QtWidgets.QGridLayout):
         """
         row = self._row_count
         self._row_count += 1
-        for col, item in enumerate(widgets):
+
+        if len(widgets) == 1:
+            item, = widgets
             if isinstance(item, QtWidgets.QLayout):
-                self.addLayout(item, row, col, **kwargs)
+                self.addLayout(item, row, 0, 1, 2, **kwargs)
             else:
-                self.addWidget(item, row, col, **kwargs)
+                self.addWidget(item, row, 0, 1, 2, **kwargs)
+        else:
+            for col, item in enumerate(widgets):
+                if isinstance(item, QtWidgets.QLayout):
+                    self.addLayout(item, row, col, **kwargs)
+                else:
+                    self.addWidget(item, row, col, **kwargs)
 
         return row
 

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -245,7 +245,7 @@ class SignalPanel(QtWidgets.QGridLayout):
         if tooltip is not None:
             label.setToolTip(tooltip)
 
-        row = self.add_row(label, TyphosLoading())
+        row = self.add_row(label, None)
 
         self.signals[name] = dict(read=None, write=None, row=row,
                                   signal=signal)
@@ -253,6 +253,7 @@ class SignalPanel(QtWidgets.QGridLayout):
         if signal.connected:
             self._add_devices_cb(name, row, signal)
         else:
+            self._update_row(row, [None, TyphosLoading()])
             signal.subscribe(_device_meta_cb, Signal.SUB_META, run=True)
 
         return row
@@ -290,11 +291,9 @@ class SignalPanel(QtWidgets.QGridLayout):
         last_widget = widgets[-1]
         if last_widget is not None:
             # Column-span the last widget over the remaining columns:
-            last_col = len(widgets) - 1
-            remaining = self.NUM_COLS - last_col
-            if remaining:
-                self.addWidget(last_widget, row, last_col, 1,
-                               self.NUM_COLS - last_col, **kwargs)
+            last_column = len(widgets) - 1
+            colspan = self.NUM_COLS - last_column
+            self.addWidget(last_widget, row, last_column, 1, colspan, **kwargs)
 
     def add_pv(self, read_pv, name, write_pv=None):
         """

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -120,6 +120,8 @@ class SignalPanel(QtWidgets.QGridLayout):
         Signals to include in the panel
         Parent of panel
     """
+    _NUM_COLS = 2
+
     def __init__(self, signals=None):
         super().__init__()
 
@@ -232,6 +234,9 @@ class SignalPanel(QtWidgets.QGridLayout):
         """
         Add ``widgets`` to the next row
 
+        If only one widget is given, it will be adjusted automatically to span
+        all columns.
+
         Parameters
         ----------
         *widgets
@@ -248,9 +253,9 @@ class SignalPanel(QtWidgets.QGridLayout):
         if len(widgets) == 1:
             item, = widgets
             if isinstance(item, QtWidgets.QLayout):
-                self.addLayout(item, row, 0, 1, 2, **kwargs)
+                self.addLayout(item, row, 0, 1, self._NUM_COLS, **kwargs)
             else:
-                self.addWidget(item, row, 0, 1, 2, **kwargs)
+                self.addWidget(item, row, 0, 1, self._NUM_COLS, **kwargs)
         else:
             for col, item in enumerate(widgets):
                 if isinstance(item, QtWidgets.QLayout):
@@ -497,7 +502,7 @@ class CompositeSignalPanel(SignalPanel):
         for name, info in self.signals.items():
             signal = info['signal']
             row = info['row']
-            for col in (0, 1):
+            for col in range(self._NUM_COLS):
                 widget = self.itemAtPosition(row, col).widget()
                 if widget:
                     widget.setVisible(signal.kind in kinds)

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -3,7 +3,7 @@ import sys
 from functools import partial
 
 from qtpy import QtCore, QtWidgets
-from qtpy.QtCore import Q_ENUMS, Property, QSize, QTimer
+from qtpy.QtCore import Q_ENUMS, Property, QTimer
 
 import ophyd
 from ophyd import Kind
@@ -515,10 +515,6 @@ class TyphosSignalPanel(TyphosBase, TyphosDesignerMixin, SignalOrder):
         # Configure the layout for the new device
         self._panel_layout.add_device(device)
         self._update_panel()
-
-    def sizeHint(self):
-        """Default SizeHint"""
-        return QSize(240, 140)
 
     def set_device_display(self, display):
         self.display = display

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -262,13 +262,13 @@ class SignalPanel(QtWidgets.QGridLayout):
         """
         Add ``widgets`` to the next row
 
-        If less widgets are given than `NUM_COLS`, the last widget will be
+        If fewer than ``NUM_COLS`` widgets are given, the last widget will be
         adjusted automatically to span the remaining columns.
 
         Parameters
         ----------
         *widgets
-            List of :class:`QtWidgets.QWidget` or :class:`QtWidgets.QLayout`.
+            List of :class:`QtWidgets.QWidget`
 
         Returns
         -------
@@ -284,6 +284,21 @@ class SignalPanel(QtWidgets.QGridLayout):
         return row
 
     def _update_row(self, row, widgets, **kwargs):
+        """
+        Update ``row`` to contain ``widgets``
+
+        If fewer widgets than ``NUM_COLS`` are given, the last widget will be
+        adjusted automatically to span the remaining columns.
+
+        Parameters
+        ----------
+        row : int
+            The row number
+        widgets : list of :class:`QtWidgets.QWidget`
+            If ``None`` is found, the cell will be skipped.
+        **kwargs
+            Passed into ``addWidget``
+        """
         for col, item in enumerate(widgets[:-1]):
             if item is not None:
                 self.addWidget(item, row, col, **kwargs)

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -288,6 +288,20 @@ class SignalPanel(QtWidgets.QGridLayout):
         return self.add_signal(sig, name)
 
     def filter_signals(self, kinds, order):
+        """
+        Filter signals based on the given kinds
+
+        Parameters
+        ----------
+        kinds : list of :class:`ophyd.Kind`
+            If given
+        order : :class:`SignalOrder`
+            Order by kind, or by name, for example
+
+        Note
+        ----
+        :class:`SignalPanel` recreates all widgets when this is called.
+        """
         self.clear()
         signals = []
 
@@ -465,6 +479,21 @@ class CompositeSignalPanel(SignalPanel):
         self._containers = {}
 
     def filter_signals(self, kinds, order):
+        """
+        Filter signals based on the given kinds
+
+        Parameters
+        ----------
+        kinds : list of :class:`ophyd.Kind`
+            If given
+        order : :class:`SignalOrder`
+            Order by kind, or by name, for example
+
+        Note
+        ----
+        :class:`CompositeSignalPanel` merely toggles visibility and does not
+        destroy nor recreate widgets when this is called.
+        """
         for name, info in self.signals.items():
             signal = info['signal']
             row = info['row']
@@ -473,7 +502,7 @@ class CompositeSignalPanel(SignalPanel):
                 if widget:
                     widget.setVisible(signal.kind in kinds)
 
-    def add_device_container(self, device, name):
+    def add_sub_device(self, device, name):
         """
         Add a sub-device to the next row
 
@@ -504,7 +533,7 @@ class CompositeSignalPanel(SignalPanel):
             dotted_name = f'{device.name}.{attr}'
             obj = getattr(device, attr)
             if issubclass(component.cls, ophyd.Device):
-                self.add_device_container(obj, name=dotted_name)
+                self.add_sub_device(obj, name=dotted_name)
             else:
                 self.add_signal(obj, name=dotted_name)
 

--- a/typhos/signal.py
+++ b/typhos/signal.py
@@ -19,7 +19,7 @@ from .widgets import (ImageDialogButton, SignalDialogButton, TyphosComboBox,
 logger = logging.getLogger(__name__)
 
 
-def signal_widget(signal, read_only=False, tooltip=None):
+def create_signal_widget(signal, read_only=False, tooltip=None):
     """
     Factory for creating a PyDMWidget from a signal
 
@@ -106,6 +106,10 @@ def signal_widget(signal, read_only=False, tooltip=None):
     return widget_instance
 
 
+# Backward-compatibility (TODO deprecate)
+signal_widget = create_signal_widget
+
+
 class SignalPanel(QGridLayout):
     """
     Base panel display for EPICS signals
@@ -127,11 +131,11 @@ class SignalPanel(QGridLayout):
 
     def _add_devices_cb(self, name, index, signal):
         # Create the read-only signal
-        read = signal_widget(signal, read_only=True)
+        read = create_signal_widget(signal, read_only=True)
         # Create the write signal
         if (not is_signal_ro(signal) and not isinstance(read,
                                                         SignalDialogButton)):
-            write = signal_widget(signal)
+            write = create_signal_widget(signal)
         else:
             write = None
 

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -546,7 +546,6 @@ class TyphosDeviceContainerTitle(QtWidgets.QFrame,
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             self.toggle_requested.emit()
-            print('title clicked', self.label.text())
 
         super().mousePressEvent(event)
 
@@ -697,12 +696,12 @@ class TyphosCompositeDisplay(TyphosBase):
             try:
                 container = containers[container_name]
             except KeyError:
-                parent_name = '.'.join(container_name.split('.')[:-1])
-                parent_container = containers[parent_name]
-
                 container = TyphosDeviceContainer(
                     title=f'{device.name}.{container_name}')
                 containers[container_name] = container
+
+                parent_name = '.'.join(container_name.split('.')[:-1])
+                parent_container = containers[parent_name]
                 parent_container.add_widget(container)
 
             if issubclass(walk.item.cls, ophyd.Device):
@@ -726,7 +725,6 @@ class TyphosCompositeDisplay(TyphosBase):
 
         self._scroll_area.setWidget(self._main_frame)
         self._scroll_area.setWidgetResizable(True)
-        print(self._main_frame.parent().objectName())
 
     @classmethod
     def from_device(cls, device, parent=None, **kwargs):

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -636,18 +636,12 @@ class TyphosDeviceContainer(QtWidgets.QFrame):
 
 class TyphosCompositeDisplay(TyphosBase):
     """
-    Complete Typhos Window
-
-    This contains all the necessities to load tools and devices into a Typhos
-    window.
+    Tree-like widget showing a full ophyd Device, with sub-devices
 
     Parameters
     ----------
     parent : QWidget, optional
     """
-    default_tools = {'Log': TyphosLogDisplay,
-                     'StripTool': TyphosTimePlot,
-                     'Console': TyphosConsole}
 
     def __init__(self, use_templates=True, parent=None):
         super().__init__(parent=parent)
@@ -734,19 +728,11 @@ class TyphosCompositeDisplay(TyphosBase):
         Parameters
         ----------
         device: ophyd.Device
-
-        children: bool, optional
-            Choice to include child Device components
-
-        parent: QWidgets
-
-        tools: dict, optional
-            Tools to load for the object. ``dict`` should be name, class pairs.
-            By default these will be ``.default_tools``, but ``None`` can be
-            passed to avoid tool loading completely.
-
-        kwargs:
-            Passed to :meth:`TyphosSuite.add_device`
+            The device
+        parent: QtWidgets.QWidget
+            The parent widget
+        **kwargs
+            Passed to :meth:`TyphosCompositeDisplay.add_device`
         """
         display = cls(parent=parent)
         display.add_device(device, **kwargs)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -12,7 +12,6 @@ from qtpy.QtWidgets import QWidget
 import pcdsutils.qt
 
 from . import display as typhos_display
-from . import signal as typhos_signal
 from . import utils, widgets
 from .display import TyphosDeviceDisplay
 from .tools import TyphosConsole, TyphosLogDisplay, TyphosTimePlot
@@ -456,55 +455,3 @@ class TyphosDeviceContainerTitle(typhos_display.TyphosDisplayTitle,
             self.toggle_requested.emit()
 
         super().mousePressEvent(event)
-
-
-class TyphosCompositeFrame(QtWidgets.QFrame):
-    threshold = 5
-
-    def __init__(self, name='', parent=None):
-        super().__init__(parent=parent)
-
-        self._title = TyphosDeviceContainerTitle(title=name)
-        self._title.toggle_requested.connect(self._toggle_view)
-        self._frame = QtWidgets.QFrame()
-
-        # self._title.switcher.template_selected.connect()
-        self.setLayout(QtWidgets.QVBoxLayout())
-        self.layout().setContentsMargins(0, 0, 0, 0)
-        self.layout().addWidget(self._title)
-        self.layout().addWidget(self._frame)
-
-        self.signal_panel = typhos_signal.SignalPanel()
-        self._frame.setLayout(self.signal_panel)
-
-        if name:
-            self.setObjectName(name)
-
-        self._frame.setObjectName(self.objectName() + '_frame')
-        self._switcher_visible = False
-        self._line_visible = False
-
-    def _toggle_view(self):
-        visible = not self._frame.isVisible()
-        self._frame.setVisible(visible)
-        if visible:
-            self._title.show_switcher = self._switcher_visible
-            self._title.show_underline = self._line_visible
-        else:
-            self._switcher_visible = self._title.show_switcher
-            self._line_visible = self._title.show_underline
-            self._title.show_switcher = False
-            self._title.show_underline = False
-
-    def _finish_layout(self):
-        if self.signal_panel.row_count < self.threshold:
-            self._title.show_underline = False
-            self._title.show_switcher = False
-
-            # font = self._title.label.font()
-            # font.setPointSizeF(font.pointSizeF() * 0.8)
-            # self._title.label.setFont(font)
-        else:
-            self._frame.setLineWidth(1)
-            self._frame.setFrameShadow(QtWidgets.QFrame.Raised)
-            self._frame.setFrameShape(QtWidgets.QFrame.StyledPanel)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -460,7 +460,7 @@ class TyphosDeviceContainerTitle(typhos_display.TyphosDisplayTitle,
         super().mousePressEvent(event)
 
 
-class TyphosDeviceContainer(QtWidgets.QFrame):
+class TyphosCompositeFrame(QtWidgets.QFrame):
     threshold = 5
 
     def __init__(self, name='', parent=None):
@@ -486,27 +486,25 @@ class TyphosDeviceContainer(QtWidgets.QFrame):
             self.setObjectName(name)
 
         self._content.setObjectName(self.objectName() + '_content')
-        self._filter_visible = False
+        self._switcher_visible = False
         self._line_visible = False
-        # self.cls = cls
-        # self.device_display = TyphosDeviceDisplay()
 
     def _toggle_view(self):
         visible = not self._content.isVisible()
         self._content.setVisible(visible)
         if visible:
-            self._title.show_filter = self._filter_visible
-            self._title.show_line = self._line_visible
+            self._title.show_switcher = self._switcher_visible
+            self._title.show_underline = self._line_visible
         else:
-            self._filter_visible = self._title.show_filter
-            self._line_visible = self._title.show_line
-            self._title.show_filter = False
-            self._title.show_line = False
+            self._switcher_visible = self._title.show_switcher
+            self._line_visible = self._title.show_underline
+            self._title.show_switcher = False
+            self._title.show_underline = False
 
-    def complete_layout(self):
+    def _finish_layout(self):
         if self.signal_panel.row_count < self.threshold:
-            self._title.show_line = False
-            self._title.show_filter = False
+            self._title.show_underline = False
+            self._title.show_switcher = False
 
             font = self._title.label.font()
             font.setPointSizeF(font.pointSizeF() * 0.8)
@@ -538,7 +536,7 @@ class TyphosCompositeDisplay(TyphosBase):
 
         self._scroll_area = None
 
-        self._main_frame = TyphosDeviceContainer(name=name)
+        self._main_frame = TyphosCompositeFrame(name=name)
         if scrollable:
             self._scroll_area = QtWidgets.QScrollArea()  # (self)
             self._scroll_area.setAlignment(Qt.AlignTop)
@@ -640,8 +638,9 @@ class TyphosCompositeDisplay(TyphosBase):
             else:
                 self._signal_panel.add_signal(obj, name=dotted_name)
 
-        # for container in containers.values():
-        #     container.complete_layout()
+        for dotted_name, container in self._containers.items():
+            if hasattr(container, '_finish_layout'):
+                container._finish_layout()
 
         self._finish_layout()
 
@@ -649,6 +648,7 @@ class TyphosCompositeDisplay(TyphosBase):
         if self._scroll_area:
             self._scroll_area.setWidget(self._main_frame)
             self._scroll_area.setWidgetResizable(True)
+        self._main_frame._finish_layout()
 
     @classmethod
     def from_device(cls, device, parent=None, **kwargs):

--- a/typhos/ui/detailed_screen.ui
+++ b/typhos/ui/detailed_screen.ui
@@ -50,6 +50,12 @@
    </item>
    <item>
     <widget class="QTabWidget" name="signal_tab">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -143,6 +149,12 @@
            </property>
            <item>
             <widget class="TyphosSignalPanel" name="config_panel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="toolTip">
               <string/>
              </property>
@@ -161,6 +173,19 @@
               <bool>false</bool>
              </property>
             </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>
@@ -238,6 +263,19 @@
               <bool>false</bool>
              </property>
             </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>

--- a/typhos/ui/detailed_tree.ui
+++ b/typhos/ui/detailed_tree.ui
@@ -31,13 +31,13 @@
     </widget>
    </item>
    <item>
-    <widget class="TyphosCompositeDisplay" name="read_panel">
+    <widget class="TyphosCompositeSignalPanel" name="signal_panel">
      <property name="toolTip">
       <string/>
      </property>
      <property name="whatsThis">
       <string>
-    Panel of Signals for Device
+    Panel of Signals + Sub-Devices for Device
     </string>
      </property>
     </widget>
@@ -46,14 +46,19 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosCompositeDisplay</class>
+   <class>TyphosSignalPanel</class>
    <extends>QWidget</extends>
-   <header>typhos.suite</header>
+   <header>typhos.signal</header>
   </customwidget>
   <customwidget>
    <class>TyphosDisplayTitle</class>
    <extends>QFrame</extends>
    <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosCompositeSignalPanel</class>
+   <extends>TyphosSignalPanel</extends>
+   <header>typhos.signal</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/typhos/ui/detailed_tree.ui
+++ b/typhos/ui/detailed_tree.ui
@@ -54,6 +54,19 @@
      </property>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/typhos/ui/detailed_tree.ui
+++ b/typhos/ui/detailed_tree.ui
@@ -19,9 +19,15 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -32,6 +38,12 @@
    </item>
    <item>
     <widget class="TyphosCompositeSignalPanel" name="signal_panel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>

--- a/typhos/ui/detailed_tree.ui
+++ b/typhos/ui/detailed_tree.ui
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>395</width>
+    <height>468</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphosCompositeDisplay" name="read_panel">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Panel of Signals for Device
+    </string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosCompositeDisplay</class>
+   <extends>QWidget</extends>
+   <header>typhos.suite</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhos/ui/embedded_screen.ui
+++ b/typhos/ui/embedded_screen.ui
@@ -37,7 +37,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="main_layout" stretch="0,2,1">
+  <layout class="QVBoxLayout" name="main_layout" stretch="0,2,0">
    <property name="spacing">
     <number>3</number>
    </property>
@@ -65,6 +65,12 @@
    </item>
    <item>
     <widget class="TyphosSignalPanel" name="hint_panel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -88,9 +94,6 @@
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::MinimumExpanding</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/typhos/ui/engineering_screen.ui
+++ b/typhos/ui/engineering_screen.ui
@@ -45,7 +45,7 @@
       <number>2</number>
      </property>
      <item>
-      <layout class="QVBoxLayout" name="read_layout" stretch="0,0,1">
+      <layout class="QVBoxLayout" name="read_layout" stretch="0,0,0">
        <item>
         <widget class="QLabel" name="read_label">
          <property name="font">

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -69,3 +69,7 @@ TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
 TyphosDeviceContainerTitle > QLabel:hover {
     border: 1px solid black;
 }
+
+TyphosDeviceContainerTitle > QLabel:hover {
+    border: 1px solid black;
+}

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -65,6 +65,10 @@ TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
     border: 2px solid red;
 }
 
+TyphosTitleLabel {
+    border: none;
+}
+
 TyphosTitleLabel:hover {
     border: 1px solid black;
 }

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -66,10 +66,6 @@ TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
     border: 2px solid red;
 }
 
-TyphosDeviceContainerTitle > QLabel:hover {
-    border: 1px solid black;
-}
-
-TyphosDeviceContainerTitle > QLabel:hover {
+TyphosDisplayTitle > QLabel:hover {
     border: 1px solid black;
 }

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -1,5 +1,4 @@
 TyphosBase {
-   background-color: #ffffff;
    color: black;
    font: bold;
 }
@@ -38,7 +37,7 @@ TyphosBase QComboBox:hover {
 }
 
 TyphosBase QListWidget::item:selected {
-    background-color: #0b3ae8;;
+    background-color: #0b3ae8;
     color: white;
 }
 

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -65,3 +65,7 @@ TyphosBase TyphosPositionerWidget[moving="false"][successful_move="true"] .QFram
 TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
     border: 2px solid red;
 }
+
+TyphosDeviceContainerTitle > QLabel:hover {
+    border: 1px solid black;
+}

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -65,7 +65,7 @@ TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
     border: 2px solid red;
 }
 
-TyphosDisplayTitle > QLabel:hover {
+TyphosTitleLabel:hover {
     border: 1px solid black;
 }
 

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -68,3 +68,9 @@ TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
 TyphosDisplayTitle > QLabel:hover {
     border: 1px solid black;
 }
+
+QLineEdit#menu_action {
+    border-width: 2px;
+    border-style: outset;
+    border-color: black;
+}

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -856,3 +856,10 @@ class DeviceConnectionMonitorThread(QtCore.QThread):
             while not self.isInterruptionRequested():
                 self._update_event.clear()
                 self._update_event.wait(timeout=0.5)
+
+
+def _get_top_level_components(device_cls):
+    """
+    Get all top-level components from a device class
+    """
+    return list(device_cls._sig_attrs.items())

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -449,6 +449,18 @@ def remove_duplicate_items(list_):
     return cls(sorted(set(list_), key=list_.index))
 
 
+def is_standard_template(template):
+    """
+    Is the template one provided with typhos?
+
+    Parameters
+    ----------
+    template : str or pathlib.Path
+    """
+    common_path = pathlib.Path(os.path.commonpath((template, MODULE_PATH)))
+    return common_path == MODULE_PATH
+
+
 def find_templates_for_class(cls, view_type, paths, *, extensions=None,
                              include_mro=True):
     '''

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -83,7 +83,7 @@ def is_signal_ro(signal):
     In the future this may be easier to do through improvements to
     introspection in the ophyd library. Until that day we need to check classes
     """
-    return isinstance(signal, (SignalRO, EpicsSignalRO))
+    return isinstance(signal, (SignalRO, EpicsSignalRO, ophyd.sim.SynSignalRO))
 
 
 def grab_kind(device, kind):

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -87,8 +87,6 @@ class TyphosComboBox(PyDMEnumComboBox):
     """
     Reimplementation of PyDMEnumComboBox to set some custom defaults
     """
-    def sizeHint(self):
-        return QSize(100, 30)
 
 
 class TyphosLineEdit(PyDMLineEdit):
@@ -102,12 +100,6 @@ class TyphosLineEdit(PyDMLineEdit):
 
         super().__init__(*args, **kwargs)
         self.showUnits = True
-        self.setMinimumHeight(30)
-        self.setMaximumHeight(30)
-        self.setMinimumWidth(60)
-
-    def sizeHint(self):
-        return QSize(100, 30)
 
     @property
     def setpoint_history(self):
@@ -222,12 +214,6 @@ class TyphosLabel(PyDMLabel):
         super().__init__(*args, **kwargs)
         self.setAlignment(Qt.AlignCenter)
         self.showUnits = True
-        self.setMinimumHeight(30)
-        self.setMaximumHeight(30)
-        self.setMinimumWidth(60)
-
-    def sizeHint(self):
-        return QSize(100, 30)
 
     def unit_changed(self, new_unit):
         """

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -213,6 +213,8 @@ class TyphosLabel(PyDMLabel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setAlignment(Qt.AlignCenter)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
+                           QtWidgets.QSizePolicy.Maximum)
         self.showUnits = True
 
     def unit_changed(self, new_unit):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add a new signal panel which aids in the display of complex devices

## Motivation and Context
ophyd Devices comprised of signals + sub-devices are problematic in typhos.
This PR adds a new signal panel which can show a complex device in a view that retains the structure laid out in the original ophyd definition.

Take, for example, a simple 3-motor device:

```python
class MyThreeMotorDevice(ophyd.Device):
    m1 = ophyd.Component(ophyd.EpicsMotor, 'm1')
    m2 = ophyd.Component(ophyd.EpicsMotor, 'm2')
    m3 = ophyd.Component(ophyd.EpicsMotor, 'm3')
    config = ophyd.Component(ophyd.EpicsSignal, "config_pv")
```

Typhos master would aggregate all signals from this device and group them according to `Kind`. To change that behavior would require adding a new template called `MyThreeMotorDevice.template_type.ui`.

With this PR, the hierarchy is retained, showing 3 `EpicsMotor` screens and 1 regular signal row.

Before (selecting embedded screen):
<img width="612" alt="image" src="https://user-images.githubusercontent.com/5139267/79909778-69d29280-83d2-11ea-930f-b472c0627213.png">

After (selecting embedded screen on each subdevice):
![image](https://user-images.githubusercontent.com/5139267/80044388-29017900-84b9-11ea-8db8-97901fb4d9c0.png)

See both the top-level device and individual sub-devices can now have their screens changed as well.

### Heuristics

There are some heuristics built-in which check to see if such a tree might be a useful way of displaying the device, or if a regular panel would be sufficient.

This isn't final and may be dropped.

## How Has This Been Tested?
Locally, so far

Testing it against:
- the composite motor device
- A massive areadetector instance

## Configuration drop-down

![image](https://user-images.githubusercontent.com/5139267/80044419-4b939200-84b9-11ea-89b2-d9419c75b55f.png)

Kind filtering:

![image](https://user-images.githubusercontent.com/5139267/80044452-61a15280-84b9-11ea-9e6b-302ac1ec56ed.png)

Name filtering:

The text at the bottom applies recursively to all child signal panels, such that "user_" in the above example would include `user_setpoint` and `user_readback` from `m1`, `m2`, and `m3`.

## Hide panels on section title click

![image](https://user-images.githubusercontent.com/5139267/80045144-6404ac00-84bb-11ea-8ddd-ac793cd38f58.png)

## Note
I waffled back and forth on this implementation, but I think it's settling in a good spot.

## Todo

- [x] Ensure signal filtering is actually working
- [ ] Update docs
- [ ] Revisit heuristic
- [x] Filter/search in the switcher?
- [x] Add click-title-to-hide-section functionality
- [x] Future PR: revisit original SignalPanel destroy-and-recreate functionality