### PR TITLE
User config-stored sqlite `obj.describe()` cache

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -87,3 +87,6 @@ def test_persistent_cache(qtbot, describe_cache, persistent_cache, sig):
     qtbot.wait_until(check_saved)
     assert persistent_cache[sig] == persistent_cache.get(sig)
     assert len(persistent_cache) == 1
+
+    persistent_cache.clear()
+    assert len(persistent_cache) == 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -74,9 +74,16 @@ def test_persistent_cache(qtbot, describe_cache, persistent_cache, sig):
     with qtbot.wait_signal(describe_cache.new_description):
         assert describe_cache.get(sig) is None
 
-    # obj, desc = block.args
+    expected_desc = describe_cache.get(sig)
 
     def check_saved():
-        assert persistent_cache.get(sig) == describe_cache.get(sig)
+        persistent_desc = {
+            key: value for key, value in persistent_cache.get(sig).items()
+            if key in expected_desc
+        }
+        assert len(persistent_desc)
+        assert persistent_desc == expected_desc
 
     qtbot.wait_until(check_saved)
+    assert persistent_cache[sig] == persistent_cache.get(sig)
+    assert len(persistent_cache) == 1

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,82 @@
+import random
+
+import pytest
+
+import ophyd
+import typhos.cache
+
+
+@pytest.fixture(scope='function')
+def describe_cache():
+    cache = typhos.cache.get_global_describe_cache()
+    cache.clear()
+
+    # Make sure we aren't talking to the real persistent cache:
+    cache.persistent_cache = {}
+
+    yield cache
+    cache.clear()
+
+
+@pytest.fixture(scope='function')
+def type_cache(describe_cache):
+    cache = typhos.cache.get_global_widget_type_cache()
+    cache.clear()
+    yield cache
+    cache.clear()
+
+
+@pytest.fixture(scope='function')
+def persistent_cache(describe_cache):
+    persistent_cache = typhos.cache._DescribeDatabase(':memory:')
+
+    # Link the caches in both directions.
+    # describe cache falls back to disk cache:
+    describe_cache.persistent_cache = persistent_cache
+
+    # new description -> written to database
+    persistent_cache.describe_cache = describe_cache
+    yield persistent_cache
+
+
+@pytest.fixture(scope='function')
+def sig():
+    name = 'test{}'.format(random.randint(0, 10000))
+    sig = ophyd.Signal(name=name)
+    yield sig
+    sig.destroy()
+
+
+def test_describe_cache_signal(qtbot, describe_cache, sig):
+    # Check that `new_description` is emitted with the correct args:
+    with qtbot.wait_signal(describe_cache.new_description) as block:
+        assert describe_cache.get(sig) is None
+
+    assert block.args == [sig, sig.describe()[sig.name]]
+
+    # And the description is now readily available:
+    assert describe_cache.get(sig) == sig.describe()[sig.name]
+
+    # And that clearing the cache works:
+    describe_cache.clear()
+    assert describe_cache.get(sig) is None
+
+
+def test_widget_type_signal(qtbot, type_cache, sig):
+    with qtbot.wait_signal(type_cache.widgets_determined) as block:
+        assert type_cache.get(sig) is None
+
+    assert block.args[0] is sig
+    assert type_cache.get(sig) is block.args[1]
+
+
+def test_persistent_cache(qtbot, describe_cache, persistent_cache, sig):
+    with qtbot.wait_signal(describe_cache.new_description):
+        assert describe_cache.get(sig) is None
+
+    # obj, desc = block.args
+
+    def check_saved():
+        assert persistent_cache.get(sig) == describe_cache.get(sig)
+
+    qtbot.wait_until(check_saved)

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -35,7 +35,9 @@ def get_global_describe_cache():
         db_path = get_describe_database_path()
         persistent_cache = _DescribeDatabase() if db_path else None
         _GLOBAL_DESCRIBE_CACHE = _GlobalDescribeCache(persistent_cache)
