### PR TITLE
FIX: font sizes in pixels, window title, and OSX toolbar

### DIFF
--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -184,6 +184,8 @@ def typhos_cli(args):
         if suite:
             window = QMainWindow()
             window.setCentralWidget(suite)
+            window.setWindowTitle(suite.windowTitle())
+            window.setUnifiedTitleAndToolBarOnMac(True)
             window.show()
             logger.info("Launching application ...")
             QApplication.instance().exec_()

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -35,7 +35,7 @@ DEFAULT_TEMPLATES = {
     for name in DisplayTypes.names
 }
 
-DETAILED_TREE_TEMPLATE = (utils.ui_dir / f'detailed_tree.ui').resolve()
+DETAILED_TREE_TEMPLATE = (utils.ui_dir / 'detailed_tree.ui').resolve()
 DEFAULT_TEMPLATES['detailed_screen'].append(DETAILED_TREE_TEMPLATE)
 
 DEFAULT_TEMPLATES_FLATTEN = [f for _, files in DEFAULT_TEMPLATES.items()

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -371,14 +371,6 @@ class TyphosDisplaySwitcher(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
 class TyphosTitleLabel(QtWidgets.QLabel):
     toggle_requested = QtCore.Signal()
 
-    def __init__(self, text):
-        super().__init__(text)
-
-        font = QtGui.QFontDatabase.systemFont(QtGui.QFontDatabase.TitleFont)
-        font.setPointSizeF(14.0)
-        font.setBold(True)
-        self.setFont(font)
-
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             self.toggle_requested.emit()

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -52,6 +52,16 @@ def _get_component_sorter(signal_order, *, kind_order=None):
             }.get(signal_order, name_sorter)
 
 
+class SignalPanelRowLabel(QtWidgets.QLabel):
+    """
+    A row label for a signal panel.
+
+    This subclass does not contain any special functionality currently, but
+    remains a special class for ease of stylesheet configuration and label
+    disambiguation.
+    """
+
+
 class SignalPanel(QtWidgets.QGridLayout):
     """
     Base panel display for EPICS signals
@@ -162,7 +172,7 @@ class SignalPanel(QtWidgets.QGridLayout):
     def _create_row_label(self, attr, dotted_name, tooltip):
         """Create a row label (i.e., the one in column 0)."""
         label_text = self.label_text_from_attribute(attr, dotted_name)
-        label = QtWidgets.QLabel(label_text)
+        label = SignalPanelRowLabel(label_text)
         label.setObjectName(dotted_name + '_row_label')
         if tooltip is not None:
             label.setToolTip(tooltip)

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -173,7 +173,7 @@ class SignalPanel(QtWidgets.QGridLayout):
         """Create a row label (i.e., the one in column 0)."""
         label_text = self.label_text_from_attribute(attr, dotted_name)
         label = SignalPanelRowLabel(label_text)
-        label.setObjectName(dotted_name + '_row_label')
+        label.setObjectName(dotted_name)
         if tooltip is not None:
             label.setToolTip(tooltip)
         return label

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -93,12 +93,18 @@ class TyphosSuite(TyphosBase):
     ----------
     parent : QWidget, optional
     """
+
+    DEFAULT_TITLE = 'Typhos Suite'
+    DEFAULT_TITLE_DEVICE = 'Typhos Suite - {device.name}'
+
     default_tools = {'Log': TyphosLogDisplay,
                      'StripTool': TyphosTimePlot,
                      'Console': TyphosConsole}
 
     def __init__(self, parent=None, *, pin=False):
         super().__init__(parent=parent)
+
+        self._update_title()
 
         self._tree = ParameterTree(parent=self, showHeader=False)
         self._tree.setAlternatingRowColors(False)
@@ -328,6 +334,20 @@ class TyphosSuite(TyphosBase):
                     for param in self.top_level_groups['Tools'].childs]
         return []
 
+    def _update_title(self, device=None):
+        """
+        Update the window title, optionally with a device.
+
+        Parameters
+        ----------
+        device : ophyd.Device, optional
+            Device to indicate in the title.
+        """
+        title_fmt = (self.DEFAULT_TITLE if device is None
+                     else self.DEFAULT_TITLE_DEVICE)
+
+        self.setWindowTitle(title_fmt.format(self=self, device=device))
+
     def add_device(self, device, children=True, category='Devices'):
         """
         Add a device to the ``TyphosSuite``
@@ -344,6 +364,7 @@ class TyphosSuite(TyphosBase):
             the "Devices" group
         """
         super().add_device(device)
+        self._update_title(device)
         # Create DeviceParameter and add to top level category
         dev_param = DeviceParameter(device, subdevices=children)
         self._add_to_sidebar(dev_param, category)

--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -65,8 +65,13 @@ TyphosBase TyphosPositionerWidget[moving="false"][failed_move="true"] .QFrame {
     border: 2px solid red;
 }
 
+SignalPanelRowLabel {
+    font: 12px sans-serif;
+}
+
 TyphosTitleLabel {
     border: none;
+    font: 16px bold serif;
 }
 
 TyphosTitleLabel:hover {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Changes row labels and titles to be in terms of pixel units. See screenshots below and related issue for details.
* Uses stylesheet instead of code for titles
* Add title for Typhos suite to get rid of ugly `python` title
* Fixes toolbar rendering on OSX (at least for now)
* Adds `SignalPanelRowLabel` for ease of styling

Closes #260 

## Screenshots (if appropriate):
Before (OSX/Win32):
![image](https://user-images.githubusercontent.com/5139267/81843030-de947a80-9501-11ea-84cc-dcaf17506138.png)

After (OSX/Win32):
![image](https://user-images.githubusercontent.com/5139267/81842897-a7be6480-9501-11ea-9a8e-defad5ce39bb.png)
