### PR TITLE
MNT: positioner widget set timeouts

### DIFF
--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -21,6 +21,10 @@ class SimMotor(SynAxis):
     # TODO: fix upstream - Mock interferes with @required_for_connection
     stop._required_for_connection = False
 
+    # PositionerBase has a timeout arg, SynAxis does not
+    def set(self, value, timeout=None):
+        return super().set(value)
+
 
 @pytest.fixture(scope='function')
 def motor_widget(qtbot):

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -410,6 +410,24 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
     def high_limit_travel_attribute(self, value):
         self._high_limit_travel_attr = value
 
+    @QtCore.Property(str, designable=True)
+    def velocity_attribute(self):
+        """The attribute name for the velocity signal."""
+        return self._velocity_attr
+
+    @velocity_attribute.setter
+    def velocity_attribute(self, value):
+        self._velocity_attr = value
+
+    @QtCore.Property(str, designable=True)
+    def acceleration_attribute(self):
+        """The attribute name for the acceleration time signal."""
+        return self._acceleration_attr
+
+    @acceleration_attribute.setter
+    def acceleration_attribute(self, value):
+        self._acceleration_attr = value
+
     def move_changed(self):
         """Called when a move is begun"""
         logger.debug("Begin showing move in TyphosPositionerWidget")

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import math
 import operator
 import os.path
 
@@ -133,6 +134,8 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
     _high_limit_switch_attr = 'high_limit_switch'
     _low_limit_travel_attr = 'low_limit_travel'
     _high_limit_travel_attr = 'high_limit_travel'
+    _velocity_attr = 'velocity'
+    _acceleration_attr = 'acceleration'
     _min_visible_operation = 0.1
 
     def __init__(self, parent=None):
@@ -168,13 +171,35 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
         thread.status_finished.connect(self._status_finished)
         thread.start()
 
+    def _get_timeout(self, value, settle_time):
+        """Use positioner's configuration to select a timeout."""
+        pos_sig = getattr(self.device, self._readback_attr, None)
+        vel_sig = getattr(self.device, self._velocity_attr, None)
+        acc_sig = getattr(self.device, self._acceleration_attr, None)
+        # Not enough info == no timeout
+        if pos_sig is None or vel_sig is None:
+            return math.inf
+        delta = abs(pos_sig.get() - value)
+        speed = vel_sig.get()
+        # Bad speed == no timeout
+        if speed == 0:
+            return math.inf
+        # Bad acceleration == ignore acceleration
+        if acc_sig is None:
+            acc_time = 0
+        else:
+            acc_time = acc_sig.get()
+        # This time is always greater than the kinematic calc
+        return delta/speed + 2 * acc_time + abs(settle_time)
+
     def _set(self, value):
         """Inner `set` routine - call device.set() and monitor the status."""
         self._clear_status_thread()
         self._last_move = None
 
         logger.debug("Setting device %r to %r", self.device, value)
-        status = self.device.set(float(value))
+        timeout = self._get_timeout(value, 5)
+        status = self.device.set(float(value), timeout=timeout)
         self._start_status_thread(status)
 
     @QtCore.Slot()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use current position, velocity, and acceleration signals to pick a motion timeout value of an appropriate size.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Slow moving motors hit a default timeout of 10s at some point in the call stack. This raises the `WaitTimeout` error in the screen, confusing users. This is a straightforward way to define a timeout that is "high enough" to not trip unless there is a problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I haven't tested this yet

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings only
<!--
## Screenshots (if appropriate):
-->