-        persistent_cache.describe_cache = _GLOBAL_DESCRIBE_CACHE
+        if persistent_cache is not None:
+            # Hook the persistent cache up to the global describe cache:
+            persistent_cache.describe_cache = _GLOBAL_DESCRIBE_CACHE
 
     return _GLOBAL_DESCRIBE_CACHE
 

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -516,7 +516,7 @@ class _DescribeDatabase(collections.abc.Mapping):
         t0 = time.time()
         self._preload()
         elapsed = time.time() - t0
-        self.log.info('Took %d ms to preload the cache', int(elapsed * 1000))
+        self.log.debug('Took %d ms to preload the cache', int(elapsed * 1000))
 
     def _preload(self):
         """Pre-load all entries from the database."""

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -3,7 +3,6 @@ import collections.abc
 import fnmatch
 import functools
 import logging
-import ophyd
 import os
 import pathlib
 import re

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -185,15 +185,14 @@ class _GlobalDescribeCache(QtCore.QObject):
         try:
             return self.cache[obj]
         except KeyError:
+            # Add the object, waiting for a connection update to call describe
+            self.connect_thread.add_object(obj)
             desc = self.persistent_cache.get(obj)
+
             if desc is not None:
                 self.cache[obj] = desc
                 self.new_description.emit(obj, desc)
                 return desc
-
-            # Add the object, waiting for a connection update to determine
-            # widget types
-            self.connect_thread.add_object(obj)
 
 
 class _GlobalWidgetTypeCache(QtCore.QObject):

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -418,7 +418,10 @@ class _DescribeDatabase(QtCore.QObject):
         str: 'text',
     }
 
-    _table_name = 'describe_cache'
+    # NOTE: If the above schema changes, the version encoded in the table name
+    # should be bumped (or the db should be wiped entirely)
+    _version = 0
+    _table_name = f'describe_cache_v{_version}'
 
     def __init__(self):
         super().__init__()

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -559,6 +559,11 @@ class _DescribeDatabase(collections.abc.Mapping):
 
     def clear(self):
         """Clear the cache."""
