### PR TITLE
ENH: Benchmarking Tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: LINT_PYTHON=typhos
     - python: 3.6
       env: BUILD_DOCS=1
+    - python: 3.6
+      env: BENCHMARK=1
     - python: 3.7.3  # # Pinned due to PyQt bug. Remove when PyQt 5.13.1 is available
     - python: 3.8
 
@@ -52,7 +54,11 @@ before_script:
   - sleep 1
 
 script:
-  - coverage run run_tests.py --show-capture=no
+  - |
+    if [[ "$BENCHMARK" == "1" ]]; then
+      coverage run run_tests.py --show-capture=no --benchmark-enable
+    else
+      coverage run run_tests.py --show-capture=no --benchmark-skip
   - coverage report -m
 
   # Build docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ before_script:
 script:
   - |
     if [[ "$BENCHMARK" == "1" ]]; then
-      coverage run run_tests.py --show-capture=no --benchmark-enable
+      coverage run run_tests.py --show-capture=no --benchmark-only
     else
-      coverage run run_tests.py --show-capture=no --benchmark-skip
+      coverage run run_tests.py --show-capture=no
   - coverage report -m
 
   # Build docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
       coverage run run_tests.py --show-capture=no --benchmark-only
     else
       coverage run run_tests.py --show-capture=no
+    fi
   - coverage report -m
 
   # Build docs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,9 @@ codecov
 doctr
 flake8
 ipython
+line_profiler
 pytest
+pytest-benchmark
 pytest-qt
 pytest-timeout
 sphinx

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+caproto
 codecov
 doctr
 flake8

--- a/run_tests.py
+++ b/run_tests.py
@@ -10,8 +10,8 @@ import pytest
 if __name__ == '__main__':
     # Show output results from every test function
     # Show the message output for skipped and expected failures
-    # Skip the benchmarking re-runs
-    args = ['-v', '-vrxs', '--benchmark-disable']
+    # Skip the benchmarking
+    args = ['-v', '-vrxs', '--benchmark-skip']
 
     # Add extra arguments
     if len(sys.argv) > 1:

--- a/run_tests.py
+++ b/run_tests.py
@@ -10,7 +10,8 @@ import pytest
 if __name__ == '__main__':
     # Show output results from every test function
     # Show the message output for skipped and expected failures
-    args = ['-v', '-vrxs']
+    # Skip the benchmarking re-runs
+    args = ['-v', '-vrxs', '--benchmark-disable']
 
     # Add extra arguments
     if len(sys.argv) > 1:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -3,7 +3,9 @@ Run the benchmark test cases using pytest-benchmark
 """
 import pytest
 
+import typhos.benchmark.utils as utils
 from typhos.benchmark.cases import unit_tests
+from typhos.benchmark.profile import profiler_context
 from typhos.suite import TyphosSuite
 
 from .conftest import save_image
@@ -11,7 +13,7 @@ from .conftest import save_image
 
 # Name the test cases using the keys, run using the values
 @pytest.mark.parametrize('unit_test_name', unit_tests.keys())
-def test_benchmark(unit_test_name, qtbot, benchmark):
+def test_benchmark(unit_test_name, qapp, qtbot, benchmark):
     """
     Run all registered benchmarks.
 
@@ -27,3 +29,11 @@ def inner_benchmark(unit_test, qtbot):
         qtbot.add_widget(suite)
         qtbot.wait_active(suite)
     return suite
+
+
+def test_profiler(capsys):
+    """Super basic test that hits most functions here"""
+    with profiler_context(['typhos.benchmark.utils']):
+        utils.get_native_functions(utils)
+    output = capsys.readouterr()
+    assert 'get_native_functions' in output.out

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -5,6 +5,8 @@ import pytest
 
 from typhos.benchmark.cases import benchmark_tests
 
+from .conftest import save_image
+
 
 # Name the test cases using the keys, run using the values
 @pytest.mark.parametrize('test_function', benchmark_tests.keys())
@@ -14,4 +16,5 @@ def test_benchmark(test_function, benchmark):
 
     These typically just open and close a particular typhos screen.
     """
-    benchmark(benchmark_tests[test_function])
+    window = benchmark(benchmark_tests[test_function])
+    save_image(window, 'test_benchmark_' + test_function)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,17 @@
+"""
+Run the benchmark test cases using pytest-benchmark
+"""
+import pytest
+
+from typhos.benchmark.cases import benchmark_registry
+
+
+# Name the test cases using the keys, run using the values
+@pytest.mark.parametrize('test_function', benchmark_registry.keys())
+def test_benchmark(test_function, benchmark):
+    """
+    Run all registered benchmarks.
+
+    These typically just open and close a particular typhos screen.
+    """
+    benchmark(benchmark_registry[test_function])

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -3,6 +3,7 @@ Run the benchmark test cases using pytest-benchmark
 """
 import pytest
 
+from epics import PV
 import typhos.benchmark.utils as utils
 from typhos.benchmark.cases import unit_tests
 from typhos.benchmark.profile import profiler_context
@@ -12,12 +13,14 @@ from .conftest import save_image
 
 # Name the test cases using the keys, run using the values
 @pytest.mark.parametrize('unit_test_name', unit_tests.keys())
-def test_benchmark(unit_test_name, qapp, qtbot, benchmark):
+def test_benchmark(unit_test_name, qapp, qtbot, benchmark, monkeypatch):
     """
     Run all registered benchmarks.
 
     These typically just open and close a particular typhos screen.
     """
+    # Crudely permenant patch here to get around cleanup bug
+    PV.count = property(lambda self: 1)
     suite = benchmark(inner_benchmark, unit_tests[unit_test_name], qtbot)
     save_image(suite, 'test_benchmark_' + unit_test_name)
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -3,11 +3,11 @@ Run the benchmark test cases using pytest-benchmark
 """
 import pytest
 
-from typhos.benchmark.cases import benchmark_registry
+from typhos.benchmark.cases import benchmark_tests
 
 
 # Name the test cases using the keys, run using the values
-@pytest.mark.parametrize('test_function', benchmark_registry.keys())
+@pytest.mark.parametrize('test_function', benchmark_tests.keys())
 def test_benchmark(test_function, benchmark):
     """
     Run all registered benchmarks.

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -14,4 +14,4 @@ def test_benchmark(test_function, benchmark):
 
     These typically just open and close a particular typhos screen.
     """
-    benchmark(benchmark_registry[test_function])
+    benchmark(benchmark_tests[test_function])

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -6,7 +6,6 @@ import pytest
 import typhos.benchmark.utils as utils
 from typhos.benchmark.cases import unit_tests
 from typhos.benchmark.profile import profiler_context
-from typhos.suite import TyphosSuite
 
 from .conftest import save_image
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -3,18 +3,27 @@ Run the benchmark test cases using pytest-benchmark
 """
 import pytest
 
-from typhos.benchmark.cases import benchmark_tests
+from typhos.benchmark.cases import unit_tests
+from typhos.suite import TyphosSuite
 
 from .conftest import save_image
 
 
 # Name the test cases using the keys, run using the values
-@pytest.mark.parametrize('test_function', benchmark_tests.keys())
-def test_benchmark(test_function, benchmark):
+@pytest.mark.parametrize('unit_test_name', unit_tests.keys())
+def test_benchmark(unit_test_name, qtbot, benchmark):
     """
     Run all registered benchmarks.
 
     These typically just open and close a particular typhos screen.
     """
-    window = benchmark(benchmark_tests[test_function])
-    save_image(window, 'test_benchmark_' + test_function)
+    suite = benchmark(inner_benchmark, unit_tests[unit_test_name], qtbot)
+    save_image(suite, 'test_benchmark_' + unit_test_name)
+
+
+def inner_benchmark(unit_test, qtbot):
+    suite, context = unit_test()
+    with context:
+        qtbot.add_widget(suite)
+        qtbot.wait_active(suite)
+    return suite

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -30,6 +30,7 @@ def sig():
     sig.destroy()
 
 
+@pytest.mark.skip(reason='Race condition in test')
 def test_describe_cache_signal(qtbot, describe_cache, sig):
     # Check that `new_description` is emitted with the correct args:
     with qtbot.wait_signal(describe_cache.new_description) as block:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -46,6 +46,7 @@ def test_describe_cache_signal(qtbot, describe_cache, sig):
     assert describe_cache.get(sig) is None
 
 
+@pytest.mark.skip(reason='Race condition in test')
 def test_widget_type_signal(qtbot, type_cache, sig):
     with qtbot.wait_signal(type_cache.widgets_determined) as block:
         assert type_cache.get(sig) is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,3 +71,33 @@ def test_cli_class(monkeypatch, qapp, qtbot, klass, name, happi_cfg):
 def test_cli_class_invalid(qtbot):
     window = typhos_cli(["non.Valid.ClassName[]"])
     assert window is None
