### PR TITLE
REF: rework default templates (misc panel removal; add normal panel)

### DIFF
--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -43,19 +43,26 @@ def test_device_display(device, motor, qtbot):
             utils.get_all_signals_from_device(device, filter_by=filter_by)
         )
 
-    def check_read_panel(device):
-        '''normal or hinted signals'''
+    def check_hint_panel(device):
         device_signals = signals_from_device(device, ophyd.Kind.hinted)
-        assert device_signals == signals_from_panel('read_panel')
+        if 'motor_setpoint' in device_signals:
+            # Signal is renamed and not reflected here
+            device_signals.remove('motor_setpoint')
+            device_signals.add('motor')
+        assert device_signals == signals_from_panel('hint_panel')
+
+    def check_read_panel(device):
+        device_signals = signals_from_device(device, ophyd.Kind.normal)
+        assert device_signals == signals_from_panel('normal_panel')
 
     def check_config_panel(device):
-        '''just config signals'''
         device_signals = signals_from_device(device, ophyd.Kind.config)
         assert device_signals == signals_from_panel('config_panel')
 
     panel = typhos.display.TyphosDeviceDisplay.from_device(
         motor, composite_heuristics=False)
     qtbot.addWidget(panel)
+    check_hint_panel(motor)
     check_read_panel(motor)
     check_config_panel(motor)
 

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -27,6 +27,8 @@ def launch_suite(suite):
     """Creates a main window and execs the application."""
     window = QMainWindow()
     window.setCentralWidget(suite)
+    window.setWindowTitle(suite.windowTitle())
+    window.setUnifiedTitleAndToolBarOnMac(True)
     window.show()
     logger.info("Launching application ...")
     get_qapp().exec_()

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -639,10 +639,11 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
         self._scroll_area = QtWidgets.QScrollArea()
         self._scroll_area.setAlignment(Qt.AlignTop)
-        self._scroll_area.setObjectName('_scroll_area')
+        self._scroll_area.setObjectName('scroll_area')
         self._scroll_area.setFrameShape(QtWidgets.QFrame.StyledPanel)
         self._scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self._scroll_area.setWidgetResizable(True)
+        self._scroll_area.setFrameStyle(QtWidgets.QFrame.NoFrame)
 
         super().__init__(parent=parent)
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -641,7 +641,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         self._scroll_area.setAlignment(Qt.AlignTop)
         self._scroll_area.setObjectName('_scroll_area')
         self._scroll_area.setFrameShape(QtWidgets.QFrame.StyledPanel)
-        self._scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
+        self._scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self._scroll_area.setWidgetResizable(True)
 
         super().__init__(parent=parent)

--- a/typhos/ui/PositionerBase.detailed.ui
+++ b/typhos/ui/PositionerBase.detailed.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>341</width>
-    <height>533</height>
+    <width>556</width>
+    <height>641</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_5">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
      <property name="toolTip">
@@ -29,6 +29,12 @@
    </item>
    <item>
     <widget class="TyphosPositionerWidget" name="TyphosPositionerWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -36,6 +42,12 @@
    </item>
    <item>
     <widget class="QTabWidget" name="signal_tab">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -69,12 +81,6 @@
      <property name="documentMode">
       <bool>false</bool>
      </property>
-     <property name="tabsClosable">
-      <bool>false</bool>
-     </property>
-     <property name="movable">
-      <bool>false</bool>
-     </property>
      <property name="tabBarAutoHide">
       <bool>false</bool>
      </property>
@@ -82,7 +88,7 @@
       <attribute name="title">
        <string>Normal</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QHBoxLayout" name="misc_tab_layout">
        <property name="leftMargin">
         <number>2</number>
        </property>
@@ -111,11 +117,11 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>305</width>
+            <width>520</width>
             <height>215</height>
            </rect>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_4">
+          <layout class="QVBoxLayout" name="verticalLayout">
            <property name="leftMargin">
             <number>2</number>
            </property>