+        self._con.execute(f'drop table {self._table_name}')
+        self._con.commit()
+        self._con.close()
+
+        self._init_database(self.path)
 
     def _row_to_key(self, row):
         """

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -185,7 +185,6 @@ class _GlobalDescribeCache(QtCore.QObject):
         try:
             return self.cache[obj]
         except KeyError:
-            print('persistent cache fallback', obj.name, self.persistent_cache)
             desc = self.persistent_cache.get(obj)
             if desc is not None:
                 self.cache[obj] = desc

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -521,7 +521,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
     def __init__(self, parent=None, *, scrollable=True,
                  composite_heuristics=True, embedded_templates=None,
                  detailed_templates=None, engineering_templates=None,
-                 display_type='detailed_screen', **kwargs):
+                 display_type='detailed_screen', nested=False, **kwargs):
 
         self._composite_heuristics = composite_heuristics
         self._current_template = None
@@ -531,6 +531,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         self._scrollable = False
         self._searched = False
         self._hide_empty = False
+        self._nested = nested
 
         self.templates = {name: [] for name in DisplayTypes.names}
         self._display_type = normalize_display_type(display_type)
@@ -1046,6 +1047,14 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
     def _tx(self, value):
         """Receive information from happi channel"""
         self.add_device(value['obj'], macros=value['md'])
+
+    def __repr__(self):
+        return (
+            f'<{self.__class__.__name__} at {hex(id(self))} '
+            f'device={self.device_class}[{self.device_name!r}] '
+            f'nested={self._nested}'
+            f'>'
+        )
 
 
 def toggle_display(widget, force_state=None):

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -641,7 +641,8 @@ class CompositeSignalPanel(SignalPanel):
         logger.debug('%s adding sub-device: %s (%s)', self.__class__.__name__,
                      device.name, device.__class__.__name__)
         container = display.TyphosDeviceDisplay(name=name, scrollable=False,
-                                                composite_heuristics=True)
+                                                composite_heuristics=True,
+                                                nested=True)
         self._containers[name] = container
         self.add_row(container)
         container.add_device(device)

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -681,7 +681,12 @@ def subscription_context(*objects, callback, event_type=None, run=True):
         yield dict(obj_to_cid)
     finally:
         for obj, cid in obj_to_cid.items():
-            obj.unsubscribe(cid)
+            try:
+                obj.unsubscribe(cid)
+            except KeyError:
+                # It's possible that when the object is being torn down, or
+                # destroyed that this has already been done.
+                ...
 
 
 def get_all_signals_from_device(device, include_lazy=False, filter_by=None):
@@ -799,7 +804,12 @@ class _ConnectionStatus:
 
             self.objects.remove(obj)
             cid = self.obj_to_cid.pop(obj)
-            obj.unsubscribe(cid)
+            try:
+                obj.unsubscribe(cid)
+            except KeyError:
+                # It's possible that when the object is being torn down, or
+                # destroyed that this has already been done.
+                ...
 
     def _connection_callback(self, *, obj, connected, **kwargs):
         with self.lock:

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -9,6 +9,7 @@ import io
 import logging
 import os
 import pathlib
+import platform
 import random
 import re
 import threading
@@ -1060,3 +1061,30 @@ def dump_grid_layout(layout, rows=None, cols=None, *, cell_width=60):
 
         print(separator, file=file)
         return file.getvalue()
+
+
+def get_config_path():
+    """Get the typhos configuration path."""
+    if platform.system().lower() == 'windows':
+        path = os.getenv('APPDATA') or '~'
+    elif platform.system().lower() == 'darwin':
+        path = pathlib.Path('~') / 'Library' / 'Caches'
+    else:
+        path = os.getenv('XDG_CACHE_HOME') or '~/.cache'
+
+    # Allow TYPHOS_CONFIG_PATH to override the above operating system-specific
+    # entries:
+    path = os.environ.get('TYPHOS_CONFIG_PATH', path / 'typhos')
+
+    # Expand and fully resolve the path:
+    path = pathlib.Path(path).expanduser().resolve()
+
+    # And create it if necessary:
+    if not path.exists():
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            logger.exception('Failed to create the typhos config path')
+            return None
+
+    return path

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -1075,16 +1075,19 @@ def dump_grid_layout(layout, rows=None, cols=None, *, cell_width=60):
 
 def get_config_path():
     """Get the typhos configuration path."""
-    if platform.system().lower() == 'windows':
+    system = platform.system().lower()
+    if system == 'windows':
         path = os.getenv('APPDATA') or '~'
-    elif platform.system().lower() == 'darwin':
-        path = pathlib.Path('~') / 'Library' / 'Caches'
-    else:
+    elif system == 'darwin':
+        path = '~/Library/Caches'
+    else:  # posix
         path = os.getenv('XDG_CACHE_HOME') or '~/.cache'
+
+    default_path = pathlib.Path(path) / 'typhos'
 
     # Allow TYPHOS_CONFIG_PATH to override the above operating system-specific
     # entries:
-    path = os.environ.get('TYPHOS_CONFIG_PATH', path / 'typhos')
+    path = os.environ.get('TYPHOS_CONFIG_PATH', default_path)
 
     # Expand and fully resolve the path:
     path = pathlib.Path(path).expanduser().resolve()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Adds `utils.get_config_path` for getting a valid configuration path for the 3 main platforms
    - This can be overridden by the environment variable `TYPHOS_CONFIG_PATH`
* Adds `cache._DescribeDatabase`, an sqlite3-backed database for storing ophyd object descriptions.
    - Path defaults to `$TYPHOS_CONFIG_PATH/typhos_describe.sqlite`
    - This can be overridden by env variable `$TYPHOS_DATABASE_PATH`
    - `TYPHOS_DATABASE_PATH` may be `:memory:`, should issues arise
* `cache._DescribeDatabase` and `cache._GlobalDescribeCache` are loosely tied together
   - A single Qt signal connects the in-memory cache to the persistent cache
   - A single attribute in the in-memory cache queries the persistent cache

## Motivation and Context
With a persistent cache, the backing control system does not need to be running for the correct widgets to be created with typhos.

First pass at (but does not close) #285 

## How Has This Been Tested?
Locally and with a couple unit tests, provided.

Note: *This _must_ be tested for viability on NFS prior to potential merging.*

## Where Has This Been Documented?
Docstrings, so far

## TODO
- [ ] Do not cache fake signals
- [x] More explicit option to disable this caching, or is `:memory:` above sufficient?