### PR TITLE
Path caching in `find_templates_for_class`

### DIFF
--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -228,7 +228,9 @@ class _GlobalWidgetTypeCache(QtCore.QObject):
 
 
 # The default stale cached_path threshold time, in seconds:
-TYPHOS_PATH_CACHE_TIME = int(os.environ.get('TYPHOS_PATH_CACHE_TIME', '600'))
+TYPHOS_DISPLAY_PATH_CACHE_TIME = int(
+    os.environ.get('TYPHOS_DISPLAY_PATH_CACHE_TIME', '600')
+)
 
 
 class _CachedPath:
@@ -253,7 +255,8 @@ class _CachedPath:
         happens on the next glob, and not on a timer-basis.
     """
 
-    def __init__(self, path, *, stale_threshold=TYPHOS_PATH_CACHE_TIME):
+    def __init__(self, path, *,
+                 stale_threshold=TYPHOS_DISPLAY_PATH_CACHE_TIME):
         self.path = pathlib.Path(path)
         self.cache = None
         self._update_time = None
@@ -334,6 +337,7 @@ class _GlobalDisplayPathCache:
             The path to add.
         """
         path = pathlib.Path(path).expanduser().resolve()
-        path = _CachedPath(path, stale_threshold=TYPHOS_PATH_CACHE_TIME)
+        path = _CachedPath(
+            path, stale_threshold=TYPHOS_DISPLAY_PATH_CACHE_TIME)
         if path not in self.paths:
             self.paths.append(path)

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -1,8 +1,14 @@
+import fnmatch
 import functools
 import logging
-import ophyd
+import os
+import pathlib
+import re
+import time
 
 from qtpy import QtCore
+
+import ophyd
 
 from . import utils
 from .widgets import SignalWidgetInfo
@@ -14,6 +20,7 @@ logger = logging.getLogger(__name__)
 # `get_global_describe_cache()` and `get_global_widget_type_cache()` below.
 _GLOBAL_WIDGET_TYPE_CACHE = None
 _GLOBAL_DESCRIBE_CACHE = None
+_GLOBAL_PATH_CACHE = None
 
 
 def get_global_describe_cache():
@@ -30,6 +37,14 @@ def get_global_widget_type_cache():
     if _GLOBAL_WIDGET_TYPE_CACHE is None:
         _GLOBAL_WIDGET_TYPE_CACHE = _GlobalWidgetTypeCache()
     return _GLOBAL_WIDGET_TYPE_CACHE
+
+
+def get_global_path_cache():
+    """Get the _GlobalDisplayPathCache singleton."""
+    global _GLOBAL_PATH_CACHE
+    if _GLOBAL_PATH_CACHE is None:
+        _GLOBAL_PATH_CACHE = _GlobalDisplayPathCache()
+    return _GLOBAL_PATH_CACHE
 
 
 class _GlobalDescribeCache(QtCore.QObject):
@@ -210,3 +225,112 @@ class _GlobalWidgetTypeCache(QtCore.QObject):
             if desc is not None:
                 # In certain scenarios (such as testing) this might happen
                 self._new_description(obj, desc)
