### PR TITLE
ENH: Drop loading gif after a certain timeout.

### DIFF
--- a/typhos/ui/style.qss
+++ b/typhos/ui/style.qss
@@ -83,3 +83,7 @@ QLineEdit#menu_action {
     border-style: outset;
     border-color: black;
 }
+
+TyphosLoading {
+    color: red;
+}

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -166,24 +166,25 @@ def random_color():
 
 
 class TyphosLoading(QtWidgets.QLabel):
+    """
+    A QLabel with an animation for loading status.
+
+    Attributes
+    ----------
+    LOADING_TIMEOUT_MS : int
+        The timeout value in milliseconds for when to stop the animation
+        and replace it with a default timeout message.
+
+    Parameters
+    ----------
+    enable_timeout : bool
+        Whether or not to stop the animation after a timeout value.
+    """
     LOADING_TIMEOUT_MS = 10000
     loading_gif = None
-    """Simple widget that displays a loading GIF"""
+
     def __init__(self, enable_timeout=True, *args, **kwargs):
-        """
-        A QLabel with an animation for loading status.
 
-        Attributes
-        ----------
-        LOADING_TIMEOUT_MS : int
-            The timeout value in milliseconds for when to stop the animation
-            and replace it with a default timeout message.
-
-        Parameters
-        ----------
-        enable_timeout : bool
-            Whether or not to stop the animation after a timeout value.
-        """
         super().__init__(*args, **kwargs)
         self._icon_size = QSize(32, 32)
         if TyphosLoading.loading_gif is None:

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -198,7 +198,6 @@ class TyphosLoading(QtWidgets.QLabel):
         self._animation.stop()
         self.setMovie(None)
         self.setText("Loading Timeout")
-        self.setStyleSheet("color: red;")
         self.setToolTip("Could not complete operation after "
                         f"{self.LOADING_TIMEOUT_MS/1000} seconds.")
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -175,15 +175,11 @@ class TyphosLoading(QtWidgets.QLabel):
         The timeout value in milliseconds for when to stop the animation
         and replace it with a default timeout message.
 
-    Parameters
-    ----------
-    enable_timeout : bool
-        Whether or not to stop the animation after a timeout value.
     """
     LOADING_TIMEOUT_MS = 10000
     loading_gif = None
 
-    def __init__(self, enable_timeout=True, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
 
         super().__init__(*args, **kwargs)
         self._icon_size = QSize(32, 32)
@@ -194,7 +190,7 @@ class TyphosLoading(QtWidgets.QLabel):
         self._animation.setScaledSize(self._icon_size)
         self.setMovie(self._animation)
         self._animation.start()
-        if enable_timeout:
+        if self.LOADING_TIMEOUT_MS > 0:
             QtCore.QTimer.singleShot(self.LOADING_TIMEOUT_MS,
                                      self._handle_timeout)
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -166,9 +166,24 @@ def random_color():
 
 
 class TyphosLoading(QtWidgets.QLabel):
+    LOADING_TIMEOUT_MS = 10000
     loading_gif = None
     """Simple widget that displays a loading GIF"""
-    def __init__(self, *args, **kwargs):
+    def __init__(self, enable_timeout=True, *args, **kwargs):
+        """
+        A QLabel with an animation for loading status.
+
+        Attributes
+        ----------
+        LOADING_TIMEOUT_MS : int
+            The timeout value in milliseconds for when to stop the animation
+            and replace it with a default timeout message.
+
+        Parameters
+        ----------
+        enable_timeout : bool
+            Whether or not to stop the animation after a timeout value.
+        """
         super().__init__(*args, **kwargs)
         self._icon_size = QSize(32, 32)
         if TyphosLoading.loading_gif is None:
@@ -178,6 +193,17 @@ class TyphosLoading(QtWidgets.QLabel):
         self._animation.setScaledSize(self._icon_size)
         self.setMovie(self._animation)
         self._animation.start()
+        if enable_timeout:
+            QtCore.QTimer.singleShot(self.LOADING_TIMEOUT_MS,
+                                     self._handle_timeout)
+
+    def _handle_timeout(self):
+        self._animation.stop()
+        self.setMovie(None)
+        self.setText("Loading Timeout")
+        self.setStyleSheet("color: red;")
+        self.setToolTip("Could not complete operation after "
+                        f"{self.LOADING_TIMEOUT_MS/1000} seconds.")
 
     @property
     def iconSize(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add a `LOADING_TIMEOUT_MS` and `enable_timeout` options at `TyphosLoading` widget.

## Motivation and Context
Closes https://github.com/pcdshub/typhos/issues/258

## How Has This Been Tested?
Locally

## Where Has This Been Documented?
Docstrings

## Screenshots (if appropriate):
![timeout](https://user-images.githubusercontent.com/8185425/82475437-596d1080-9a81-11ea-828a-e81e36532541.gif)