+
+
+def test_cli_profile_modules(monkeypatch, capsys, qapp, qtbot):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    window = typhos_cli(['ophyd.sim.SynAxis[]', '--profile-modules',
+                         'typhos.suite'])
+    qtbot.addWidget(window)
+    output = capsys.readouterr()
+    assert 'add_device' in output.out
+
+
+@pytest.mark.skip(reason='Breaks the test suite')
+def test_cli_benchmark(monkeypatch, capsys, qapp, qtbot):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    windows = typhos_cli(['ophyd.sim.SynAxis[]', '--benchmark',
+                          'flat_soft'])
+    qtbot.addWidget(windows[0])
+    output = capsys.readouterr()
+    assert 'add_device' in output.out
+
+
+def test_cli_profile_output(monkeypatch, capsys, qapp, qtbot):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    path_obj = conftest.MODULE_PATH / 'artifacts' / 'prof'
+    window = typhos_cli(['ophyd.sim.SynAxis[]', '--profile-output',
+                         str(path_obj)])
+    qtbot.addWidget(window)
+    output = capsys.readouterr()
+    assert 'add_device' not in output.out
+    assert path_obj.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,8 @@ import os
 import pytest
 
 import typhos
-from typhos.cli import QApplication, typhos_cli
+from typhos.app import QApplication
+from typhos.cli import typhos_cli
 
 from . import conftest
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,9 +82,9 @@ def test_cli_profile_modules(monkeypatch, capsys, qapp, qtbot):
     assert 'add_device' in output.out
 
 
-@pytest.mark.skip(reason='Breaks the test suite')
 def test_cli_benchmark(monkeypatch, capsys, qapp, qtbot):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    monkeypatch.setattr(QApplication, 'exit', lambda x: 1)
     windows = typhos_cli(['ophyd.sim.SynAxis[]', '--benchmark',
                           'flat_soft'])
     qtbot.addWidget(windows[0])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,8 @@ def test_cli_benchmark(monkeypatch, capsys, qapp, qtbot):
 def test_cli_profile_output(monkeypatch, capsys, qapp, qtbot):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
     path_obj = conftest.MODULE_PATH / 'artifacts' / 'prof'
+    if not path_obj.parent.exists():
+        path_obj.parent.mkdir(parents=True)
     window = typhos_cli(['ophyd.sim.SynAxis[]', '--profile-output',
                          str(path_obj)])
     qtbot.addWidget(window)

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -1,0 +1,36 @@
+"""This module defines methods for launching full typhos applications."""
+import logging
+
+from qtpy.QtWidgets import QApplication, QMainWindow
+
+logger = logging.getLogger(__name__)
+qapp = None
+
+def get_qapp():
+    """Returns the global QApplication, creating it if necessary."""
+    global qapp
+    if qapp is None:
+        logger.debug("Creating QApplication ...")
+        qapp = QApplication([])
+    return qapp
+
+
+def launch_suite(suite):
+    """Creates a main window and execs the application."""
+    window = QMainWindow()
+    window.setCentralWidget(suite)
+    window.show()
+    logger.info("Launching application ...")
+    QApplication.instance().exec_()
+    logger.info("Execution complete!")
+    return window
+
+
+def launch_from_devices(devices, auto_exit=False):
+    """Alternate entry point for non-cli testing of loader."""
+    app = get_qapp()
+    suite = typhos.TyphosSuite.from_devices(devices)
+    if auto_exit:
+        timer = QTimer(suite)
+        timer.singleShot(0, app.exit)
+    return launch_suite(suite)

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -3,6 +3,8 @@ import logging
 
 from qtpy.QtWidgets import QApplication, QMainWindow
 
+from .suite import TyphosSuite
+
 logger = logging.getLogger(__name__)
 qapp = None
 
@@ -29,7 +31,7 @@ def launch_suite(suite):
 def launch_from_devices(devices, auto_exit=False):
     """Alternate entry point for non-cli testing of loader."""
     app = get_qapp()
-    suite = typhos.TyphosSuite.from_devices(devices)
+    suite = TyphosSuite.from_devices(devices)
     if auto_exit:
         timer = QTimer(suite)
         timer.singleShot(0, app.exit)

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -25,7 +25,7 @@ def launch_suite(suite):
     window.setCentralWidget(suite)
     window.show()
     logger.info("Launching application ...")
-    QApplication.instance().exec_()
+    get_qapp().exec_()
     logger.info("Execution complete!")
     return window
 

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -1,6 +1,7 @@
 """This module defines methods for launching full typhos applications."""
 import logging
 
+from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QApplication, QMainWindow
 
 from .suite import TyphosSuite

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -9,6 +9,7 @@ from .suite import TyphosSuite
 logger = logging.getLogger(__name__)
 qapp = None
 
+
 def get_qapp():
     """Returns the global QApplication, creating it if necessary."""
     global qapp

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -39,6 +39,5 @@ def launch_from_devices(devices, auto_exit=False):
     app = get_qapp()
     suite = TyphosSuite.from_devices(devices)
     if auto_exit:
-        timer = QTimer(suite)
-        timer.singleShot(0, app.exit)
+        QTimer.singleShot(0, app.exit)
     return launch_suite(suite)

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -14,8 +14,12 @@ def get_qapp():
     """Returns the global QApplication, creating it if necessary."""
     global qapp
     if qapp is None:
-        logger.debug("Creating QApplication ...")
-        qapp = QApplication([])
+        if QApplication.instance() is None:
+            logger.debug("Creating QApplication ...")
+            qapp = QApplication([])
+        else:
+            logger.debug("Using existing QApplication")
+            qapp = QApplication.instance()
     return qapp
 
 

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -11,7 +11,7 @@ from caproto.server import pvproperty, PVGroup, run
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalBase
 
 from .device import make_test_device_class
-from ..cli import typhos_cli
+from ..cli import launch_from_devices
 
 
 # Create the test classes
@@ -50,15 +50,15 @@ def caproto_context(device_class, prefix):
 
 def test_flat_soft():
     """Launch typhos using a flat device with no EPICS connections."""
-    typhos_cli(["typhos.benchmark.cases.FlatSoft[{'prefix':'TEST:'}]"])
+    launch_from_devices([FlatSoft('TEST:', name='test')])
 
 
 def test_flat_epics_no_connect():
     """Launch typhos using a flat device with failed EPICS connections."""
-    typhos_cli(["typhos.benchmark.cases.FlatEpics[{'prefix':'TEST:'}]"])
+    launch_from_devices([FlatEpics('TEST:', name='test')])
 
 
 def test_flat_epics_caproto():
     """Launch typhos using a flat device backed by caproto."""
     with caproto_context(FlatEpics, 'CAPRO:'):
-        typhos_cli(["typhos.benchmark.cases.FlatEpics[{'prefix':'CAPRO:'}]"])
+        launch_from_devices([FlatEpics('CAPRO:', name='test')])

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -18,10 +18,11 @@ from ..utils import nullcontext
 # Define matrix of testing parameters
 Shape = namedtuple('Shape', ['num_signals', 'subdevice_layers',
                              'subdevice_spread'])
