### PR TITLE
FIX: non-importable devices from CLI arguments

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,8 @@ def test_cli_no_entry(monkeypatch, qtbot, happi_cfg):
 def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
     monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
     with open('test.qss', 'w+') as handle:
-        handle.write("TyphosDeviceDisplay {qproperty-force_template: 'test.ui'}")
+        handle.write(
+            "TyphosDeviceDisplay {qproperty-force_template: 'test.ui'}")
     style = qapp.styleSheet()
     window = typhos_cli(['test_motor', '--stylesheet', 'test.qss',
                         '--happi-cfg', happi_cfg])
@@ -52,7 +53,7 @@ def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
 
 
 @pytest.mark.parametrize('klass, name', [
-    ("ophyd.sim.SynAxis[]", "device"),
+    ("ophyd.sim.SynAxis[]", "SynAxis"),
     ("ophyd.sim.SynAxis[{'name':'foo'}]", "foo")
 ])
 def test_cli_class(monkeypatch, qapp, qtbot, klass, name, happi_cfg):

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -152,7 +152,10 @@ def create_devices(device_names, cfg=None, fake_devices=False):
                     # This might fail, but is best effort
                     for arg in inspect.getfullargspec(klass).args:
                         if arg not in default_kwargs and arg != 'self':
-                            default_kwargs[arg] = 'FAKE'
+                            if arg == 'prefix':
+                                default_kwargs[arg] = 'FAKE_PREFIX:'
+                            else:
+                                default_kwargs[arg] = 'FAKE'
 
                 device = klass(**default_kwargs)
                 devices.append(device)

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -12,8 +12,8 @@ import pcdsutils
 import typhos
 from ophyd.sim import clear_fake_device, make_fake_device
 from typhos.app import get_qapp, launch_suite
-from typhos.benchmark.profile import profiler_context
 from typhos.benchmark.cases import run_benchmarks
+from typhos.benchmark.profile import profiler_context
 from typhos.utils import nullcontext
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ def create_devices(device_names, cfg=None, fake_devices=False):
                 klass, args = result[0]
                 klass = pcdsutils.utils.import_helper(klass)
 
-                default_kwargs = {"name": "device"}
+                default_kwargs = {"name": klass.__name__}
                 if args:
                     kwargs = ast.literal_eval(args)
                     default_kwargs.update(kwargs)

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -163,6 +163,7 @@ def create_devices(device_names, cfg=None, fake_devices=False):
             except Exception:
                 logger.exception("Unable to load class entry: %s with args %s",
                                  klass, args)
+                continue
         else:
             if not happi_client:
                 logger.error("Happi not available. Unable to load entry: %r",


### PR DESCRIPTION
* Default name set to the classname, overridden with `[{'name': ...}]` syntax.
* Prefix by default will be `FAKE_PREFIX:` instead of just `FAKE`
* Closes #303 by not adding the device if loading fails