### PR TITLE
FIX: Force sizeHint on widget with size as suggestion.

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -872,6 +872,12 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         self._display_widget = widget
         self._current_template = template
 
+        def size_hint(*args, **kwargs):
+            return widget.size()
+
+        # sizeHint is not defined so we suggest the widget size
+        widget.sizeHint = size_hint
+
         # We should _move_display_to_layout as soon as it is created. This
         # allow us to speed up since if the widget is too complex it takes
         # seconds to set it to the QScrollArea


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
The widget (Display) has no sizeHint assigned to it. In this case here we set a suggested sizeHint to the widget size.

Closes #304

## Screenshots (if appropriate):
```
typhos ophyd.sim.SynAxis[] ophyd.sim.SynAxis["{'name':'foo'}"]
```
Before:
![image](https://user-images.githubusercontent.com/8185425/82165506-23a20f00-986a-11ea-9dc9-23524ec0cdbf.png)

After:
<img width="1309" alt="Screen Shot 2020-05-17 at 6 10 02 PM" src="https://user-images.githubusercontent.com/8185425/82165432-da51bf80-9869-11ea-96d1-f66dc1742330.png">

```
 typhos --fake-device pcdsdevices.device_types.BeckhoffAxis[]
```
Before:
![image](https://user-images.githubusercontent.com/8185425/82165481-108f3f00-986a-11ea-839c-17ace3661682.png)

After:
![image](https://user-images.githubusercontent.com/8185425/82165438-df167380-9869-11ea-9829-b60ce9f4560a.png)