+
+
+# The default stale cached_path threshold time, in seconds:
+TYPHOS_PATH_CACHE_TIME = int(os.environ.get('TYPHOS_PATH_CACHE_TIME', '600'))
+
+
+class _CachedPath:
+    """
+    A wrapper around pathlib.Path to support repeated globbing
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        The path to cache
+
+    Attributes
+    ----------
+    path : pathlib.Path
+        The underlying path
+    cache : list
+        The cache of filenames
+    _update_time : float
+        The last time the cache was updated
+    stale_threshold : float, optional
+        The time (in seconds) after which to update the path cache.  This
+        happens on the next glob, and not on a timer-basis.
+    """
+
+    def __init__(self, path, *, stale_threshold=TYPHOS_PATH_CACHE_TIME):
+        self.path = pathlib.Path(path)
+        self.cache = None
+        self._update_time = None
+        self.stale_threshold = stale_threshold
+
+    @classmethod
+    def from_path(cls, path, **kwargs):
+        """
+        Get a cached path, if not already cached.
+
+        Parameters
+        ----------
+        path : :class:`pathlib.Path` or :class:`_CachedPath`
+            The paths to cache, if not already cached.
+        """
+        if isinstance(path, (cls, _GlobalDisplayPathCache)):
+            # Already a _CachedPath
+            return path
+        return cls(path, **kwargs)
+
+    def __hash__(self):
+        # Keep the hash the same as the internal path for set()/dict() usage
+        return hash(self.path)
+
+    @property
+    def time_since_last_update(self):
+        """Time (in seconds) since the last update."""
+        if self._update_time is None:
+            return 0
+        return time.monotonic() - self._update_time
+
+    def update(self):
+        """Update the file list"""
+        self.cache = os.listdir(self.path)
+        self._update_time = time.monotonic()
+
+    def glob(self, pattern):
+        """Glob a pattern"""
+        if self.cache is None:
+            self.update()
+        elif self.time_since_last_update > self.stale_threshold:
+            self.update()
+
+        if any(c in pattern for c in '*?['):
+            # Convert from glob syntax -> regular expression
+            # And compile it for repeated usage.
+            regex = re.compile(fnmatch.translate(pattern))
+            for path in self.cache:
+                if regex.match(path):
+                    yield self.path / path
+        else:
+            # No globbing syntax: only check if file is in the list
+            if pattern in self.cache:
+                yield self.path / pattern
+
+
+class _GlobalDisplayPathCache:
+    """
+    A cache for all configured display paths
+    """
+
+    def __init__(self):
+        self.paths = []
+        self._update_times = {}
+        for path in utils.DISPLAY_PATHS:
+            self.add_path(path)
+
+    def clear(self):
+        self.paths.clear()
+
+    def add_path(self, path):
+        path = pathlib.Path(path).expanduser().resolve()
+        path = _CachedPath(path, stale_threshold=TYPHOS_PATH_CACHE_TIME)
+        if path not in self.paths:
+            self.paths.append(path)
+
+    def glob(self, pattern):
+        """Glob a pattern in all cached directories."""
+        for path in self.paths:
+            yield from path.glob(pattern)

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -337,8 +337,3 @@ class _GlobalDisplayPathCache:
         path = _CachedPath(path, stale_threshold=TYPHOS_PATH_CACHE_TIME)
         if path not in self.paths:
             self.paths.append(path)
-
-    def glob(self, pattern):
-        """Glob a pattern in all cached directories."""
-        for path in self.paths:
-            yield from path.glob(pattern)

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # `get_global_describe_cache()` and `get_global_widget_type_cache()` below.
 _GLOBAL_WIDGET_TYPE_CACHE = None
 _GLOBAL_DESCRIBE_CACHE = None
-_GLOBAL_PATH_CACHE = None
+_GLOBAL_DISPLAY_PATH_CACHE = None
 
 
 def get_global_describe_cache():
@@ -39,12 +39,12 @@ def get_global_widget_type_cache():
     return _GLOBAL_WIDGET_TYPE_CACHE
 
 
-def get_global_path_cache():
+def get_global_display_path_cache():
     """Get the _GlobalDisplayPathCache singleton."""
-    global _GLOBAL_PATH_CACHE
-    if _GLOBAL_PATH_CACHE is None:
-        _GLOBAL_PATH_CACHE = _GlobalDisplayPathCache()
-    return _GLOBAL_PATH_CACHE
+    global _GLOBAL_DISPLAY_PATH_CACHE
+    if _GLOBAL_DISPLAY_PATH_CACHE is None:
+        _GLOBAL_DISPLAY_PATH_CACHE = _GlobalDisplayPathCache()
+    return _GLOBAL_DISPLAY_PATH_CACHE
 
 
 class _GlobalDescribeCache(QtCore.QObject):
@@ -312,19 +312,27 @@ class _CachedPath:
 
 class _GlobalDisplayPathCache:
     """
-    A cache for all configured display paths
+    A cache for all configured display paths.
+
+    All paths from `utils.DISPLAY_PATHS` will be included:
+        1. Environment variable ``PYDM_DISPLAYS_PATH``
+        2. Typhos package built-in paths
     """
 
     def __init__(self):
         self.paths = []
-        self._update_times = {}
         for path in utils.DISPLAY_PATHS:
             self.add_path(path)
 
-    def clear(self):
-        self.paths.clear()
-
     def add_path(self, path):
+        """
+        Add a path to be searched during ``glob``.
+
+        Parameters
+        ----------
+        path : pathlib.Path or str
+            The path to add.
+        """
         path = pathlib.Path(path).expanduser().resolve()
         path = _CachedPath(path, stale_threshold=TYPHOS_PATH_CACHE_TIME)
         if path not in self.paths:

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -782,7 +782,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
     @staticmethod
     def _get_templates_from_macros(macros):
         ret = {}
