### PR TITLE
MNT: contingency for error in selecting timeout

### DIFF
--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -199,7 +199,12 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
         self._last_move = None
         set_position = float(value)
 
-        timeout = self._get_timeout(set_position, 5)
+        try:
+            timeout = self._get_timeout(set_position, 5)
+        except Exception:
+            # Something went wrong, just run without a timeout.
+            logger.exception('Unable to estimate motor timeout.')
+            timeout = math.inf
         logger.debug("Setting device %r to %r with timeout %r",
                      self.device, value, timeout)
         # Send timeout through thread because status timeout stops the move


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
If something goes wrong in the determination of the timeout, let the user know but do not stop the move.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The timeout determination isn't strictly necessary for the screen to start motion. The user should know that something has gone wrong, but should not be penalized by a non-move.