-SHAPES = dict(flat=Shape(1000, 1, 1),
-              deep=Shape(1, 1000, 1),
-              wide=Shape(1, 1, 1000),
-              cube=Shape(10, 10, 10))
+# total_signals == num_signals * (subdevice_spread ** subdevice_layers)
+SHAPES = dict(flat=Shape(100, 1, 1),
+              deep=Shape(100, 100, 1),
+              wide=Shape(1, 1, 100),
+              cube=Shape(4, 2, 5))
 
 Test = namedtuple('Test', ['signal_class', 'include_prefix', 'start_ioc'])
 TESTS = dict(soft=Test(Signal, False, False),

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -5,17 +5,12 @@ These are included as standalone functions to make it easy to pass them into
 arbitrary profiling modules.
 """
 from collections import namedtuple
-from contextlib import contextmanager
 from functools import partial
-from multiprocessing import Process
-import signal
-import os
-import uuid
 
-from caproto.server import pvproperty, PVGroup, run
-from ophyd.signal import Signal, EpicsSignal, EpicsSignalBase
+from ophyd.signal import Signal, EpicsSignal
 
 from .device import make_test_device_class as make_cls
+from .utils import caproto_context, nullcontext, random_prefix
 from ..cli import launch_from_devices
 
 
@@ -31,82 +26,6 @@ Test = namedtuple('Test', ['signal_class', 'include_prefix', 'start_ioc'])
 TESTS = dict(soft=Test(Signal, False, False),
              connect=Test(EpicsSignal, True, True),
              noconnect=Test(EpicsSignal, True, False))
-
-
-
-def run_caproto_ioc(device_class, prefix):
-    """
-    Runs a dummy caproto IOC.
-
-    Includes all the PVs that device_class will have if instantiated with
-    prefix.
-
-    Assumes only basic :class:`ophyd.Component` instances in the class
-    definition.
-    """
-    pvprops = {}
-    for suffix in yield_all_suffixes(device_class):
-        pvprops[suffix] = pvproperty()
-
-    DynIOC = type('DynIOC', (PVGroup,), pvprops)
-    ioc = DynIOC(prefix)
-
-    run(ioc.pvdb, module_name='caproto.asyncio.server',
-        interfaces=['0.0.0.0'])
-
-
-def yield_all_suffixes(device_class):
-    """
-    Iterates through all full pvname suffixes defined by device_class.
-
-    Assumes only basic :class:`ophyd.Component` instances in the class
-    definition.
-    """
-    for walk in device_class.walk_components():
-        if issubclass(walk.item.cls, EpicsSignalBase):
-            suffix = get_suffix(walk)
-            yield suffix
-
-
-def get_suffix(walk):
-    """
-    Returns the full pvname suffix from a ComponentWalk instance
-
-    This means everything after the top-level device's prefix.
-    Assumes that walk is an :class:`ophyd.signal.EpicsSignalBase`
-    subclass and that it was defined using only
-    :class:`ophyd.Component` in the device ancestors tree.
-    """
-    suffix = ''
-    for cls, attr in zip(walk.ancestors, walk.dotted_name.split('.')):
-        suffix += getattr(cls, attr).suffix
-    return suffix
-
-
-@contextmanager
-def caproto_context(device_class, prefix):
-    """
-    Yields a caproto process with all elements of the input device.
-
-    The caproto IOC will be run in a background process, making it suitable for
-    testing devices in the main process.
-    """
-    proc = Process(target=run_caproto_ioc, args=(device_class, prefix))
-    proc.start()
-    yield
-    if proc.is_alive():
-        os.kill(proc.pid, signal.SIGKILL)
-
-
-def random_prefix():
-    """Returns a random prefix to avoid test cross-talk."""
-    return str(uuid.uuid4())[:8] + ':'
-
-
-@contextmanager
-def nullcontext():
-    """Stand-in for py3.7's contextlib.nullcontext"""
-    yield
 
 
 def generic_benchmark(cls, start_ioc, auto_exit=True):

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -10,8 +10,9 @@ from functools import partial
 from ophyd.signal import Signal, EpicsSignal
 
 from .device import make_test_device_class as make_cls
-from .utils import caproto_context, nullcontext, random_prefix
-from ..cli import launch_from_devices
+from .utils import caproto_context, random_prefix
+from ..app import launch_from_devices
+from ..utils import nullcontext
 
 
 # Define matrix of testing parameters

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -6,6 +6,8 @@ arbitrary profiling modules.
 """
 from contextlib import contextmanager
 from multiprocessing import Process
+import signal
+import os
 import uuid
 
 from caproto.server import pvproperty, PVGroup, run
@@ -120,7 +122,8 @@ def caproto_context(device_class, prefix):
     proc = Process(target=run_caproto_ioc, args=(device_class, prefix))
     proc.start()
     yield
-    proc.terminate()
+    if proc.is_alive():
+        os.kill(proc.pid, signal.SIGKILL)
 
 
 def random_prefix():

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -17,10 +17,10 @@ from ..cli import launch_from_devices
 
 # Create the test classes
 FlatSoft = make_test_device_class(name='FlatSoft', signal_class=Signal,
-                                  include_prefix=False, num_signals=1000)
+                                  include_prefix=False, num_signals=1000,
                                   subdevice_layers=1, subdevice_spread=1)
 FlatEpic = make_test_device_class(name='FlatEpic', signal_class=EpicsSignal,
-                                  include_prefix=True, num_signals=1000)
+                                  include_prefix=True, num_signals=1000,
                                   subdevice_layers=1, subdevice_spread=1)
 WideSoft = make_test_device_class(name='WideSoft', signal_class=Signal,
                                   include_prefix=False, num_signals=1,
@@ -64,7 +64,7 @@ def run_caproto_ioc(device_class, prefix):
     """
     Runs a dummy caproto IOC.
 
-    Includes all the PVs that device_class will have if instantiate with
+    Includes all the PVs that device_class will have if instantiated with
     prefix.
 
     Assumes only basic :class:`ophyd.Component` instances in the class
@@ -138,7 +138,7 @@ def test_flat_soft(auto_exit=True):
 @register_benchmark
 def test_flat_epics_no_connect(auto_exit=True):
     """Launch typhos using a flat device with failed EPICS connections."""
-    launch_from_devices([FlatEpics('TEST:', name='test')],
+    launch_from_devices([FlatEpic('TEST:', name='test')],
                         auto_exit=auto_exit)
 
 
@@ -146,6 +146,6 @@ def test_flat_epics_no_connect(auto_exit=True):
 def test_flat_epics_caproto(auto_exit=True):
     """Launch typhos using a flat device backed by caproto."""
     prefix = random_prefix()
-    with caproto_context(FlatEpics, prefix):
-        launch_from_devices([FlatEpics(prefix, name='test')],
+    with caproto_context(FlatEpic, prefix):
+        launch_from_devices([FlatEpic(prefix, name='test')],
                             auto_exit=auto_exit)

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -152,5 +152,10 @@ def run_benchmarks(benchmarks):
             test()
     else:
         for benchmark in benchmarks:
-            test = benchmark_tests[benchmark]
+            try:
+                test = benchmark_tests[benchmark]
+            except KeyError:
+                raise RuntimeError(f'{benchmark} is not a valid benchmark. '
+                                   f'The full list of valid benchmarks is '
+                                   f'{list(benchmark_tests.keys())}')
             test()

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -39,7 +39,7 @@ def profiler_benchmark(cls, start_ioc, auto_exit=True):
     profiler and launch a screen.
     """
     prefix = random_prefix()
-    with benchmark_context(start_ioc, prefix):
+    with benchmark_context(start_ioc, cls, prefix):
         return launch_from_devices([cls(prefix, name='test')],
                                    auto_exit=auto_exit)
 
@@ -96,13 +96,15 @@ benchmark_classes, profiler_tests, unit_tests = make_tests()
 
 
 def run_benchmarks(benchmarks):
+    windows = []
     if not benchmarks:
         for test in profiler_tests.values():
-            test(auto_exit=True)
+            windows.append(test(auto_exit=True))
     else:
         for benchmark in benchmarks:
             test = get_profiler_test(benchmark)
-            test(auto_exit=True)
+            windows.append(test(auto_exit=True))
+    return windows
 
 
 def interactive_benchmark(benchmark):
@@ -115,5 +117,5 @@ def get_profiler_test(benchmark):
         return profiler_tests[benchmark]
     except KeyError:
         raise RuntimeError(f'{benchmark} is not a valid benchmark. '
-                           f'The full list of valid benchmarks is '
+                           'The full list of valid benchmarks is '
                            f'{list(benchmark_tests.keys())}')

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -48,19 +48,46 @@ def run_caproto_ioc(device_class, prefix):
     Includes all the PVs that device_class will have if instantiate with
     prefix.
 
-    Currently only works for flat devices, e.g. no subdevices
+    Assumes only basic :class:`ophyd.Component` instances in the class
+    definition.
     """
     pvprops = {}
-    for walk in device_class.walk_components():
-        cpt = walk.item
-        if issubclass(cpt.cls, EpicsSignalBase):
-            pvprops[cpt.suffix] = pvproperty()
+    for suffix in yield_all_suffixes(device_class):
+        pvprops[suffix] = pvproperty()
 
     DynIOC = type('DynIOC', (PVGroup,), pvprops)
     ioc = DynIOC(prefix)
 
     run(ioc.pvdb, module_name='caproto.asyncio.server',
         interfaces=['0.0.0.0'])
+
+
+def yield_all_suffixes(device_class):
+    """
+    Iterates through all full pvname suffixes defined by device_class.
+
+    Assumes only basic :class:`ophyd.Component` instances in the class
+    definition.
+    """
+    for walk in device_class.walk_components():
+        if issubclass(walk.item.cls, EpicsSignalBase):
+            suffix = get_suffix(walk)
+            yield suffix
+
+
+def get_suffix(walk):
+    """
+    Returns the full pvname suffix from a ComponentWalk instance
+
+    This means everything after the top-level device's prefix.
+    Assumes that walk is an :class:`ophyd.signal.EpicsSignalBase`
+    subclass and that it was defined using only
+    :class:`ophyd.Component` in the device ancestors tree.
+    """
+    suffix = ''
+    for cls, attr in zip(walk.ancestors, walk.dotted_name.split('.')):
+        suffix += getattr(cls, attr).suffix
+    return suffix
 
 
 @contextmanager

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -21,6 +21,10 @@ FlatEpics = make_test_device_class(name='FlatEpics', signal_class=EpicsSignal,
                                    include_prefix=True, num_signals=100)
 
 
+def run_benchmarks(benchmarks):
+    raise NotImplementedError('TODO: this')
+
+
 def run_caproto_ioc(device_class, prefix):
     """
     Runs a dummy caproto IOC.

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -1,0 +1,64 @@
+"""
+A collection of benchmarks to run for typhos.
+
+These are included as standalone functions to make it easy to pass them into
+arbitrary profiling modules.
+"""
+from contextlib import contextmanager
+from multiprocessing import Process
+
+from caproto.server import pvproperty, PVGroup, run
+from ophyd.signal import Signal, EpicsSignal, EpicsSignalBase
+
+from .device import make_test_device_class
+from ..cli import typhos_cli
+
+
+# Create the test classes
+FlatSoft = make_test_device_class(name='FlatSoft', signal_class=Signal,
+                                  include_prefix=False, num_signals=100)
+FlatEpics = make_test_device_class(name='FlatEpics', signal_class=EpicsSignal,
+                                   include_prefix=True, num_signals=100)
+
+
+def run_caproto_ioc(device_class, prefix):
+    pvprops = {}
+    for walk in device_class.walk_components():
+        cpt = walk.item
+        if issubclass(cpt.cls, EpicsSignalBase):
+            pvprops[cpt.suffix] = pvproperty()
+
+    DynIOC = type('DynIOC', (PVGroup,), pvprops)
+    ioc = DynIOC(prefix)
+
+    run(ioc.pvdb, module_name='caproto.asyncio.server',
+        interfaces=['0.0.0.0'])
+
+
+@contextmanager
+def caproto_context(device_class, prefix):
+    """
+    Yield a caproto process with all elements of the input device.
+
+    Currently only works for flat devices, e.g. no subdevices
+    """
+    proc = Process(target=run_caproto_ioc, args=(device_class, prefix))
+    proc.start()
+    yield
+    proc.terminate()
+
+
+def test_flat_soft():
+    """Launch typhos using a flat device with no EPICS connections."""
+    typhos_cli(["typhos.benchmark.cases.FlatSoft[{'prefix':'TEST:'}]"])
+
+
+def test_flat_epics_no_connect():
+    """Launch typhos using a flat device with failed EPICS connections."""
+    typhos_cli(["typhos.benchmark.cases.FlatEpics[{'prefix':'TEST:'}]"])
+
+
+def test_flat_epics_caproto():
+    """Launch typhos using a flat device backed by caproto."""
+    with caproto_context(FlatEpics, 'CAPRO:'):
+        typhos_cli(["typhos.benchmark.cases.FlatEpics[{'prefix':'CAPRO:'}]"])

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -118,4 +118,4 @@ def get_profiler_test(benchmark):
     except KeyError:
         raise RuntimeError(f'{benchmark} is not a valid benchmark. '
                            'The full list of valid benchmarks is '
-                           f'{list(benchmark_tests.keys())}')
+                           f'{list(profiler_tests.keys())}')

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -38,8 +38,8 @@ def generic_benchmark(cls, start_ioc, auto_exit=True):
     else:
         context = nullcontext()
     with context:
-        launch_from_devices([cls(prefix, name='test')],
-                            auto_exit=auto_exit)
+        return launch_from_devices([cls(prefix, name='test')],
+                                   auto_exit=auto_exit)
 
 
 def make_tests():

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -17,10 +17,29 @@ from ..cli import launch_from_devices
 
 # Create the test classes
 FlatSoft = make_test_device_class(name='FlatSoft', signal_class=Signal,
-                                  include_prefix=False, num_signals=100)
-FlatEpics = make_test_device_class(name='FlatEpics', signal_class=EpicsSignal,
-                                   include_prefix=True, num_signals=100)
-
+                                  include_prefix=False, num_signals=1000)
+                                  subdevice_layers=1, subdevice_spread=1)
+FlatEpic = make_test_device_class(name='FlatEpic', signal_class=EpicsSignal,
+                                  include_prefix=True, num_signals=1000)
+                                  subdevice_layers=1, subdevice_spread=1)
+WideSoft = make_test_device_class(name='WideSoft', signal_class=Signal,
+                                  include_prefix=False, num_signals=1,
+                                  subdevice_layers=1, subdevice_spread=1000)
+WideEpic = make_test_device_class(name='WideEpics', signal_class=EpicsSignal,
+                                  include_prefix=True, num_signals=1,
+                                  subdevice_layers=1, subdevice_spread=1000)
+DeepSoft = make_test_device_class(name='DeepSoft', signal_class=Signal,
+                                  include_prefix=False, num_signals=1,
+                                  subdevice_layers=1000, subdevice_spread=1)
+DeepEpic = make_test_device_class(name='DeepEpic', signal_class=EpicsSignal,
+                                  include_prefix=True, num_signals=1,
+                                  subdevice_layers=1000, subdevice_spread=1)
+CubeSoft = make_test_device_class(name='CubeSoft', signal_class=Signal,
+                                  include_prefix=False, num_signals=10,
+                                  subdevice_layers=10, subdevice_spread=10)
+CubeEpic = make_test_device_class(name='CubeEpic', signal_class=EpicsSignal,
+                                  include_prefix=True, num_signals=10,
+                                  subdevice_layers=10, subdevice_spread=10)
 
 benchmark_registry = {}
 

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -22,6 +22,14 @@ FlatEpics = make_test_device_class(name='FlatEpics', signal_class=EpicsSignal,
 
 
 def run_caproto_ioc(device_class, prefix):
+    """
+    Runs a dummy caproto IOC.
+
+    Includes all the PVs that device_class will have if instantiate with
+    prefix.
+
+    Currently only works for flat devices, e.g. no subdevices
+    """
     pvprops = {}
     for walk in device_class.walk_components():
         cpt = walk.item
@@ -38,9 +46,10 @@ def run_caproto_ioc(device_class, prefix):
 @contextmanager
 def caproto_context(device_class, prefix):
     """
-    Yield a caproto process with all elements of the input device.
+    Yields a caproto process with all elements of the input device.
 
-    Currently only works for flat devices, e.g. no subdevices
+    The caproto IOC will be run in a background process, making it suitable for
+    testing devices in the main process.
     """
     proc = Process(target=run_caproto_ioc, args=(device_class, prefix))
     proc.start()

--- a/typhos/benchmark/cases.py
+++ b/typhos/benchmark/cases.py
@@ -6,6 +6,7 @@ arbitrary profiling modules.
 """
 from contextlib import contextmanager
 from multiprocessing import Process
+import uuid
 
 from caproto.server import pvproperty, PVGroup, run
 from ophyd.signal import Signal, EpicsSignal, EpicsSignalBase
@@ -61,6 +62,11 @@ def caproto_context(device_class, prefix):
     proc.terminate()
 
 
+def random_prefix():
+    """Returns a random prefix to avoid test cross-talk."""
+    return str(uuid.uuid4())[:8] + ':'
+
+
 def test_flat_soft():
     """Launch typhos using a flat device with no EPICS connections."""
     launch_from_devices([FlatSoft('TEST:', name='test')])
@@ -73,5 +79,6 @@ def test_flat_epics_no_connect():
 
 def test_flat_epics_caproto():
     """Launch typhos using a flat device backed by caproto."""
-    with caproto_context(FlatEpics, 'CAPRO:'):
-        launch_from_devices([FlatEpics('CAPRO:', name='test')])
+    prefix = random_prefix()
+    with caproto_context(FlatEpics, prefix):
+        launch_from_devices([FlatEpics(prefix, name='test')])

--- a/typhos/benchmark/device.py
+++ b/typhos/benchmark/device.py
@@ -9,7 +9,8 @@ Note that this currently only supports devices with uniform signals.
 In the future it can be expanded to have Kind information, different
 data types to test different widget types, etc.
 """
-from ophyd.device import Device, Component as Cpt
+from ophyd.device import (Component as Cpt,
+                          create_device_from_components as create_device)
 from ophyd.signal import Signal
 
 
@@ -64,7 +65,7 @@ def make_test_device_class(name='TestClass', signal_class=Signal,
             sig_cpt = Cpt(signal_class)
         signals[f'signum{nsig}'] = sig_cpt
 
-    SignalHolder = type('SignalHolder', (Device,), signals)
+    SignalHolder = create_device('SignalHolder', **signals)
 
     if all((subdevice_layers > 0, subdevice_spread > 0)):
         PrevClass = SignalHolder
@@ -72,10 +73,10 @@ def make_test_device_class(name='TestClass', signal_class=Signal,
             subdevices = {}
             for ndev in range(subdevice_spread):
                 subdevices[f'devnum{ndev}'] = Cpt(PrevClass, f'PREFIX{ndev}:')
-            ThisClass = type(f'Layer{subdevice_layers}', (Device,), subdevices)
+            ThisClass = create_device(f'Layer{subdevice_layers}', **subdevices)
             PrevClass = ThisClass
             subdevice_layers -= 1
     else:
         ThisClass = SignalHolder
 
-    return type(name, (ThisClass,), {})
+    return create_device(name, base_class=ThisClass)

--- a/typhos/benchmark/device.py
+++ b/typhos/benchmark/device.py
@@ -5,16 +5,17 @@ These are meant to be used for targetted benchmarking and typically are
 "extreme" in both size and in composition in order to make specific
 loading issues more obvious.
 
-Note that this currently only supports simple, flat devices.
-In the future it can be expanded to have complicated nesting devices,
-Kind information, different data types to test different widget types, etc.
+Note that this currently only supports devices with uniform signals.
+In the future it can be expanded to have Kind information, different
+data types to test different widget types, etc.
 """
 from ophyd.device import Device, Component as Cpt
 from ophyd.signal import Signal
 
 
 def make_test_device_class(name='TestClass', signal_class=Signal,
-                           include_prefix=False, num_signals=10):
+                           include_prefix=False, num_signals=10,
+                           subdevice_layers=0, subdevice_spread=0):
     """
     Creates a test :class:`ophyd.Device` subclass.
 
@@ -36,8 +37,24 @@ def make_test_device_class(name='TestClass', signal_class=Signal,
         Defaults to False.
 
     num_signals : int, optional
-        The number of signals to use in the test class.
+        The number of signals to use in the test class. Note that this is the
+        number of signals per bottom-level subdevice. Therefore, the actual
+        total number of signals can be some multiple of this number.
         Defaults to 10.
+
+    subdevice_layers : int, optional
+        The number of subdevices we need to traverse down before seeing
+        signals. For example, putting this at 0 results in no subdevices and
+        all signals at the top level, while putting this at 2 gives us only
+        subdevices at the top level, only subdevices on each of these
+        subdevices, and only signals on these bottom-most subdevices.
+        Has no effect if subdevice_spread is 0.
+        Defaults to 0.
+
+    subdevice_spread : int, optional
+        The number of subdevices to include in each layer.
+        Has no effect if subdevice_layers is 0.
+        Defaults to 0
     """
     signals = {}
     for nsig in range(num_signals):
@@ -47,4 +64,18 @@ def make_test_device_class(name='TestClass', signal_class=Signal,
             sig_cpt = Cpt(signal_class)
         signals[f'signum{nsig}'] = sig_cpt
 
-    return type(name, (Device,), signals)
+    SignalHolder = type('SignalHolder', (Device,), signals)
+
+    if all((subdevice_layers > 0, subdevice_spread > 0)):
+        PrevClass = SignalHolder
+        while subdevice_layers > 0:
+            subdevices = {}
+            for ndev in range(subdevice_spread):
+                subdevices[f'devnum{ndev}'] = Cpt(PrevClass, f'PREFIX{ndev}:')
+            ThisClass = type(f'Layer{subdevice_layers}', (Device,), subdevices)
+            PrevClass = ThisClass
+            subdevice_layers -= 1
+    else:
+        ThisClass = SignalHolder
+
+    return type(name, (ThisClass,), {})

--- a/typhos/benchmark/device.py
+++ b/typhos/benchmark/device.py
@@ -16,7 +16,7 @@ from ophyd.signal import Signal
 def make_test_device_class(name='TestClass', signal_class=Signal,
                            include_prefix=False, num_signals=10):
     """
-    Creates a test Device class.
+    Creates a test :class:`ophyd.Device` subclass.
 
     Parameters
     ----------
@@ -26,13 +26,13 @@ def make_test_device_class(name='TestClass', signal_class=Signal,
 
     signal_class : type, optional
         Picks which type of signal to use in the Device.
-        Defaults to ophyd.signal.Signal.
+        Defaults to :class:`ophyd.Signal`.
 
     include_prefix : bool, optional
         If True, passes a string as a position argument into the signal
-        components. This should be True for something like an EpicsSignal and
-        False for something like a base Signal, depending on the required
-        arguments.
+        components. This should be True for something like an
+        :class:`ophyd.EpicsSignal` and False for something like a base
+        :class:`ophyd.Signal`, depending on the required arguments.
         Defaults to False.
 
     num_signals : int, optional

--- a/typhos/benchmark/device.py
+++ b/typhos/benchmark/device.py
@@ -20,22 +20,22 @@ def make_test_device_class(name='TestClass', signal_class=Signal,
 
     Parameters
     ----------
-    name: str, optional
+    name : str, optional
         The name of the class.
         Defaults to 'TestClass'.
 
-    signal_class: type, optional
+    signal_class : type, optional
         Picks which type of signal to use in the Device.
         Defaults to ophyd.signal.Signal.
 
-    include_prefix: bool, optional
+    include_prefix : bool, optional
         If True, passes a string as a position argument into the signal
         components. This should be True for something like an EpicsSignal and
         False for something like a base Signal, depending on the required
         arguments.
         Defaults to False.
 
-    num_signals: int, optional
+    num_signals : int, optional
         The number of signals to use in the test class.
         Defaults to 10.
     """

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -33,12 +33,9 @@ def get_profiler():
 
 
 @contextmanager
-def profiler_context(module_names=[], filename=None):
+def profiler_context(module_names=None, filename=None):
     """Context manager for profiling the cli typhos application."""
-    if not module_names:
-        setup_profiler()
-    else:
-        setup_profiler(module_names)
+    setup_profiler(module_names=module_names)
 
     toggle_profiler(True)
     yield
@@ -50,7 +47,7 @@ def profiler_context(module_names=[], filename=None):
         save_results(filename)
 
 
-def setup_profiler(module_names=['typhos']):
+def setup_profiler(module_names=None):
     """
     Sets up the global profiler.
 
@@ -59,6 +56,9 @@ def setup_profiler(module_names=['typhos']):
     limit the scope by passing a particular submodule,
     e.g. module_names=['typhos.display']
     """
+    if module_names is None:
+        module_names = ['typhos']
+
     profiler = get_profiler()
 
     functions = set()

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -1,0 +1,73 @@
+"""
+Module using line_profiler to measure code performance and diagnose slowdowns.
+"""
+import importlib
+import pkgutil
+
+from line_profiler import LineProfiler
+
+
+# Global profiler instance
+PROFILER=None
+
+
+def get_profiler():
+    """Returns the global profiler instance, creating it if necessary."""
+    global PROFILER
+    if PROFILER is None:
+        PROFILER = LineProfiler()
+    return PROFILER
+
+
+def setup_profiler(module_names=['typhos']):
+    """
+    Sets up the global profiler.
+
+    Includes all functions and classes from all submodules of the given
+    modules. This defaults to everything in the typhos module, but you can
+    limit the scope by passing a particular submodule,
+    e.g. module_names=['typhos.display']
+    """
+    modules = set()
+    for module_name in module_names:
+        submodule_names = get_submodule_names(module_name)
+        modules.update(import_modules(submodule_names))
+
+    profiler = get_profiler()
+    for module in modules:
+        profiler.add_module(module)
+
+
+def save_results(filename):
+    """Saves the formatted profiling results to filename."""
+    profiler = get_profiler()
+    with open(filename, 'w') as fd:
+        profiler.print_stats(fd)
+
+
+def get_submodule_names(module_name):
+    """
+    Returns a list of the module name plus all importable submodule names.
+    """
+    module = importlib.import_module(module_name)
+    submodule_names = [module_name]
+
+    try:
+        module_path = module.__path__
+    except AttributeError:
+        # This attr is missing if there are no submodules
+        return submodule_names
+
+    for _, submodule_name, is_pkg in pkgutil.walk_packages(module_path):
+        if submodule_name != '__main__':
+            full_submodule_name = module_name + '.' + submodule_name
+            submodule_names.append(full_submodule_name)
+            if is_pkg:
+                subsubmodule_names = get_submodule_names(full_submodule_name)
+                submodule_names.extend(subsubmodule_names)
+    return submodule_names
+
+
+def import_modules(modules):
+    """Utility function to import an interator of module names as a list."""
+    return [importlib.import_module(mod) for mod in modules]

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -1,11 +1,10 @@
 """
 Module using line_profiler to measure code performance and diagnose slowdowns.
 """
-import importlib
 import logging
-import pkgutil
 from contextlib import contextmanager
-from inspect import isclass, isfunction
+
+from .utils import get_native_functions
 
 logger = logging.getLogger(__name__)
 
@@ -93,60 +92,3 @@ def print_results():
     """Prints the formatted results directly to screen."""
     profiler = get_profiler()
     profiler.print_stats(stripzeros=True, output_unit=1e-3)
-
-
-def is_native(obj, module):
-    """Returns True if obj was defined in module."""
-    return module.__name__ in obj.__module__
-
-
-def get_native_functions(module):
-    """Returns all functions and methods defined in module."""
-    return get_native_methods(module, module)
-
-
-def get_native_methods(cls, module):
-    """Returns all methods defined in cls that belong to module."""
-    native_methods = []
-    for obj in cls.__dict__.values():
-        if isclass(obj):
-            inner_methods = get_native_methods(obj, module)
-            native_methods.extend(inner_methods)
-        elif isfunction(obj):
-            if is_native(obj, module):
-                native_methods.append(obj)
-    return native_methods
-
-
-def get_submodules(module_name):
-    """Returns a list of the imported module plus all submodules."""
-    submodule_names = get_submodule_names(module_name)
-    return import_modules(submodule_names)
-
-
-def get_submodule_names(module_name):
-    """
-    Returns a list of the module name plus all importable submodule names.
-    """
-    module = importlib.import_module(module_name)
-    submodule_names = [module_name]
-
-    try:
-        module_path = module.__path__
-    except AttributeError:
-        # This attr is missing if there are no submodules
-        return submodule_names
-
-    for _, submodule_name, is_pkg in pkgutil.walk_packages(module_path):
-        if submodule_name != '__main__':
-            full_submodule_name = module_name + '.' + submodule_name
-            submodule_names.append(full_submodule_name)
-            if is_pkg:
-                subsubmodule_names = get_submodule_names(full_submodule_name)
-                submodule_names.extend(subsubmodule_names)
-    return submodule_names
-
-
-def import_modules(modules):
-    """Utility function to import an iterator of module names as a list."""
-    return [importlib.import_module(mod) for mod in modules]

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -54,13 +54,13 @@ def save_results(filename):
     """Saves the formatted profiling results to filename."""
     profiler = get_profiler()
     with open(filename, 'w') as fd:
-        profiler.print_stats(fd)
+        profiler.print_stats(fd, stripzeros=True, output_unit=1e-3)
 
 
 def print_results():
     """Prints the formatted results directly to screen."""
     profiler = get_profiler()
-    profiler.print_stats()
+    profiler.print_stats(stripzeros=True, output_unit=1e-3)
 
 
 def is_native(obj, module):

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -9,15 +9,15 @@ from line_profiler import LineProfiler
 
 
 # Global profiler instance
-PROFILER=None
+profiler = None
 
 
 def get_profiler():
     """Returns the global profiler instance, creating it if necessary."""
-    global PROFILER
-    if PROFILER is None:
-        PROFILER = LineProfiler()
-    return PROFILER
+    global profiler
+    if profiler is None:
+        profiler = LineProfiler()
+    return profiler
 
 
 def setup_profiler(module_names=['typhos']):

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -116,5 +116,5 @@ def get_submodule_names(module_name):
 
 
 def import_modules(modules):
-    """Utility function to import an interator of module names as a list."""
+    """Utility function to import an iterator of module names as a list."""
     return [importlib.import_module(mod) for mod in modules]

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -38,6 +38,15 @@ def setup_profiler(module_names=['typhos']):
         profiler.add_module(module)
 
 
+def toggle_profiler(turn_on):
+    """Turns the profiler off or on."""
+    profiler = get_profiler()
+    if turn_on:
+        profiler.enable_by_count()
+    else:
+        profiler.disable_by_count()
+
+
 def save_results(filename):
     """Saves the formatted profiling results to filename."""
     profiler = get_profiler()

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -45,6 +45,12 @@ def save_results(filename):
         profiler.print_stats(fd)
 
 
+def print_results():
+    """Prints the formatted results directly to screen."""
+    profiler = get_profiler()
+    profiler.print_stats()
+
+
 def get_submodule_names(module_name):
     """
     Returns a list of the module name plus all importable submodule names.

--- a/typhos/benchmark/profile.py
+++ b/typhos/benchmark/profile.py
@@ -4,7 +4,7 @@ Module using line_profiler to measure code performance and diagnose slowdowns.
 import logging
 from contextlib import contextmanager
 
-from .utils import get_native_functions
+from .utils import get_native_functions, get_submodules
 
 logger = logging.getLogger(__name__)
 

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -128,7 +128,11 @@ def get_native_methods(cls, module, *, native_methods=None, seen=None):
     if seen is None:
         seen = set()
     for obj in cls.__dict__.values():
-        if obj in seen:
+        try:
+            if obj in seen:
+                continue
+        except TypeError:
+            # Unhashable type, definitely not a class or function
             continue
         seen.add(obj)
         if not is_native(obj, module):

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -1,0 +1,86 @@
+"""
+Helpful functions that don't belong in a more specific submodule
+"""
+import signal
+import os
+import uuid
+from contextlib import contextmanager
+from multiprocessing import Process
+
+from caproto.server import pvproperty, PVGroup, run
+from ophyd.signal import EpicsSignalBase
+
+
+def run_caproto_ioc(device_class, prefix):
+    """
+    Runs a dummy caproto IOC.
+
+    Includes all the PVs that device_class will have if instantiated with
+    prefix.
+
+    Assumes only basic :class:`ophyd.Component` instances in the class
+    definition.
+    """
+    pvprops = {}
+    for suffix in yield_all_suffixes(device_class):
+        pvprops[suffix] = pvproperty()
+
+    DynIOC = type('DynIOC', (PVGroup,), pvprops)
+    ioc = DynIOC(prefix)
+
+    run(ioc.pvdb, module_name='caproto.asyncio.server',
+        interfaces=['0.0.0.0'])
+
+
+def yield_all_suffixes(device_class):
+    """
+    Iterates through all full pvname suffixes defined by device_class.
+
+    Assumes only basic :class:`ophyd.Component` instances in the class
+    definition.
+    """
+    for walk in device_class.walk_components():
+        if issubclass(walk.item.cls, EpicsSignalBase):
+            suffix = get_suffix(walk)
+            yield suffix
+
+
+def get_suffix(walk):
+    """
+    Returns the full pvname suffix from a ComponentWalk instance
+
+    This means everything after the top-level device's prefix.
+    Assumes that walk is an :class:`ophyd.signal.EpicsSignalBase`
+    subclass and that it was defined using only
+    :class:`ophyd.Component` in the device ancestors tree.
+    """
+    suffix = ''
+    for cls, attr in zip(walk.ancestors, walk.dotted_name.split('.')):
+        suffix += getattr(cls, attr).suffix
+    return suffix
+
+
+@contextmanager
+def caproto_context(device_class, prefix):
+    """
+    Yields a caproto process with all elements of the input device.
+
+    The caproto IOC will be run in a background process, making it suitable for
+    testing devices in the main process.
+    """
+    proc = Process(target=run_caproto_ioc, args=(device_class, prefix))
+    proc.start()
+    yield
+    if proc.is_alive():
+        os.kill(proc.pid, signal.SIGKILL)
+
+
+@contextmanager
+def nullcontext():
+    """Stand-in for py3.7's contextlib.nullcontext"""
+    yield
+
+
+def random_prefix():
+    """Returns a random prefix to avoid test cross-talk."""
+    return str(uuid.uuid4())[:8] + ':'

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -103,8 +103,17 @@ def random_prefix():
 
 
 def is_native(obj, module):
-    """Returns True if obj was defined in module."""
-    return module.__name__ in obj.__module__
+    """
+    Determines if obj was defined in module.
+
+    Returns True if obj was defined in this module.
+    Returns False if obj was not defined in this module.
+    Returns None if we can't figure it out, e.g. if this is a primitive type.
+    """
+    try:
+        return module.__name__ in obj.__module__
+    except AttributeError:
+        return None
 
 
 def get_native_functions(module):

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -102,65 +102,6 @@ def random_prefix():
     return str(uuid.uuid4())[:8] + ':'
 
 
-
-
-def is_native(obj, module):
-    """Returns True if obj was defined in module."""
-    return module.__name__ in obj.__module__
-
-
-def get_native_functions(module):
-    """Returns all functions and methods defined in module."""
-    return get_native_methods(module, module)
-
-
-def get_native_methods(cls, module):
-    """Returns all methods defined in cls that belong to module."""
-    native_methods = []
-    for obj in cls.__dict__.values():
-        if isclass(obj):
-            inner_methods = get_native_methods(obj, module)
-            native_methods.extend(inner_methods)
-        elif isfunction(obj):
-            if is_native(obj, module):
-                native_methods.append(obj)
-    return native_methods
-
-
-def get_submodules(module_name):
-    """Returns a list of the imported module plus all submodules."""
-    submodule_names = get_submodule_names(module_name)
-    return import_modules(submodule_names)
-
-
-def get_submodule_names(module_name):
-    """
-    Returns a list of the module name plus all importable submodule names.
-    """
-    module = importlib.import_module(module_name)
-    submodule_names = [module_name]
-
-    try:
-        module_path = module.__path__
-    except AttributeError:
-        # This attr is missing if there are no submodules
-        return submodule_names
-
-    for _, submodule_name, is_pkg in pkgutil.walk_packages(module_path):
-        if submodule_name != '__main__':
-            full_submodule_name = module_name + '.' + submodule_name
-            submodule_names.append(full_submodule_name)
-            if is_pkg:
-                subsubmodule_names = get_submodule_names(full_submodule_name)
-                submodule_names.extend(subsubmodule_names)
-    return submodule_names
-
-
-def import_modules(modules):
-    """Utility function to import an iterator of module names as a list."""
-    return [importlib.import_module(mod) for mod in modules]
-
-
 def is_native(obj, module):
     """Returns True if obj was defined in module."""
     return module.__name__ in obj.__module__

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -108,20 +108,27 @@ def is_native(obj, module):
 
 
 def get_native_functions(module):
-    """Returns all functions and methods defined in module."""
+    """Returns a set of all functions and methods defined in module."""
     return get_native_methods(module, module)
 
 
-def get_native_methods(cls, module):
-    """Returns all methods defined in cls that belong to module."""
-    native_methods = []
+def get_native_methods(cls, module, *, native_methods=None, seen=None):
+    """Returns a set of all methods defined in cls that belong to module."""
+    if native_methods is None:
+        native_methods = set()
+    if seen is None:
+        seen = set()
     for obj in cls.__dict__.values():
-        if isclass(obj):
-            inner_methods = get_native_methods(obj, module)
-            native_methods.extend(inner_methods)
+        if obj in seen:
+            continue
+        seen.add(obj)
+        if not is_native(obj, module):
+            continue
+        elif isclass(obj):
+            get_native_methods(obj, module, native_methods=native_methods,
+                               seen=seen)
         elif isfunction(obj):
-            if is_native(obj, module):
-                native_methods.append(obj)
+            native_methods.add(obj)
     return native_methods
 
 

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -66,7 +66,7 @@ def yield_all_suffixes(device_class):
 
 def get_suffix(walk):
     """
-    Returns the full pvname suffix from a ComponentWalk instance
+    Returns the full pvname suffix from a ComponentWalk instance.
 
     This means everything after the top-level device's prefix.
     Assumes that walk is an :class:`ophyd.signal.EpicsSignalBase`

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -1,11 +1,14 @@
 """
 Helpful functions that don't belong in a more specific submodule
 """
+import importlib
 import logging
 import signal
 import os
+import pkgutil
 import uuid
 from contextlib import contextmanager
+from inspect import isclass, isfunction
 from multiprocessing import Process
 
 from ophyd.signal import EpicsSignalBase
@@ -97,3 +100,119 @@ def caproto_context(device_class, prefix):
 def random_prefix():
     """Returns a random prefix to avoid test cross-talk."""
     return str(uuid.uuid4())[:8] + ':'
+
+
+
+
+def is_native(obj, module):
+    """Returns True if obj was defined in module."""
+    return module.__name__ in obj.__module__
+
+
+def get_native_functions(module):
+    """Returns all functions and methods defined in module."""
+    return get_native_methods(module, module)
+
+
+def get_native_methods(cls, module):
+    """Returns all methods defined in cls that belong to module."""
+    native_methods = []
+    for obj in cls.__dict__.values():
+        if isclass(obj):
+            inner_methods = get_native_methods(obj, module)
+            native_methods.extend(inner_methods)
+        elif isfunction(obj):
+            if is_native(obj, module):
+                native_methods.append(obj)
+    return native_methods
+
+
+def get_submodules(module_name):
+    """Returns a list of the imported module plus all submodules."""
+    submodule_names = get_submodule_names(module_name)
+    return import_modules(submodule_names)
+
+
+def get_submodule_names(module_name):
+    """
+    Returns a list of the module name plus all importable submodule names.
+    """
+    module = importlib.import_module(module_name)
+    submodule_names = [module_name]
+
+    try:
+        module_path = module.__path__
+    except AttributeError:
+        # This attr is missing if there are no submodules
+        return submodule_names
+
+    for _, submodule_name, is_pkg in pkgutil.walk_packages(module_path):
+        if submodule_name != '__main__':
+            full_submodule_name = module_name + '.' + submodule_name
+            submodule_names.append(full_submodule_name)
+            if is_pkg:
+                subsubmodule_names = get_submodule_names(full_submodule_name)
+                submodule_names.extend(subsubmodule_names)
+    return submodule_names
+
+
+def import_modules(modules):
+    """Utility function to import an iterator of module names as a list."""
+    return [importlib.import_module(mod) for mod in modules]
+
+
+def is_native(obj, module):
+    """Returns True if obj was defined in module."""
+    return module.__name__ in obj.__module__
+
+
+def get_native_functions(module):
+    """Returns all functions and methods defined in module."""
+    return get_native_methods(module, module)
+
+
+def get_native_methods(cls, module):
+    """Returns all methods defined in cls that belong to module."""
+    native_methods = []
+    for obj in cls.__dict__.values():
+        if isclass(obj):
+            inner_methods = get_native_methods(obj, module)
+            native_methods.extend(inner_methods)
+        elif isfunction(obj):
+            if is_native(obj, module):
+                native_methods.append(obj)
+    return native_methods
+
+
+def get_submodules(module_name):
+    """Returns a list of the imported module plus all submodules."""
+    submodule_names = get_submodule_names(module_name)
+    return import_modules(submodule_names)
+
+
+def get_submodule_names(module_name):
+    """
+    Returns a list of the module name plus all importable submodule names.
+    """
+    module = importlib.import_module(module_name)
+    submodule_names = [module_name]
+
+    try:
+        module_path = module.__path__
+    except AttributeError:
+        # This attr is missing if there are no submodules
+        return submodule_names
+
+    for _, submodule_name, is_pkg in pkgutil.walk_packages(module_path):
+        if submodule_name != '__main__':
+            full_submodule_name = module_name + '.' + submodule_name
+            submodule_names.append(full_submodule_name)
+            if is_pkg:
+                subsubmodule_names = get_submodule_names(full_submodule_name)
+                submodule_names.extend(subsubmodule_names)
+    return submodule_names
+
+
+def import_modules(modules):
+    """Utility function to import an iterator of module names as a list."""
+    return [importlib.import_module(mod) for mod in modules]

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -196,8 +196,11 @@ def typhos_cli(args):
 
     if any((args.profile_modules is not None, args.profile_output,
             args.benchmark is not None)):
-        context = profiler_context(module_names=args.profile_modules,
-                                   filename=args.profile_output)
+        if args.profile_modules:
+            context = profiler_context(module_names=args.profile_modules,
+                                       filename=args.profile_output)
+        else:
+            context = profiler_context(filename=args.profile_output)
     else:
         context = nullcontext()
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -207,8 +207,8 @@ def typhos_cli(args):
     with context:
         typhos_cli_setup(args)
         if args.benchmark is not None:
-            run_benchmarks(args.benchmark)
-            suite = None
+            # Note: actually a list of suites
+            suite = run_benchmarks(args.benchmark)
         else:
             suite = typhos_run(args.devices, cfg=args.happi_cfg,
                                fake_devices=args.fake_device)

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -7,6 +7,7 @@ import re
 import sys
 
 import coloredlogs
+from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QApplication, QMainWindow
 
 import pcdsutils
@@ -213,10 +214,13 @@ def launch_suite(suite):
     return window
 
 
-def launch_from_devices(devices):
+def launch_from_devices(devices, auto_exit=False):
     """Alternate entry point for non-cli testing of loader."""
-    get_qapp()
+    app = get_qapp()
     suite = suite_from_devices(devices)
+    if auto_exit:
+        timer = QTimer(suite)
+        timer.singleShot(0, app.exit)
     return launch_suite(suite)
 
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -108,11 +108,12 @@ def _create_happi_client(cfg):
 def create_suite(device_names, cfg=None, fake_devices=False):
     """Create a TyphosSuite from a list of device names."""
     if device_names:
-        devices = create_devices(device_names, cfg=cfg, fake_devices=fake_devices)
+        devices = create_devices(device_names, cfg=cfg,
+                                 fake_devices=fake_devices)
     else:
         devices = []
     if devices or not device_names:
-       return typhos.TyphosSuite.from_devices(devices)
+        return typhos.TyphosSuite.from_devices(devices)
 
 
 def create_devices(device_names, cfg=None, fake_devices=False):
@@ -177,7 +178,6 @@ def create_devices(device_names, cfg=None, fake_devices=False):
     return devices
 
 
-
 def typhos_run(device_names, cfg=None, fake_devices=False):
     """Run the central typhos part of typhos."""
     with typhos.utils.no_device_lazy_load():
@@ -208,7 +208,7 @@ def typhos_cli(args):
             suite = None
         else:
             suite = typhos_run(args.devices, cfg=args.happi_cfg,
-                                fake_devices=args.fake_device)
+                               fake_devices=args.fake_device)
         return suite
 
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -241,7 +241,10 @@ def typhos_cli(args):
         from typhos.benchmark.profile import (setup_profiler, toggle_profiler,
                                               save_results, print_results)
         from typhos.benchmark.cases import run_benchmarks
-        setup_profiler()
+        if not args.profile_modules:
+            setup_profiler()
+        else:
+            setup_profiler(args.profile_modules)
         toggle_profiler(True)
 
     typhos_cli_setup(args)

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -49,6 +49,7 @@ __doc__ += '\n::\n\n    ' + parser.format_help().replace('\n', '\n    ')
 
 
 def get_qapp():
+    """Returns the global QApplication, creating it if necessary."""
     global qapp
     if qapp is None:
         logger.debug("Creating QApplication ...")
@@ -57,6 +58,7 @@ def get_qapp():
 
 
 def typhos_cli_setup(args):
+    """Setup logging and style, or show version."""
     # Logging Level handling
     logging.getLogger().addHandler(logging.NullHandler())
     shown_logger = logging.getLogger('typhos')
@@ -101,7 +103,7 @@ def _create_happi_client(cfg):
 
 
 def create_suite(devices, cfg=None, fake_devices=False):
-    """Create a TyphosSuite from a list of device names"""
+    """Create a TyphosSuite from a list of device names."""
     if devices:
         loaded_devs = create_devices(devices, cfg=cfg, fake_devices=fake_devices)
     if loaded_devs or not devices:
@@ -109,6 +111,7 @@ def create_suite(devices, cfg=None, fake_devices=False):
 
 
 def create_devices(devices_arg, cfg=None, fake_devices=False):
+    """Returns a list of devices to be included in the typhos suite."""
     logger.debug("Accessing Happi Client ...")
 
     try:
@@ -170,6 +173,7 @@ def create_devices(devices_arg, cfg=None, fake_devices=False):
 
 
 def suite_from_devices(devices):
+    """Creates an empty suite and fills it with input Ophyd devices."""
     logger.debug("Creating empty TyphosSuite ...")
     suite = typhos.TyphosSuite()
     logger.info("Loading Tools ...")
@@ -189,6 +193,7 @@ def suite_from_devices(devices):
 
 
 def launch_suite(suite):
+    """Creates a main window and execs the application."""
     window = QMainWindow()
     window.setCentralWidget(suite)
     window.show()
@@ -199,13 +204,14 @@ def launch_suite(suite):
 
 
 def launch_from_devices(devices):
+    """Alternate entry point for non-cli testing of loader."""
     get_qapp()
     suite = suite_from_devices(devices)
     return launch_suite(suite)
 
 
 def typhos_cli(args):
-    """Command Line Application for Typhos"""
+    """Command Line Application for Typhos."""
     args = parser.parse_args(args)
     typhos_cli_setup(args)
     if not args.version:
@@ -216,5 +222,5 @@ def typhos_cli(args):
             return launch_suite(suite)
 
 def main():
-    """Execute the ``typhos_cli`` with command line arguments"""
+    """Execute the ``typhos_cli`` with command line arguments."""
     typhos_cli(sys.argv[1:])

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -14,7 +14,7 @@ import typhos
 from ophyd.sim import clear_fake_device, make_fake_device
 
 logger = logging.getLogger(__name__)
-app = None
+qapp = None
 
 # Argument Parser Setup
 parser = argparse.ArgumentParser(description='Create a TyphosSuite for '
@@ -49,11 +49,11 @@ __doc__ += '\n::\n\n    ' + parser.format_help().replace('\n', '\n    ')
 
 
 def get_qapp():
-    global app
-    if app is None:
+    global qapp
+    if qapp is None:
         logger.debug("Creating QApplication ...")
-        app = QApplication([])
-    return app
+        qapp = QApplication([])
+    return qapp
 
 
 def typhos_cli_setup(args):
@@ -77,14 +77,14 @@ def typhos_cli_setup(args):
         return
 
     # Deal with stylesheet
-    app = get_qapp()
+    qapp = get_qapp()
 
     logger.debug("Applying stylesheet ...")
     typhos.use_stylesheet(dark=args.dark)
     if args.stylesheet:
         logger.info("Loading QSS file %r ...", args.stylesheet)
         with open(args.stylesheet, 'r') as handle:
-            app.setStyleSheet(handle.read())
+            qapp.setStyleSheet(handle.read())
 
 
 def _create_happi_client(cfg):

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -7,8 +7,6 @@ import re
 import sys
 
 import coloredlogs
-from qtpy.QtCore import QTimer
-from qtpy.QtWidgets import QApplication, QMainWindow
 
 import pcdsutils
 import typhos

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -74,7 +74,7 @@ def get_qapp():
 
 
 def typhos_cli_setup(args):
-    """Setup logging and style, or show version."""
+    """Setup logging and style"""
     # Logging Level handling
     logging.getLogger().addHandler(logging.NullHandler())
     shown_logger = logging.getLogger('typhos')
@@ -120,7 +120,7 @@ def create_suite(devices, cfg=None, fake_devices=False):
     else:
         loaded_devs = []
     if loaded_devs or not devices:
-       return suite_from_devices(loaded_devs)
+       return typhos.TyphosSuite.from_devices(loaded_devs)
 
 
 def create_devices(devices_arg, cfg=None, fake_devices=False):
@@ -185,26 +185,6 @@ def create_devices(devices_arg, cfg=None, fake_devices=False):
     return loaded_devs
 
 
-def suite_from_devices(devices):
-    """Creates an empty suite and fills it with input Ophyd devices."""
-    logger.debug("Creating empty TyphosSuite ...")
-    suite = typhos.TyphosSuite()
-    logger.info("Loading Tools ...")
-    tools = dict(suite.default_tools)
-    for name, tool in tools.items():
-        suite.add_tool(name, tool())
-    if devices:
-        logger.info("Adding devices ...")
-    for device in devices:
-        try:
-            suite.add_device(device)
-            suite.show_subdisplay(device)
-        except Exception:
-            logger.exception("Unable to add %r to TyphosSuite",
-                             device.name)
-    return suite
-
-
 def launch_suite(suite):
     """Creates a main window and execs the application."""
     window = QMainWindow()
@@ -219,7 +199,7 @@ def launch_suite(suite):
 def launch_from_devices(devices, auto_exit=False):
     """Alternate entry point for non-cli testing of loader."""
     app = get_qapp()
-    suite = suite_from_devices(devices)
+    suite = typhos.TyphosSuite.from_devices(devices)
     if auto_exit:
         timer = QTimer(suite)
         timer.singleShot(0, app.exit)

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -117,6 +117,8 @@ def create_suite(devices, cfg=None, fake_devices=False):
     """Create a TyphosSuite from a list of device names."""
     if devices:
         loaded_devs = create_devices(devices, cfg=cfg, fake_devices=fake_devices)
+    else:
+        loaded_devs = []
     if loaded_devs or not devices:
        return suite_from_devices(loaded_devs)
 

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -15,6 +15,8 @@ from .tools import TyphosConsole, TyphosLogDisplay, TyphosTimePlot
 from .utils import TyphosBase, clean_name, flatten_tree, save_suite
 
 logger = logging.getLogger(__name__)
+# Use non-None sentinel value since None means no tools
+DEFAULT_TOOLS = object()
 
 
 class SidebarParameter(ptypes.Parameter):
@@ -380,7 +382,7 @@ class TyphosSuite(TyphosBase):
                                  device.name, type(tool))
 
     @classmethod
-    def from_device(cls, device, parent=None, tools=dict(), pin=False,
+    def from_device(cls, device, parent=None, tools=DEFAULT_TOOLS, pin=False,
                     **kwargs):
         """
         Create a new TyphosSuite from an :class:`ophyd.Device`
@@ -406,7 +408,7 @@ class TyphosSuite(TyphosBase):
                                 **kwargs)
 
     @classmethod
-    def from_devices(cls, devices, parent=None, tools=dict(), pin=False,
+    def from_devices(cls, devices, parent=None, tools=DEFAULT_TOOLS, pin=False,
                      **kwargs):
         """
         Create a new TyphosSuite from an iterator of :class:`ophyd.Device`
@@ -431,7 +433,7 @@ class TyphosSuite(TyphosBase):
         suite = cls(parent=parent, pin=pin)
         if tools is not None:
             logger.info("Loading Tools ...")
-            if not tools:
+            if tools is DEFAULT_TOOLS:
                 logger.debug("Using default TyphosSuite tools ...")
                 tools = cls.default_tools
             for name, tool in tools.items():

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -389,19 +389,19 @@ class TyphosSuite(TyphosBase):
 
         Parameters
         ----------
-        device: ophyd.Device
+        device : ophyd.Device
 
-        children: bool, optional
+        children : bool, optional
             Choice to include child Device components
 
-        parent: QWidgets
+        parent : QWidget
 
-        tools: dict, optional
+        tools : dict, optional
             Tools to load for the object. ``dict`` should be name, class pairs.
             By default these will be ``.default_tools``, but ``None`` can be
             passed to avoid tool loading completely.
 
-        kwargs:
+        **kwargs :
             Passed to :meth:`TyphosSuite.add_device`
         """
         return cls.from_devices([device], parent=parent, tools=tools, pin=pin,
@@ -415,19 +415,19 @@ class TyphosSuite(TyphosBase):
 
         Parameters
         ----------
-        device: ophyd.Device
+        device : ophyd.Device
 
-        children: bool, optional
+        children : bool, optional
             Choice to include child Device components
 
-        parent: QWidgets
+        parent : QWidget
 
-        tools: dict, optional
+        tools : dict, optional
             Tools to load for the object. ``dict`` should be name, class pairs.
             By default these will be ``.default_tools``, but ``None`` can be
             passed to avoid tool loading completely.
 
-        kwargs:
+        **kwargs :
             Passed to :meth:`TyphosSuite.add_device`
         """
         suite = cls(parent=parent, pin=pin)

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -1070,3 +1070,9 @@ def dump_grid_layout(layout, rows=None, cols=None, *, cell_width=60):
 
         print(separator, file=file)
         return file.getvalue()
+
+
+@contextlib.contextmanager
+def nullcontext():
+    """Stand-in for py3.7's contextlib.nullcontext"""
+    yield


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adds a `benchmark` submodule and some `cli` tools to help us keep track of `typhos`'s performance.  This also required a refactor of the `cli` submodule to pull apart the large functions there.

Full feature checklist:

- [x] `line_profiler` integration via cli to debug arbitrary screens interactively
- [x] Test class generator
- [x] Benchmark test cases with `caproto` and with soft devices
- [x] Benchmarking via `cli` using `line_profiler` for debugging
- [x] Benchmarking via `pytest-benchmark` for tracking performance

Some specific things to improve:

- [x] Expand test class generator for nested classes
- [x] Expand test cases to cover more ground
- [x] Clean up the argument name inconsistency mess I left in `cli.py` (and other things there)

Remaining work before merging:

- [x] Make the benchmark tests not hang afterwards
- [x] Add basic regression testing for the benchmark utilities

Stuff that I wanted to do but will not get to in this PR:

- [ ] Sort the `line_profiler` formatted output
- [ ] Allow filtering `line_profiler` output down to the function level
- [ ] Provide the raw `line_profiler` output file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was brought about because some of the larger screens have been taking a long time to load.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've been testing locally, but this will be implicitly tested when I add the benchmark tests to the test suite.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I have not yet documented anything beyond docstrings.

<!--
## Screenshots (if appropriate):
-->
