### PR TITLE
ENH: Allow SignalDialogButton to produce persistent widgets.

### DIFF
--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -863,3 +863,23 @@ def _get_top_level_components(device_cls):
     Get all top-level components from a device class
     """
     return list(device_cls._sig_attrs.items())
+
+
+def find_parent_with_class(widget, cls=QWidget):
+    """
+    Finds the first parent of a widget that is an instance of ``klass``
+
+    Parameters
+    ----------
+    widget : QWidget
+        The widget from which to start the search
+    cls : type, optional
+        The class which the parent must be an instance of
+
+    """
+    parent = widget
+    while parent is not None:
+        if isinstance(parent, cls):
+            return parent
+        parent = parent.parent()
+    return None

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -382,6 +382,7 @@ class SignalDialogButton(QPushButton):
     """QPushButton to launch a QDialog with a PyDMWidget"""
     text = NotImplemented
     icon = NotImplemented
+    persistent = False
 
     def __init__(self, init_channel, text=None, icon=None, parent=None):
         self.text = text or self.text
@@ -402,7 +403,8 @@ class SignalDialogButton(QPushButton):
         if not self.dialog:
             logger.debug("Creating QDialog for %r", self.channel)
             # Set up the QDialog
-            self.dialog = QDialog(self)
+            parent = None if self.persistent else self
+            self.dialog = QDialog(parent)
             self.dialog.setWindowTitle(self.channel)
             self.dialog.setLayout(QVBoxLayout())
             self.dialog.layout().setContentsMargins(2, 2, 2, 2)
@@ -422,6 +424,7 @@ class ImageDialogButton(SignalDialogButton):
     """QPushButton to show a 2-d array"""
     text = 'Show Image'
     icon = 'fa.camera'
+    persistent = True
 
     def widget(self):
         """Create PyDMImageView"""
@@ -433,6 +436,7 @@ class WaveformDialogButton(SignalDialogButton):
     """QPushButton to show a 1-d array"""
     text = 'Show Waveform'
     icon = 'fa5s.chart-line'
+    persistent = True
 
     def widget(self):
         """Create PyDMWaveformPlot"""

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -14,6 +14,8 @@ from pydm.widgets import (PyDMEnumComboBox, PyDMImageView, PyDMLabel,
 from pydm.widgets.base import PyDMWidget
 from pydm.widgets.channel import PyDMChannel
 
+from .utils import find_parent_with_class
+
 logger = logging.getLogger(__name__)
 
 EXPONENTIAL_UNITS = ['mtorr', 'torr', 'kpa', 'pa']
@@ -382,7 +384,7 @@ class SignalDialogButton(QPushButton):
     """QPushButton to launch a QDialog with a PyDMWidget"""
     text = NotImplemented
     icon = NotImplemented
-    persistent = False
+    parent_widget_class = QtWidgets.QWidget
 
     def __init__(self, init_channel, text=None, icon=None, parent=None):
         self.text = text or self.text
@@ -403,7 +405,7 @@ class SignalDialogButton(QPushButton):
         if not self.dialog:
             logger.debug("Creating QDialog for %r", self.channel)
             # Set up the QDialog
-            parent = None if self.persistent else self
+            parent = find_parent_with_class(self, self.parent_widget_class)
             self.dialog = QDialog(parent)
             self.dialog.setWindowTitle(self.channel)
             self.dialog.setLayout(QVBoxLayout())
@@ -424,7 +426,7 @@ class ImageDialogButton(SignalDialogButton):
     """QPushButton to show a 2-d array"""
     text = 'Show Image'
     icon = 'fa.camera'
-    persistent = True
+    parent_widget_class = QtWidgets.QMainWindow
 
     def widget(self):
         """Create PyDMImageView"""
@@ -436,7 +438,7 @@ class WaveformDialogButton(SignalDialogButton):
     """QPushButton to show a 1-d array"""
     text = 'Show Waveform'
     icon = 'fa5s.chart-line'
-    persistent = True
+    parent_widget_class = QtWidgets.QMainWindow
 
     def widget(self):
         """Create PyDMWaveformPlot"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add a class attribute `persistent` to `SignalDialogButton` allowing us to configure wether or not the dialog generated to display the widget will be available even if the parent is destroyed or not.

## Motivation and Context
This change allow us to have images and plots as standalone dialogs even if we change the layout or if we close the current screen for a device.
That is useful when performing diverse operations.

## How Has This Been Tested?
Locally.

## Where Has This Been Documented?
N/A

## Screenshots (if appropriate):
![persistent](https://user-images.githubusercontent.com/8185425/80265725-5da63980-864d-11ea-9c80-23a6b67d4529.gif)