@@ -133,6 +139,14 @@
              <property name="toolTip">
               <string/>
              </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
              <property name="showNormal" stdset="0">
               <bool>true</bool>
              </property>
@@ -143,6 +157,19 @@
               <bool>false</bool>
              </property>
             </widget>
+           </item>
+           <item>
+            <spacer name="normal_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>
@@ -188,8 +215,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>98</width>
-            <height>28</height>
+            <width>520</width>
+            <height>215</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -207,6 +234,12 @@
            </property>
            <item>
             <widget class="TyphosSignalPanel" name="config_panel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="toolTip">
               <string/>
              </property>
@@ -226,82 +259,18 @@
              </property>
             </widget>
            </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="misc_tab">
-      <attribute name="title">
-       <string>Miscellaneous</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="misc_tab_layout">
-       <property name="leftMargin">
-        <number>2</number>
-       </property>
-       <property name="topMargin">
-        <number>2</number>
-       </property>
-       <property name="rightMargin">
-        <number>2</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
-       <item>
-        <widget class="QScrollArea" name="misc_scroll">
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="misc_widget">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>98</width>
-            <height>28</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <property name="leftMargin">
-            <number>2</number>
-           </property>
-           <property name="topMargin">
-            <number>2</number>
-           </property>
-           <property name="rightMargin">
-            <number>2</number>
-           </property>
-           <property name="bottomMargin">
-            <number>2</number>
-           </property>
            <item>
-            <widget class="TyphosSignalPanel" name="misc_panel">
-             <property name="toolTip">
-              <string/>
+            <spacer name="config_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
              </property>
-             <property name="whatsThis">
-              <string>
-    Panel of Signals for Device
-    </string>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
              </property>
-             <property name="showHints" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showNormal" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showConfig" stdset="0">
-              <bool>false</bool>
-             </property>
-            </widget>
+            </spacer>
            </item>
           </layout>
          </widget>

--- a/typhos/ui/detailed_screen.ui
+++ b/typhos/ui/detailed_screen.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="form_layout">
    <item>
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
      <property name="toolTip">
@@ -30,8 +30,14 @@
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="TyphosSignalPanel" name="read_panel">
+   <item alignment="Qt::AlignTop">
+    <widget class="TyphosSignalPanel" name="hint_panel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
@@ -39,6 +45,9 @@
       <string>
     Panel of Signals for Device
     </string>
+     </property>
+     <property name="showNormal" stdset="0">
+      <bool>false</bool>
      </property>
      <property name="showConfig" stdset="0">
       <bool>false</bool>
@@ -48,7 +57,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item alignment="Qt::AlignTop">
     <widget class="QTabWidget" name="signal_tab">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
@@ -92,6 +101,99 @@
      <property name="tabBarAutoHide">
       <bool>false</bool>
      </property>
+     <widget class="QWidget" name="normal_tab">
+      <attribute name="title">
+       <string>Normal</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="misc_tab_layout">
+       <property name="leftMargin">
+        <number>2</number>
+       </property>
+       <property name="topMargin">
+        <number>2</number>
+       </property>
+       <property name="rightMargin">
+        <number>2</number>
+       </property>
+       <property name="bottomMargin">
+        <number>2</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="normal_scroll">
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="normal_widget">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>359</width>
+            <height>215</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>2</number>
+           </property>
+           <property name="topMargin">
+            <number>2</number>
+           </property>
+           <property name="rightMargin">
+            <number>2</number>
+           </property>
+           <property name="bottomMargin">
+            <number>2</number>
+           </property>
+           <item>
+            <widget class="TyphosSignalPanel" name="normal_panel">
+             <property name="toolTip">
+              <string/>
+             </property>
+             <property name="whatsThis">
+              <string>
+    Panel of Signals for Device
+    </string>
+             </property>
+             <property name="showHints" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showNormal" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="showConfig" stdset="0">
+              <bool>false</bool>
+             </property>
+             <property name="showOmitted" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="normal_spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="config_tab">
       <attribute name="title">
        <string>Configuration</string>