-        paths = [cache.get_global_display_path_cache()]
+        paths = cache.get_global_display_path_cache().paths
         for display_type in DisplayTypes.names:
             ret[display_type] = None
             try:
@@ -901,7 +901,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         logger.debug('Searching for templates for %s', cls.__name__)
         macro_templates = self._get_templates_from_macros(self._macros)
 
-        paths = [cache.get_global_display_path_cache()]
+        paths = cache.get_global_display_path_cache().paths
         for display_type in DisplayTypes.names:
             view = display_type
             if view.endswith('_screen'):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -782,7 +782,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
     @staticmethod
     def _get_templates_from_macros(macros):
         ret = {}
-        paths = [cache.get_global_path_cache()]
+        paths = [cache.get_global_display_path_cache()]
         for display_type in DisplayTypes.names:
             ret[display_type] = None
             try:
@@ -901,7 +901,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         logger.debug('Searching for templates for %s', cls.__name__)
         macro_templates = self._get_templates_from_macros(self._macros)
 
-        paths = [cache.get_global_path_cache()]
+        paths = [cache.get_global_display_path_cache()]
         for display_type in DisplayTypes.names:
             view = display_type
             if view.endswith('_screen'):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -13,6 +13,7 @@ import pydm.display
 import pydm.exception
 import pydm.utilities
 
+from . import cache
 from . import panel as typhos_panel
 from . import utils, widgets
 
@@ -781,6 +782,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
     @staticmethod
     def _get_templates_from_macros(macros):
         ret = {}
+        paths = [cache.get_global_path_cache()]
         for display_type in DisplayTypes.names:
             ret[display_type] = None
             try:
@@ -796,7 +798,8 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                     logger.debug('Invalid path specified in macro: %s=%s',
                                  display_type, value, exc_info=ex)
                 else:
-                    ret[display_type] = list(utils.find_file_in_paths(value))
+                    ret[display_type] = list(utils.find_file_in_paths(
+                        value, paths=paths))
 
         return ret
 
@@ -898,7 +901,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         logger.debug('Searching for templates for %s', cls.__name__)
         macro_templates = self._get_templates_from_macros(self._macros)
 
-        paths = [utils._CachedPath(p) for p in utils.DISPLAY_PATHS]
+        paths = [cache.get_global_path_cache()]
         for display_type in DisplayTypes.names:
             view = display_type
             if view.endswith('_screen'):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -898,6 +898,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         logger.debug('Searching for templates for %s', cls.__name__)
         macro_templates = self._get_templates_from_macros(self._macros)
 
+        paths = [utils._CachedPath(p) for p in utils.DISPLAY_PATHS]
         for display_type in DisplayTypes.names:
             view = display_type
             if view.endswith('_screen'):
@@ -918,8 +919,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                     template_list.append(DETAILED_TREE_TEMPLATE)
 
             # 3. Templates based on class hierarchy names
-            filenames = utils.find_templates_for_class(
-                cls, view, utils.DISPLAY_PATHS)
+            filenames = utils.find_templates_for_class(cls, view, paths)
             for filename in filenames:
                 if filename not in template_list:
                     template_list.append(filename)

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -476,8 +476,9 @@ class _CachedPath:
         if self.cache is None:
             self.update()
 
+        regex = re.compile(fnmatch.translate(pattern))
         for path in self.cache:
-            if fnmatch.fnmatch(path, pattern):
+            if regex.match(path):
                 yield self.path / path
 
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -474,7 +474,7 @@ class _CachedPath:
     def glob(self, pattern):
         """Glob a pattern"""
         if self.cache is None:
-            self.update_cache()
+            self.update()
 
         for path in self.cache:
             if fnmatch.fnmatch(path.name, pattern):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -476,10 +476,14 @@ class _CachedPath:
         if self.cache is None:
             self.update()
 
-        regex = re.compile(fnmatch.translate(pattern))
-        for path in self.cache:
-            if regex.match(path):
-                yield self.path / path
+        if any(c in pattern for c in '*?['):
+            regex = re.compile(fnmatch.translate(pattern))
+            for path in self.cache:
+                if regex.match(path):
+                    yield self.path / path
+        else:
+            if pattern in self.cache:
+                yield self.path / pattern
 
 
 def is_standard_template(template):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -44,7 +44,7 @@ def _get_display_paths():
     'Get all display paths based on PYDM_DISPLAY_PATHS + typhos built-ins'
     paths = os.environ.get('PYDM_DISPLAYS_PATH', '')
     for path in paths.split(os.pathsep):
