### PR TITLE
FIX: Prime signal value before describe.

### DIFF
--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -73,6 +73,8 @@ class _GlobalDescribeCache(QtCore.QObject):
             # Force initial value readout otherwise _readback was never
             # set and that causes issues with more complex describe
             # types such as DerivedSignal and NDDerivedSignal.
+            # TODO: This is a temporary fix and must be removed once
+            #       https://github.com/bluesky/ophyd/pull/858 is merged
             obj.get()
             return obj.describe()[obj.name]
         except Exception:

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -70,6 +70,10 @@ class _GlobalDescribeCache(QtCore.QObject):
     def _describe(self, obj):
         """Retrieve the description of ``obj``."""
         try:
+            # Force initial value readout otherwise _readback was never
+            # set and that causes issues with more complex describe
+            # types such as DerivedSignal and NDDerivedSignal.
+            obj.get()
             return obj.describe()[obj.name]
         except Exception:
             logger.error("Unable to connect to %r during widget creation",

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import ophyd
 
 from qtpy import QtCore
 
@@ -70,12 +71,13 @@ class _GlobalDescribeCache(QtCore.QObject):
     def _describe(self, obj):
         """Retrieve the description of ``obj``."""
         try:
-            # Force initial value readout otherwise _readback was never
-            # set and that causes issues with more complex describe
-            # types such as DerivedSignal and NDDerivedSignal.
-            # TODO: This is a temporary fix and must be removed once
-            #       https://github.com/bluesky/ophyd/pull/858 is merged
-            obj.get()
+            if isinstance(obj, ophyd.NDDerivedSignal):
+                # Force initial value readout otherwise _readback was never
+                # set and that causes issues with more complex describe
+                # types such as DerivedSignal and NDDerivedSignal.
+                # TODO: This is a temporary fix and must be removed once
+                #       https://github.com/bluesky/ophyd/pull/858 is merged
+                obj.get()
             return obj.describe()[obj.name]
         except Exception:
             logger.error("Unable to connect to %r during widget creation",


### PR DESCRIPTION
Maybe not the best solution but a solution so far...
Closes #288 

## Description
While debugging this issue I noticed that if a value never arrived and describe is called at a signal it may report the wrong information which is what happened with the Image Button.

This fix calls get to force a prime of the value at the signal. I am not sure yet if there is a better way to address this issue. I will look into it for a bit to try and identify if the value callback was executed at least once so we can avoid this "HACK".

## Motivation and Context
Fix the issue #288.

## How Has This Been Tested?
Locally tested with IOC.

## Where Has This Been Documented?
N/A

## Screenshots (if appropriate):
Before the fix:
![image](https://user-images.githubusercontent.com/8185425/81016350-179f6180-8e15-11ea-8f39-ce064c2920d3.png)

After proposed fix:
![image](https://user-images.githubusercontent.com/8185425/81016273-f6d70c00-8e14-11ea-816c-e67696a73aa4.png)

