### PR TITLE
WIP: Hide empty panels option.

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1,4 +1,5 @@
 import enum
+import functools
 import logging
 import os.path
 import pathlib
@@ -173,6 +174,26 @@ class TyphosDisplayConfigButton(TyphosToolButton):
         action.setDefaultWidget(line_edit)
         base_menu.addAction(action)
 
+    def create_hide_empty_panels_menu(self, panels, base_menu):
+        """
+        Create the hide empty panels menu
+
+        Parameters
+        ----------
+        base_menu : QMenu
+            The menu to add actions to
+        """
+        action = base_menu.addAction("Hide empty panels")
+        action.setCheckable(True)
+        action.setChecked(all(panel.hide_empty for panel in panels))
+        action.triggered.connect(
+            functools.partial(self._hide_empty_panels, panels)
+        )
+
+    def _hide_empty_panels(self, panels, checked):
+        for panel in panels:
+            panel.hide_empty = checked
+
     def generate_context_menu(self):
         """
         Generates the custom context menu
@@ -186,6 +207,7 @@ class TyphosDisplayConfigButton(TyphosToolButton):
         Kind filter > Show hinted
                       ...
                       Show only hinted
+        Hide empty panels
         Filter by name
         """
         base_menu = QtWidgets.QMenu(parent=self)
@@ -204,6 +226,8 @@ class TyphosDisplayConfigButton(TyphosToolButton):
         self.create_kind_filter_menu(panels, filter_menu, only=False)
         filter_menu.addSeparator()
         self.create_kind_filter_menu(panels, filter_menu, only=True)
+
+        self.create_hide_empty_panels_menu(panels, base_menu)
 
         base_menu.addSeparator()
         self.create_name_filter_menu(panels, base_menu)

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -523,7 +523,6 @@ class TyphosSignalPanel(TyphosBase, TyphosDesignerMixin, SignalOrder):
             order=self._signal_order,
         )
 
-
         hide = self.hide_empty and self._panel_layout.active_row_count == 0
         logger.debug(f'Update Panel {self} -> hide_empty: {self.hide_empty} '
                      f'| arc -> {self._panel_layout.active_row_count} '


### PR DESCRIPTION
## Description
Provide option to hide empty panels.
Closes #278 

## Motivation and Context
Discussion at PR #278 

## How Has This Been Tested?
Locally


This almost works for all cases... I am now having an issue with a situation in which `TyphosDeviceDisplay` is always visible if it was more `TyphosDeviceDisplay` in it.
I need some help to understand how to deal with this situation.