### PR TITLE
FIX: Adjust comparison to check for None instead of general check.

### DIFF
--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -490,7 +490,7 @@ class SignalPanel(QtWidgets.QGridLayout):
             item = self.itemAtPosition(row, col)
             if item:
                 widget = item.widget()
-                if widget:
+                if widget is not None:
                     widget.setVisible(visible)
 
         if not visible or info['signal'] is not None:


### PR DESCRIPTION
Take a sit as this one is going to be hard to believe...
@klauer and I chased the damn ghost widgets for a while in the past and it looked like it was because of multiple calls to the creation of the widgets.
After noticing them back when switching templates or refreshing templates via the display settings menu I decided to go after this hunt again.

## Steps to reproduce the issue
- Start a SimDetector
- typhos ophyd.areadetector.SimDetector['{"name":"camera", "prefix":"13SIM1:"}']
- Click at the Display Settings... and select Refresh Templates.
- Notice now the ghost widgets appearing without label or readback.

![image](https://user-images.githubusercontent.com/8185425/82408034-8ab4f480-9a1f-11ea-9f65-859458bd1ce8.png)

Interestingly, this does not happen with a Fake device:
- typhos --fake ophyd.areadetector.SimDetector['{"name":"camera", "prefix":"13SIM1:"}']

## Description

While testing I was being lead to believe that it was due to the fact that kind was different at component from when the signal was instantiated but this was a red herring.

In fact for my surprise the issue was on the fact that TyphosLabel and TyphosCombobox have different behavior when compared on an if statement.

Here is what I mean:

```ipython

In [1]: from typhos.widgets import TyphosLabel, TyphosComboBox
In [2]: label = TyphosLabel()
In [3]: combo = TyphosComboBox()
In [4]: def test(widget):
   ...:     if widget:
   ...:         return True
   ...:     return False
   ...:

In [5]: test(label)
Out[5]: True

In [6]: test(combo)
Out[6]: False
```

## How Has This Been Tested?
Locally

## Where Has This Been Documented?
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/8185425/82408275-2181b100-9a20-11ea-86d9-a782842d69ff.png)
