### PR TITLE
REF: do not automatically add hinted signals

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,8 +1,6 @@
 """
-Module Docstring
+Tests for the plot tool.
 """
-import time
-
 import pytest
 
 from ophyd import EpicsSignal, Signal
@@ -64,13 +62,7 @@ def test_device_plot(motor, qapp, qtbot):
     dtp = TyphosTimePlot.from_device(motor)
     qtbot.addWidget(dtp)
 
-    # Update happens in a background thread
-    t0 = time.time()
-    while time.time() - t0 < 1:
-        qapp.processEvents()
-        time.sleep(0.1)
+    def all_signals_listed():
+        assert dtp.signal_combo.count() == len(motor.component_names)
 
-    # Add the hint
-    assert len(dtp.timechart.chart.curves) == 1
-    # Added all the signals
-    assert dtp.signal_combo.count() == len(motor.component_names)
+    qtbot.wait_until(all_signals_listed)

--- a/typhos/tools/plot.py
+++ b/typhos/tools/plot.py
@@ -28,8 +28,6 @@ class TyphosTimePlot(utils.TyphosBase):
     parent : QWidget
     """
 
-    hint_limit = 20
-
     def __init__(self, parent=None):
         super().__init__(parent=parent)
         # Setup layout
@@ -172,18 +170,6 @@ class TyphosTimePlot(utils.TyphosBase):
         except ValueError:
             # Signal already added
             return
-
-        if len(self.channel_to_curve) >= self.hint_limit:
-            logger.debug('Too many hinted signals (at limit of %d)',
-                         self.hint_limit)
-            return
-
-        if signal.name in signal.root.hints.get('fields', []):
-            try:
-                self.add_curve(utils.channel_from_signal(signal), name=name)
-            except RuntimeError:
-                logger.debug('Attempted to add curve while plot tearing down',
-                             exc_info=True)
 
     def add_device(self, device):
         """Add a device and it's component signals to the plot."""


### PR DESCRIPTION
(A bit heavy-handed of a solution to #307; closes #307 most likely)

Normally, the plot would automatically add all hinted signals to the plot tool as soon as it's added.
However, this appears to be a common source of segmentation faults on Travis CI.