-        path = pathlib.Path(path).resolve()
+        path = pathlib.Path(path).expanduser().resolve()
         if path.exists() and path.is_dir():
             yield path
     yield ui_dir
@@ -530,11 +530,12 @@ def find_templates_for_class(cls, view_type, paths, *, extensions=None,
     elif isinstance(extensions, str):
         extensions = [extensions]
 
-    paths = remove_duplicate_items(
-        [pathlib.Path(p).expanduser().resolve() for p in paths]
-    )
+    if not isinstance(paths[0], _CachedPath):
+        paths = remove_duplicate_items(
+            [pathlib.Path(p).expanduser().resolve() for p in paths]
+        )
 
-    paths = [_CachedPath(p) for p in paths]
+        paths = [_CachedPath(p) for p in paths]
 
     for candidate_filename in _get_template_filenames_for_class(
             cls, view_type, include_mro=include_mro):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -40,7 +40,7 @@ if happi is None:
 
 
 def _get_display_paths():
-    'Get all display paths based on PYDM_DISPLAY_PATHS + typhos built-ins'
+    """Get all display paths based on PYDM_DISPLAYS_PATH + typhos built-ins."""
     paths = os.environ.get('PYDM_DISPLAYS_PATH', '')
     for path in paths.split(os.pathsep):
         path = pathlib.Path(path).expanduser().resolve()

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -469,7 +469,7 @@ class _CachedPath:
 
     def update(self):
         """Update the file list"""
-        self.cache = list(self.path.iterdir())
+        self.cache = os.listdir(self.path)
 
     def glob(self, pattern):
         """Glob a pattern"""
@@ -477,8 +477,8 @@ class _CachedPath:
             self.update()
 
         for path in self.cache:
-            if fnmatch.fnmatch(path.name, pattern):
-                yield path
+            if fnmatch.fnmatch(path, pattern):
+                yield self.path / path
 
 
 def is_standard_template(template):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -493,13 +493,10 @@ def find_templates_for_class(cls, view_type, paths, *, extensions=None,
     elif isinstance(extensions, str):
         extensions = [extensions]
 
-    if len(paths) > 1:
-        paths = remove_duplicate_items(
-            [pathlib.Path(p) for p in paths]
-        )
-
     from .cache import _CachedPath
-    paths = [_CachedPath.from_path(p) for p in paths]
+    paths = remove_duplicate_items(
+        [_CachedPath.from_path(p) for p in paths]
+    )
 
     for candidate_filename in _get_template_filenames_for_class(
             cls, view_type, include_mro=include_mro):
@@ -536,13 +533,10 @@ def find_file_in_paths(filename, *, paths=None):
 
         filename = filename.name
 
-    if len(paths) > 1:
-        paths = remove_duplicate_items(
-            [pathlib.Path(p) for p in paths]
-        )
-
     from .cache import _CachedPath
-    paths = [_CachedPath.from_path(p) for p in paths]
+    paths = remove_duplicate_items(
+        [_CachedPath.from_path(p) for p in paths]
+    )
 
     for path in paths:
         for match in path.glob(filename):


### PR DESCRIPTION
master baseline on NFS: 

```
In [1]: %timeit list(typhos.utils.find_templates_for_class(ophyd.EpicsMotor, 'embedded', paths=typhos.utils.DISPLAY_PATHS))
2.93 ms ± 12.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

This PR:

```
In [2]: %timeit list(typhos.utils.find_templates_for_class(ophyd.EpicsMotor, 'embedded', paths=typhos.utils.DISPLAY_PATHS))
1.08 ms ± 15.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

This is called 3x per display, and each call time scales linearly with `len(cls.mro())`

So assuming 200 devices, baseline should be 200 * 3 * 3ms = 1.8sec
With this, 200 * 3 * 1ms = 0.6s
Moving the caching up a level as in 18dbeb5, should reduce this by ~3

Not sure it's worth the complexity just yet

Alternatives
-------------
* LRU cache (builtin) - and a custom time-to-live / stale threshold https://docs.python.org/3/library/functools.html#functools.lru_cache
* 3rd party library https://cachetools.readthedocs.io/en/stable/