### PR TITLE
FIX: clear path cache when user clicks "reload templates"

### DIFF
--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -329,6 +329,12 @@ class _GlobalDisplayPathCache:
         for path in utils.DISPLAY_PATHS:
             self.add_path(path)
 
+    def update(self):
+        """Force a reload of all paths in the cache."""
+        logger.debug('Clearing global path cache.')
+        for path in self.paths:
+            path.cache = None
+
     def add_path(self, path):
         """
         Add a path to be searched during ``glob``.
@@ -338,6 +344,7 @@ class _GlobalDisplayPathCache:
         path : pathlib.Path or str
             The path to add.
         """
+        logger.debug('Path added to _GlobalDisplayPathCache: %s', path)
         path = pathlib.Path(path).expanduser().resolve()
         path = _CachedPath(
             path, stale_threshold=TYPHOS_DISPLAY_PATH_CACHE_TIME)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -714,13 +714,16 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                 action = menu.addAction(os.path.split(filename)[-1])
                 action.triggered.connect(switch_template)
 
-        def refresh_templates():
-            self.search_for_templates()
-            self.load_best_template()
-
         base_menu.addSeparator()
         refresh_action = base_menu.addAction("Refresh Templates")
-        refresh_action.triggered.connect(refresh_templates)
+        refresh_action.triggered.connect(self._refresh_templates)
+
+    def _refresh_templates(self):
+        """Context menu 'Refresh Templates' clicked."""
+        # Force an update of the display cache.
+        cache.get_global_display_path_cache().update()
+        self.search_for_templates()
+        self.load_best_template()
 
     def generate_context_menu(self):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Path cache was not previously cleared when the user clicked 'reload templates', meaning unless the cache was stale, it's possible nothing would happen.

## How Has This Been Tested?
Locally