### PR TITLE
FIX: do not fail if `unsubscribe` fails; mark nested devices

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -521,7 +521,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
     def __init__(self, parent=None, *, scrollable=True,
                  composite_heuristics=True, embedded_templates=None,
                  detailed_templates=None, engineering_templates=None,
-                 display_type='detailed_screen', **kwargs):
+                 display_type='detailed_screen', nested=False, **kwargs):
 
         self._composite_heuristics = composite_heuristics
         self._current_template = None
@@ -531,6 +531,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         self._scrollable = False
         self._searched = False
         self._hide_empty = False
+        self._nested = nested
 
         self.templates = {name: [] for name in DisplayTypes.names}
         self._display_type = normalize_display_type(display_type)
@@ -1050,6 +1051,14 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
     def _tx(self, value):
         """Receive information from happi channel"""
         self.add_device(value['obj'], macros=value['md'])
+
+    def __repr__(self):
+        return (
+            f'<{self.__class__.__name__} at {hex(id(self))} '
+            f'device={self.device_class}[{self.device_name!r}] '
+            f'nested={self._nested}'
+            f'>'
+        )
 
 
 def toggle_display(widget, force_state=None):

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -641,7 +641,8 @@ class CompositeSignalPanel(SignalPanel):
         logger.debug('%s adding sub-device: %s (%s)', self.__class__.__name__,
                      device.name, device.__class__.__name__)
         container = display.TyphosDeviceDisplay(name=name, scrollable=False,
-                                                composite_heuristics=True)
+                                                composite_heuristics=True,
+                                                nested=True)
         self._containers[name] = container
         self.add_row(container)
         container.add_device(device)

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -680,7 +680,12 @@ def subscription_context(*objects, callback, event_type=None, run=True):
         yield dict(obj_to_cid)
     finally:
         for obj, cid in obj_to_cid.items():
-            obj.unsubscribe(cid)
+            try:
+                obj.unsubscribe(cid)
+            except KeyError:
+                # It's possible that when the object is being torn down, or
+                # destroyed that this has already been done.
+                ...
 
 
 def get_all_signals_from_device(device, include_lazy=False, filter_by=None):
@@ -798,7 +803,12 @@ class _ConnectionStatus:
 
             self.objects.remove(obj)
             cid = self.obj_to_cid.pop(obj)
-            obj.unsubscribe(cid)
+            try:
+                obj.unsubscribe(cid)
+            except KeyError:
+                # It's possible that when the object is being torn down, or
+                # destroyed that this has already been done.
+                ...
 
     def _connection_callback(self, *, obj, connected, **kwargs):
         with self.lock:


### PR DESCRIPTION
Pulled from #290 