@@ -175,97 +277,7 @@
             </widget>
            </item>
            <item>
-            <spacer name="verticalSpacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="misc_tab">
-      <attribute name="title">
-       <string>Miscellaneous</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="misc_tab_layout">
-       <property name="leftMargin">
-        <number>2</number>
-       </property>
-       <property name="topMargin">
-        <number>2</number>
-       </property>
-       <property name="rightMargin">
-        <number>2</number>
-       </property>
-       <property name="bottomMargin">
-        <number>2</number>
-       </property>
-       <item>
-        <widget class="QScrollArea" name="misc_scroll">
-         <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-         </property>
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="misc_widget">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>359</width>
-            <height>215</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <property name="leftMargin">
-            <number>2</number>
-           </property>
-           <property name="topMargin">
-            <number>2</number>
-           </property>
-           <property name="rightMargin">
-            <number>2</number>
-           </property>
-           <property name="bottomMargin">
-            <number>2</number>
-           </property>
-           <item>
-            <widget class="TyphosSignalPanel" name="misc_panel">
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    Panel of Signals for Device
-    </string>
-             </property>
-             <property name="showHints" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showNormal" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="showConfig" stdset="0">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="verticalSpacer_2">
+            <spacer name="config_spacer">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>
@@ -285,6 +297,19 @@
      </widget>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -299,6 +324,11 @@
    <header>typhos.display</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>signal_tab</tabstop>
+  <tabstop>config_scroll</tabstop>
+  <tabstop>normal_scroll</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/typhos/ui/engineering_screen.ui
+++ b/typhos/ui/engineering_screen.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1070</width>
-    <height>196</height>
+    <width>662</width>
+    <height>273</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -28,7 +28,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="signal_layout" stretch="1,0,1,0,1">
+    <layout class="QHBoxLayout" name="signal_layout" stretch="1,0,1">
      <property name="spacing">
       <number>2</number>
      </property>
@@ -85,7 +85,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer">
+        <spacer name="read_spacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -156,78 +156,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QFrame" name="frame_2">
-       <property name="frameShape">
-        <enum>QFrame::VLine</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
-       </property>
-       <property name="lineWidth">
-        <number>3</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="misc_layout" stretch="0,0,1">
-       <item>
-        <widget class="QLabel" name="misc_label">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Miscellaneous</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item alignment="Qt::AlignTop">
-        <widget class="TyphosSignalPanel" name="misc_panel">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="whatsThis">
-          <string>
-    Panel of Signals for Device
-    </string>
-         </property>
-         <property name="showHints" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="showNormal" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="showConfig" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="sortBy" stdset="0">
-          <enum>TyphosSignalPanel::byName</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
+        <spacer name="config_spacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -242,6 +171,19 @@
       </layout>
      </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="frame_spacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Closes #320 
Closes #319 

Adds back some OSX fixes lost in a rebase, and removes border for the scroll area.

Previews for a BeckhoffAxis, made large enough to not show the vertical scrollbar:

Embedded positioner
-----------------------
<img width="484" alt="image" src="https://user-images.githubusercontent.com/5139267/82104071-4b5a7100-96ca-11ea-8070-f0165affc6b1.png">


Detailed screen
----------------
<img width="545" alt="image" src="https://user-images.githubusercontent.com/5139267/82104112-6a590300-96ca-11ea-89a3-ed1009d118c7.png">


Detailed positioner
--------------------
<img width="585" alt="image" src="https://user-images.githubusercontent.com/5139267/82104119-72b13e00-96ca-11ea-9fdb-4b2c8576b30d.png">


Engineering
---------------

<img width="661" alt="image" src="https://user-images.githubusercontent.com/5139267/82104127-7ba20f80-96ca-11ea-98d7-f340df621ffa.png">

Tree does not change.