### PR TITLE
Variety metadata + test IOC

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,9 +19,13 @@
 #
 import os
 import sys
+
+from datetime import datetime
+
 import sphinx_rtd_theme
+
 module_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),'../../')
-sys.path.insert(0,module_path)
+sys.path.insert(0, module_path)
 
 
 # -- General configuration ------------------------------------------------
@@ -58,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Typhos'
-copyright = '2017, SLAC National Accelerator Laboratory'
+copyright = f'{datetime.now().year}, SLAC National Accelerator Laboratory'
 author = 'SLAC National Accelerator Laboratory'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -71,25 +71,49 @@ Functions and Methods
 Miscellaneous
 =============
 
-.. autoclass:: typhos.widgets.TogglePanel
+.. autoclass:: typhos.widgets.ClickableBitIndicator
    :members:
 
-.. autoclass:: typhos.widgets.TyphosComboBox
-   :members:
-
-.. autoclass:: typhos.widgets.TyphosLineEdit
-   :members:
-
-.. autoclass:: typhos.widgets.TyphosLabel
-   :members:
-
-.. autoclass:: typhos.widgets.TyphosSidebarItem
+.. autoclass:: typhos.widgets.ImageDialogButton
    :members:
 
 .. autoclass:: typhos.widgets.SignalDialogButton
    :members:
 
-.. autoclass:: typhos.widgets.ImageDialogButton
+.. autoclass:: typhos.widgets.SubDisplay
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosArrayTable
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosByteIndicator
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosByteSetpoint
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosComboBox
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosCommandButton
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosCommandEnumButton
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosLabel
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosLineEdit
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosScalarRange
+   :members:
+
+.. autoclass:: typhos.widgets.TyphosSidebarItem
+   :members:
+
+.. autoclass:: typhos.textedit.TyphosTextEdit
    :members:
 
 .. autoclass:: typhos.widgets.WaveformDialogButton

--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -113,6 +113,9 @@ Miscellaneous
 .. autoclass:: typhos.widgets.TyphosSidebarItem
    :members:
 
+.. autoclass:: typhos.tweakable.TyphosTweakable
+   :members:
+
 .. autoclass:: typhos.textedit.TyphosTextEdit
    :members:
 

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -12,11 +12,22 @@ from pcdsdevices.variety import set_metadata
 class Variants(ophyd.Device):
     soft_delta = Cpt(ophyd.Signal, value=1)
 
-    tweakable_delta_source = Cpt(EpicsSignal, 'tweakable')
+    tweakable_delta_source_by_name = Cpt(EpicsSignal, 'tweakable')
     set_metadata(
-        tweakable_delta_source,
+        tweakable_delta_source_by_name,
         {'variety': 'scalar-tweakable',
          'delta.signal': 'soft_delta',
+         'delta.source': 'signal',
+         'range.source': 'value',
+         'range.value': [-10, 10],
+         }
+    )
+
+    tweakable_delta_source_by_component = Cpt(EpicsSignal, 'tweakable')
+    set_metadata(
+        tweakable_delta_source_by_component,
+        {'variety': 'scalar-tweakable',
+         'delta.signal': soft_delta,
          'delta.source': 'signal',
          'range.source': 'value',
          'range.value': [-10, 10],

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -36,14 +36,18 @@ class Variants(ophyd.Device):
 
 
 class MyDevice(ophyd.Device):
-    command = Cpt(EpicsSignal, 'command')
+    command = Cpt(EpicsSignal, 'command-with-enum')
     set_metadata(command, {'variety': 'command'})
 
-    command_proc = Cpt(EpicsSignal, 'command-proc')
+    command_proc = Cpt(EpicsSignal, 'command-without-enum')
     set_metadata(command_proc, {'variety': 'command-proc'})
 
-    command_enum = Cpt(EpicsSignal, 'command-enum')
-    set_metadata(command_enum, {'variety': 'command-enum'})
+    command_enum = Cpt(EpicsSignal, 'command-without-enum')
+    set_metadata(command_enum,
+                 {'variety': 'command-enum',
+                  'enum_dict': {0: 'No', 1: 'Yes', 3: 'Metadata-defined'},
+                  }
+                 )
 
     command_setpoint_tracks_readback = Cpt(EpicsSignal,
                                            'command-setpoint-tracks-readback')
@@ -116,9 +120,11 @@ class MyDevice(ophyd.Device):
 class VarietyIOC(PVGroup):
     """
     """
-    command = pvproperty(value=0, name='command')
-    command_proc = pvproperty(value=0, name='command-proc')
-    command_enum = pvproperty(value=0, name='command-enum')
+    command_without_enum = pvproperty(value=0, name='command-without-enum')
+    command_with_enum = pvproperty(value=0, name='command-with-enum',
+                                   enum_strings=['Off', 'On'],
+                                   dtype=caproto.ChannelType.ENUM)
+
     command_setpoint_tracks_readback = pvproperty(
         value=0, name='command-setpoint-tracks-readback')
     tweakable = pvproperty(value=0, name='tweakable',

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -25,7 +25,15 @@ class MyDevice(ophyd.Device):
                  {'variety': 'command-setpoint-tracks-readback'})
 
     tweakable = Cpt(EpicsSignal, 'tweakable')
-    set_metadata(tweakable, {'variety': 'tweakable', 'delta': 0.5})
+    set_metadata(
+        tweakable,
+        {'variety': 'scalar-tweakable',
+         'delta.value': 0.5,
+         'delta.range': [-1, 1],
+         'range.source': 'value',
+         'range.value': [-1, 1],
+         }
+    )
 
     array_timeseries = Cpt(EpicsSignal, 'array-timeseries')
     set_metadata(array_timeseries, {'variety': 'array-timeseries'})
@@ -34,10 +42,20 @@ class MyDevice(ophyd.Device):
     set_metadata(array_histogram, {'variety': 'array-histogram'})
 
     array_image = Cpt(EpicsSignal, 'array-image')
-    set_metadata(array_image, {'variety': 'array-image'})
+    set_metadata(
+        array_image,
+        {'variety': 'array-image',
+         'shape': (32, 32)
+         }
+    )
 
     array_nd = Cpt(EpicsSignal, 'array-nd')
-    set_metadata(array_nd, {'variety': 'array-nd'})
+    set_metadata(
+        array_nd,
+        {'variety': 'array-nd',
+         'shape': (16, 16, 4)
+         }
+    )
 
     scalar = Cpt(EpicsSignal, 'scalar')
     set_metadata(scalar, {'variety': 'scalar'})
@@ -48,13 +66,13 @@ class MyDevice(ophyd.Device):
     bitmask = Cpt(EpicsSignal, 'bitmask')
     set_metadata(bitmask, {'variety': 'bitmask'})
 
-    text = Cpt(EpicsSignal, 'text')
+    text = Cpt(EpicsSignal, 'text', string=True)
     set_metadata(text, {'variety': 'text'})
 
-    text_multiline = Cpt(EpicsSignal, 'text-multiline')
+    text_multiline = Cpt(EpicsSignal, 'text-multiline', string=True)
     set_metadata(text_multiline, {'variety': 'text-multiline'})
 
-    text_enum = Cpt(EpicsSignal, 'text-enum')
+    text_enum = Cpt(EpicsSignal, 'text-enum', string=True)
     set_metadata(text_enum, {'variety': 'text-enum'})
 
     enum = Cpt(EpicsSignal, 'enum')
@@ -69,13 +87,20 @@ class VarietyIOC(PVGroup):
     command_enum = pvproperty(value=0, name='command-enum')
     command_setpoint_tracks_readback = pvproperty(
         value=0, name='command-setpoint-tracks-readback')
-    tweakable = pvproperty(value=0, name='tweakable')
+    tweakable = pvproperty(value=0, name='tweakable',
+                           lower_ctrl_limit=-5,
+                           upper_ctrl_limit=5,
+                           )
     array_timeseries = pvproperty(value=[0.5] * 30, name='array-timeseries')
     array_histogram = pvproperty(value=[0.5] * 30, name='array-histogram')
     array_image = pvproperty(value=[200] * 1024, name='array-image')
     array_nd = pvproperty(value=[200] * 1024, name='array-nd')
     scalar = pvproperty(value=1.2, name='scalar')
-    scalar_range = pvproperty(value=1.3, name='scalar-range')
+    scalar_range = pvproperty(value=1.3, name='scalar-range',
+                              lower_ctrl_limit=-3.14,
+                              upper_ctrl_limit=3.14,
+                              precision=3,
+                              )
     bitmask = pvproperty(value=0, name='bitmask')
     text = pvproperty(value='the text', name='text')
     text_multiline = pvproperty(value='multiline\ntext', name='text-multiline')

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -90,7 +90,11 @@ class MyDevice(ophyd.Device):
     set_metadata(scalar_range, {'variety': 'scalar-range'})
 
     bitmask = Cpt(EpicsSignal, 'bitmask')
-    set_metadata(bitmask, {'variety': 'bitmask'})
+    set_metadata(bitmask, {'variety': 'bitmask',
+                           'style': dict(shape='circle',
+                                         on_color='yellow',
+                                         off_color='white')
+                           })
 
     text = Cpt(EpicsSignal, 'text', string=True)
     set_metadata(text, {'variety': 'text'})

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -9,6 +9,21 @@ from ophyd import EpicsSignal
 from pcdsdevices.variety import set_metadata
 
 
+class Variants(ophyd.Device):
+    soft_delta = Cpt(ophyd.Signal, value=1)
+
+    tweakable_delta_source = Cpt(EpicsSignal, 'tweakable')
+    set_metadata(
+        tweakable_delta_source,
+        {'variety': 'scalar-tweakable',
+         'delta.signal': 'soft_delta',
+         'delta.source': 'signal',
+         'range.source': 'value',
+         'range.value': [-10, 10],
+         }
+    )
+
+
 class MyDevice(ophyd.Device):
     command = Cpt(EpicsSignal, 'command')
     set_metadata(command, {'variety': 'command'})
@@ -77,6 +92,8 @@ class MyDevice(ophyd.Device):
 
     enum = Cpt(EpicsSignal, 'enum')
     set_metadata(enum, {'variety': 'enum'})
+
+    variants = Cpt(Variants, '')
 
 
 class VarietyIOC(PVGroup):

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -1,0 +1,93 @@
+from textwrap import dedent
+
+import caproto
+from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
+
+import ophyd
+from ophyd import Component as Cpt
+from ophyd import EpicsSignal
+from pcdsdevices.variety import set_metadata
+
+
+class MyDevice(ophyd.Device):
+    command = Cpt(EpicsSignal, 'command')
+    set_metadata(command, {'variety': 'command'})
+
+    command_proc = Cpt(EpicsSignal, 'command-proc')
+    set_metadata(command_proc, {'variety': 'command-proc'})
+
+    command_enum = Cpt(EpicsSignal, 'command-enum')
+    set_metadata(command_enum, {'variety': 'command-enum'})
+
+    command_setpoint_tracks_readback = Cpt(EpicsSignal,
+                                           'command-setpoint-tracks-readback')
+    set_metadata(command_setpoint_tracks_readback,
+                 {'variety': 'command-setpoint-tracks-readback'})
+
+    tweakable = Cpt(EpicsSignal, 'tweakable')
+    set_metadata(tweakable, {'variety': 'tweakable', 'delta': 0.5})
+
+    array_timeseries = Cpt(EpicsSignal, 'array-timeseries')
+    set_metadata(array_timeseries, {'variety': 'array-timeseries'})
+
+    array_histogram = Cpt(EpicsSignal, 'array-histogram')
+    set_metadata(array_histogram, {'variety': 'array-histogram'})
+
+    array_image = Cpt(EpicsSignal, 'array-image')
+    set_metadata(array_image, {'variety': 'array-image'})
+
+    array_nd = Cpt(EpicsSignal, 'array-nd')
+    set_metadata(array_nd, {'variety': 'array-nd'})
+
+    scalar = Cpt(EpicsSignal, 'scalar')
+    set_metadata(scalar, {'variety': 'scalar'})
+
+    scalar_range = Cpt(EpicsSignal, 'scalar-range')
+    set_metadata(scalar_range, {'variety': 'scalar-range'})
+
+    bitmask = Cpt(EpicsSignal, 'bitmask')
+    set_metadata(bitmask, {'variety': 'bitmask'})
+
+    text = Cpt(EpicsSignal, 'text')
+    set_metadata(text, {'variety': 'text'})
+
+    text_multiline = Cpt(EpicsSignal, 'text-multiline')
+    set_metadata(text_multiline, {'variety': 'text-multiline'})
+
+    text_enum = Cpt(EpicsSignal, 'text-enum')
+    set_metadata(text_enum, {'variety': 'text-enum'})
+
+    enum = Cpt(EpicsSignal, 'enum')
+    set_metadata(enum, {'variety': 'enum'})
+
+
+class VarietyIOC(PVGroup):
+    """
+    """
+    command = pvproperty(value=0, name='command')
+    command_proc = pvproperty(value=0, name='command-proc')
+    command_enum = pvproperty(value=0, name='command-enum')
+    command_setpoint_tracks_readback = pvproperty(
+        value=0, name='command-setpoint-tracks-readback')
+    tweakable = pvproperty(value=0, name='tweakable')
+    array_timeseries = pvproperty(value=[0.5] * 30, name='array-timeseries')
+    array_histogram = pvproperty(value=[0.5] * 30, name='array-histogram')
+    array_image = pvproperty(value=[200] * 1024, name='array-image')
+    array_nd = pvproperty(value=[200] * 1024, name='array-nd')
+    scalar = pvproperty(value=1.2, name='scalar')
+    scalar_range = pvproperty(value=1.3, name='scalar-range')
+    bitmask = pvproperty(value=0, name='bitmask')
+    text = pvproperty(value='the text', name='text')
+    text_multiline = pvproperty(value='multiline\ntext', name='text-multiline')
+    text_enum = pvproperty(value='enum value 0', name='text-enum')
+    enum = pvproperty(
+        value='enum1', enum_strings=['enum1', 'enum2'],
+        dtype=caproto.ChannelType.ENUM, name='enum')
+
+
+if __name__ == '__main__':
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='variety:',
+        desc=dedent(VarietyIOC.__doc__))
+    ioc = VarietyIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -37,7 +37,12 @@ class Variants(ophyd.Device):
 
 class MyDevice(ophyd.Device):
     command = Cpt(EpicsSignal, 'command-with-enum')
-    set_metadata(command, {'variety': 'command'})
+    set_metadata(command,
+                 {'variety': 'command',
+                  'tags': {'confirm', 'protected'},
+                  'value': 1,
+                  }
+                 )
 
     command_proc = Cpt(EpicsSignal, 'command-without-enum')
     set_metadata(command_proc, {'variety': 'command-proc'})

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -34,6 +34,14 @@ class Variants(ophyd.Device):
          }
     )
 
+    array_tabular = Cpt(EpicsSignal, 'array-tabular')
+    set_metadata(
+        array_tabular,
+        {'variety': 'array-tabular',
+         'shape': (3, 3),
+         }
+    )
+
 
 class MyDevice(ophyd.Device):
     command = Cpt(EpicsSignal, 'command-with-enum')
@@ -136,6 +144,7 @@ class VarietyIOC(PVGroup):
                            lower_ctrl_limit=-5,
                            upper_ctrl_limit=5,
                            )
+    array_tabular = pvproperty(value=[1.5] * (3 * 3), name='array-tabular')
     array_timeseries = pvproperty(value=[0.5] * 30, name='array-timeseries')
     array_histogram = pvproperty(value=[0.5] * 30, name='array-histogram')
     array_image = pvproperty(value=[200] * 1024, name='array-image')

--- a/tests/variety_ioc.py
+++ b/tests/variety_ioc.py
@@ -91,9 +91,11 @@ class MyDevice(ophyd.Device):
 
     bitmask = Cpt(EpicsSignal, 'bitmask')
     set_metadata(bitmask, {'variety': 'bitmask',
+                           'bits': 4,
                            'style': dict(shape='circle',
                                          on_color='yellow',
-                                         off_color='white')
+                                         off_color='white'),
+                           'meaning': ['A', 'B', 'C'],
                            })
 
     text = Cpt(EpicsSignal, 'text', string=True)

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -8,8 +8,6 @@ import time
 
 from qtpy import QtCore
 
-import ophyd
-
 from . import utils
 from .widgets import SignalWidgetInfo
 
@@ -87,13 +85,6 @@ class _GlobalDescribeCache(QtCore.QObject):
     def _describe(self, obj):
         """Retrieve the description of ``obj``."""
         try:
-            if isinstance(obj, ophyd.NDDerivedSignal):
-                # Force initial value readout otherwise _readback was never
-                # set and that causes issues with more complex describe
-                # types such as DerivedSignal and NDDerivedSignal.
-                # TODO: This is a temporary fix and must be removed once
-                #       https://github.com/bluesky/ophyd/pull/858 is merged
-                obj.get()
             return obj.describe()[obj.name]
         except Exception:
             logger.error("Unable to connect to %r during widget creation",

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -2,7 +2,7 @@
 
 import enum
 import logging
-import os.path
+import os
 import pathlib
 
 from qtpy import QtCore, QtGui, QtWidgets
@@ -323,6 +323,11 @@ class TyphosDisplayConfigButton(TyphosToolButton):
 
         base_menu.addSeparator()
         self.create_hide_empty_menu(panels, base_menu)
+
+        if utils.DEBUG_MODE:
+            base_menu.addSection('Debug')
+            action = base_menu.addAction('&Copy to clipboard')
+            action.triggered.connect(display.copy_to_clipboard)
 
         return base_menu
 
@@ -1135,6 +1140,26 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                 device_cls, 'detailed', utils.DISPLAY_PATHS)
             if not utils.is_standard_template(template)
         ]
+
+    def to_image(self):
+        """
+        Return the entire display as a QtGui.QImage.
+
+        Returns
+        -------
+        QtGui.QImage
+            The display, as an image.
+        """
+        if self._display_widget is not None:
+            return utils.widget_to_image(self._display_widget)
+
+    @Slot()
+    def copy_to_clipboard(self):
+        """Copy the display image to the clipboard."""
+        image = self.to_image()
+        if image is not None:
+            clipboard = QtGui.QGuiApplication.clipboard()
+            clipboard.setImage(image)
 
     @Slot(object)
     def _tx(self, value):

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -207,9 +207,6 @@ class SignalPanel(QtWidgets.QGridLayout):
         sig_info['widget_info'] = info
         row = sig_info['row']
 
-        read = info.read_cls(**info.read_kwargs)
-        write = info.write_cls(**info.write_kwargs) if info.write_cls else None
-
         # Remove the 'loading...' animation if it's there
         item = self.itemAtPosition(row, self.COL_SETPOINT)
         if item:
@@ -218,10 +215,12 @@ class SignalPanel(QtWidgets.QGridLayout):
                 self.removeItem(item)
                 val_widget.deleteLater()
 
-        # And add the new widgets to the layout:
-        widgets = [None, read]
-        if write is not None:
-            widgets += [write]
+        widgets = [None]
+        if info.read_cls is not None:
+            widgets.append(info.read_cls(**info.read_kwargs))
+
+        if info.write_cls is not None:
+            widgets.append(info.write_cls(**info.write_kwargs))
 
         self._update_row(row, widgets)
 

--- a/typhos/textedit.py
+++ b/typhos/textedit.py
@@ -1,0 +1,115 @@
+import logging
+
+import numpy as np
+from qtpy import QtWidgets
+
+from pydm.widgets.base import PyDMWritableWidget
+
+from .variety import use_for_variety_write
+
+logger = logging.getLogger(__name__)
+
+
+@use_for_variety_write('text-multiline')
+class TyphosTextEdit(QtWidgets.QWidget, PyDMWritableWidget):
+    """
+    A writable, multiline text editor with support for PyDM Channels.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget.
+
+    init_channel : str, optional
+        The channel to be used by the widget.
+    """
+
+    def __init__(self, parent=None, init_channel=None):
+        QtWidgets.QWidget.__init__(self, parent)
+        PyDMWritableWidget.__init__(self, init_channel=init_channel)
+        # superclasses do *not* support cooperative init:
+        # super().__init__(self, parent=parent, init_channel=init_channel)
+        self._display = None
+        self._scale = 1
+
+        self._setup_ui()
+        self._string_encoding = "utf_8"
+
+    def _setup_ui(self):
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        self._text_edit = QtWidgets.QTextEdit()
+        self._send_button = QtWidgets.QPushButton('Send')
+        self._send_button.clicked.connect(self._send_clicked)
+
+        self._revert_button = QtWidgets.QPushButton('Revert')
+        self._revert_button.clicked.connect(self._revert_clicked)
+
+        self._button_layout = QtWidgets.QHBoxLayout()
+
+        self._button_layout.addWidget(self._revert_button)
+        self._button_layout.addWidget(self._send_button)
+
+        layout.addWidget(self._text_edit)
+        layout.addLayout(self._button_layout)
+
+    def _revert_clicked(self):
+        self._set_text(self._display)
+
+    def _send_clicked(self):
+        self.send_value()
+
+    def value_changed(self, value):
+        """Receive and update the TyphosTextEdit for a new channel value."""
+        super().value_changed(self._from_wire(value))
+        self.set_display()
+
+    def _to_wire(self, text=None):
+        """TextEdit text -> numpy array."""
+        if text is None:
+            # text-format: toMarkdown, toHtml
+            text = self._text_edit.toPlainText()
+        return np.array(list(text.encode(self._string_encoding)),
+                        dtype=np.uint8)
+
+    def _from_wire(self, value):
+        """numpy array/string/bytes -> string."""
+        if isinstance(value, (list, np.ndarray)):
+            return bytes(value).decode(self._string_encoding)
+        return value
+
+    def _set_text(self, text):
+        return self._text_edit.setText(text)
+
+    def send_value(self):
+        """Emit a :attr:`send_value_signal` to update channel value."""
+        send_value = self._to_wire()
+
+        try:
+            self.send_value_signal[np.ndarray].emit(send_value)
+        except ValueError:
+            logger.exception(
+                "send_value error %r with type %r and format %r (widget %r).",
+                send_value, self.channeltype, self._display_format_type,
+                self.objectName()
+            )
+
+        self._text_edit.document().setModified(False)
+
+    def write_access_changed(self, new_write_access):
+        """
+        Change the TyphosTextEdit to read only if write access is denied
+        """
+        super().write_access_changed(new_write_access)
+        self._text_edit.setReadOnly(not new_write_access)
+        self._send_button.setVisible(new_write_access)
+        self._revert_button.setVisible(new_write_access)
+
+    def set_display(self):
+        """Set the text display of the TyphosTextEdit."""
+        if self.value is None or self._text_edit.document().isModified():
+            return
+
+        self._display = str(self.value)
+        self._set_text(self._display)

--- a/typhos/tweakable.py
+++ b/typhos/tweakable.py
@@ -28,6 +28,9 @@ class TyphosTweakable(utils.TyphosBase):
 
     init_channel : str, optional
         The channel to be used by the widget.
+
+    Notes
+    -----
     """
 
     ui_template = utils.ui_dir / 'tweakable.ui'

--- a/typhos/tweakable.py
+++ b/typhos/tweakable.py
@@ -1,0 +1,85 @@
+"""
+Tweakable value widget.
+
+Variety support pending:
+- everything
+"""
+import logging
+
+import qtpy
+from qtpy import QtCore
+
+from . import utils, variety
+
+logger = logging.getLogger(__name__)
+
+
+@variety.uses_key_handlers
+@variety.use_for_variety_write('scalar-tweakable')
+class TyphosTweakable(utils.TyphosBase):
+    #  TODO rearrange package: widgets.TyphosDesignerMixin):
+    """
+    Widget for a tweakable scalar.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget.
+
+    init_channel : str, optional
+        The channel to be used by the widget.
+    """
+
+    ui_template = utils.ui_dir / 'tweakable.ui'
+    _readback_attr = 'readback'
+    _setpoint_attr = 'setpoint'
+
+    def __init__(self, parent=None, init_channel=None, variety_metadata=None,
+                 ophyd_signal=None):
+
+        self._ophyd_signal = ophyd_signal
+        super().__init__(parent=parent)
+
+        self.ui = qtpy.uic.loadUi(str(self.ui_template), self)
+        self.ui.readback.channel = init_channel
+        self.ui.setpoint.channel = init_channel
+        self.ui.tweak_positive.clicked.connect(self.positive_tweak)
+        self.ui.tweak_negative.clicked.connect(self.negative_tweak)
+
+        self.variety_metadata = variety_metadata
+
+    variety_metadata = variety.create_variety_property()
+
+    def _update_variety_metadata(self, *, display_format=None, **kwargs):
+        display_format = variety.get_display_format(display_format)
+        self.ui.readback.displayFormat = display_format
+        self.ui.setpoint.displayFormat = display_format
+
+        variety._warn_unhandled_kwargs(self, kwargs)
+
+    def tweak(self, offset):
+        """Tweak by the given ``offset``."""
+        try:
+            setpoint = float(self.readback.text()) + float(offset)
+        except Exception:
+            logger.exception('Tweak failed')
+            return
+
+        self.ui.setpoint.setText(str(setpoint))
+        self.ui.setpoint.send_value()
+
+    @QtCore.Slot()
+    def positive_tweak(self):
+        """Tweak positive by the amount listed in ``ui.tweak_value``"""
+        try:
+            self.tweak(float(self.tweak_value.text()))
+        except Exception:
+            logger.exception('Tweak failed')
+
+    @QtCore.Slot()
+    def negative_tweak(self):
+        """Tweak negative by the amount listed in ``ui.tweak_value``"""
+        try:
+            self.tweak(-float(self.tweak_value.text()))
+        except Exception:
+            logger.exception('Tweak failed')

--- a/typhos/ui/tweakable.ui
+++ b/typhos/ui/tweakable.ui
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>272</width>
+    <height>209</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0">
+   <property name="spacing">
+    <number>10</number>
+   </property>
+   <property name="leftMargin">
+    <number>5</number>
+   </property>
+   <property name="topMargin">
+    <number>5</number>
+   </property>
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>5</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="motion_frame">
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <layout class="QHBoxLayout" name="set_layout" stretch="0">
+      <property name="spacing">
+       <number>5</number>
+      </property>
+      <item>
+       <layout class="QVBoxLayout" name="value_layout" stretch="1,0,0,1,0,0">
+        <property name="spacing">
+         <number>10</number>
+        </property>
+        <item>
+         <widget class="PyDMLabel" name="readback">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="whatsThis">
+           <string/>
+          </property>
+          <property name="styleSheet">
+           <string notr="true"/>
+          </property>
+          <property name="text">
+           <string>readback</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="showUnits" stdset="0">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="PyDMLineEdit" name="user_setpoint">
+          <property name="maximumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="PyDMLineEdit" name="setpoint">
+          <property name="toolTip">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="tweak_layout" stretch="0,1,0">
+          <property name="spacing">
+           <number>3</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QToolButton" name="tweak_negative">
+            <property name="minimumSize">
+             <size>
+              <width>25</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>-</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="tweak_value">
+            <property name="minimumSize">
+             <size>
+              <width>60</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="tweak_positive">
+            <property name="minimumSize">
+             <size>
+              <width>25</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>+</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="status_label">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>pydm.widgets.line_edit</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -18,6 +18,7 @@ from qtpy.QtCore import QSize
 from qtpy.QtGui import QColor, QMovie, QPainter
 from qtpy.QtWidgets import QWidget
 
+import ophyd
 import ophyd.sim
 from ophyd import Device
 from ophyd.signal import EpicsSignalBase, EpicsSignalRO
@@ -1048,3 +1049,41 @@ def dump_grid_layout(layout, rows=None, cols=None, *, cell_width=60):
 def nullcontext():
     """Stand-in for py3.7's contextlib.nullcontext"""
     yield
+
+
+def get_component(obj):
+    """
+    Get the component that made the given object.
+
+    Parameters
+    ----------
+    obj : ophyd.OphydItem
+        The ophyd item for which to get the component.
+
+    Returns
+    -------
+    component : ophyd.Component
+        The component, if available.
+    """
+    return getattr(type(obj.parent), obj.attr_name)
+
+
+def get_metadata(cpt):
+    """
+    Get "variety" metadata from a component or signal.
+
+    Parameters
+    ----------
+    cpt : ophyd.Component or ophyd.OphydItem
+        The component / ophyd item to get the metadata for.
+
+    Returns
+    -------
+    metadata : dict
+        The metadata, if set. Otherwise an empty dictionary.  This metadata is
+        guaranteed to be valid according to the known schemas.
+    """
+    if not isinstance(cpt, ophyd.Component):
+        cpt = get_component(cpt)
+
+    return getattr(cpt, '_variety_metadata', {})

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -1066,7 +1066,10 @@ def get_component(obj):
     component : ophyd.Component
         The component, if available.
     """
-    return getattr(type(obj.parent), obj.attr_name)
+    if obj.parent is None:
+        return None
+
+    return getattr(type(obj.parent), obj.attr_name, None)
 
 
 def get_variety_metadata(cpt):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -1068,7 +1068,7 @@ def get_component(obj):
     return getattr(type(obj.parent), obj.attr_name)
 
 
-def get_metadata(cpt):
+def get_variety_metadata(cpt):
     """
     Get "variety" metadata from a component or signal.
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -13,7 +13,7 @@ import random
 import re
 import threading
 
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import QSize
 from qtpy.QtGui import QColor, QMovie, QPainter
 from qtpy.QtWidgets import QWidget
@@ -34,6 +34,7 @@ MODULE_PATH = pathlib.Path(__file__).parent.resolve()
 ui_dir = MODULE_PATH / 'ui'
 GrabKindItem = collections.namedtuple('GrabKindItem',
                                       ('attr', 'component', 'signal'))
+DEBUG_MODE = bool(os.environ.get('TYPHOS_DEBUG', False))
 
 
 if happi is None:
@@ -1087,3 +1088,24 @@ def get_variety_metadata(cpt):
         cpt = get_component(cpt)
 
     return getattr(cpt, '_variety_metadata', {})
+
+
+def widget_to_image(widget, fill_color=QtCore.Qt.transparent):
+    """
+    Paint the given widget in a new QtGui.QImage.
+
+    Returns
+    -------
+    QtGui.QImage
+        The display, as an image.
+    """
+    image = QtGui.QImage(widget.width(), widget.height(),
+                         QtGui.QImage.Format_ARGB32_Premultiplied)
+
+    image.fill(fill_color)
+    pixmap = QtGui.QPixmap(image)
+
+    painter = QtGui.QPainter(pixmap)
+    widget.render(image)
+    painter.end()
+    return image

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -5,6 +5,8 @@ Typhos handling of "variety" metadata and related utilities.
 import inspect
 import logging
 
+from pydm.widgets.display_format import DisplayFormat
+
 logger = logging.getLogger(__name__)
 _variety_to_widget_class = {}
 
@@ -241,3 +243,10 @@ def get_enum_strings(enum_strings, enum_dict):
                 for idx in range(max_value + 1)]
 
     return enum_strings
+
+
+def get_display_format(value):
+    """Get the display format enum value from the variety metadata value."""
+    if value is not None:
+        return getattr(DisplayFormat, value.capitalize(),
+                       DisplayFormat.Default)

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -205,7 +205,7 @@ def create_variety_property():
                 self._update_variety_metadata(**self._variety_metadata)
         except Exception:
             logger.exception('Failed to set variety metadata for class %s: %s',
-                             type(self).__name__, metadata)
+                             type(self).__name__, self._variety_metadata)
 
         # Optionally, there may be 'handlers' for individual top-level keys.
         handlers = getattr(self, '_variety_handlers', {})

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -24,7 +24,7 @@ def _warn_unhandled_kwargs(instance, kwargs):
         _warn_unhandled(instance, key, value)
 
 
-def _set_variety_key_handler(key):
+def key_handler(key):
     """
     A method wrapper to mark a specific variety metadata key with the method.
 
@@ -55,7 +55,7 @@ def _get_variety_handlers(members):
     return handlers
 
 
-def uses_variety_handler(cls):
+def uses_key_handlers(cls):
     """
     Class wrapper to finish variety handler configuration.
 
@@ -68,7 +68,7 @@ def uses_variety_handler(cls):
     return cls
 
 
-def for_variety(variety, *, read=True, write=True):
+def use_for_variety(variety, *, read=True, write=True):
     """
     A class wrapper to associate a specific variety with the class.
 
@@ -128,14 +128,14 @@ def for_variety(variety, *, read=True, write=True):
     return wrapper
 
 
-def for_variety_read(variety):
+def use_for_variety_read(variety):
     """`for_variety` shorthand for setting the readback widget class."""
-    return for_variety(variety, read=True, write=False)
+    return use_for_variety(variety, read=True, write=False)
 
 
-def for_variety_write(variety):
+def use_for_variety_write(variety):
     """`for_variety` shorthand for setting the setpoint widget class."""
-    return for_variety(variety, read=False, write=True)
+    return use_for_variety(variety, read=False, write=True)
 
 
 def _get_widget_class_from_variety(desc, variety_md, read_only):

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -152,3 +152,31 @@ def _get_widget_class_from_variety(desc, variety_md, read_only):
             logger.error('TODO no widget?: %s (%s / %s)',
                          variety_md['variety'], desc, variety_md)
         return widget_cls
+
+
+def get_referenced_signal(widget, name_or_component):
+    """
+    Get the signal referenced from metadata.
+
+    Parameters
+    ----------
+    widget : QWidget
+        The widget which holds the metadata.
+
+    name_or_component : str or ophyd.Component
+        The signal name or ophyd Component.
+    """
+    ophyd_signal = getattr(widget, 'ophyd_signal', None)
+    if ophyd_signal is None:
+        logger.error('Incorrectly configured widget (ophyd_signal unset?)')
+        return
+
+    device = ophyd_signal.parent
+    if device is None:
+        logger.debug('Cannot be used on isolated (non-Device) signal')
+        return
+
+    if hasattr(name_or_component, 'attr'):
+        name_or_component = name_or_component.attr
+
+    return getattr(device, name_or_component)

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -119,9 +119,13 @@ def use_for_variety(variety, *, read=True, write=True):
 
         if read:
             _variety_to_widget_class[variety]['read'] = cls
+            if cls.__doc__ is not None:
+                cls.__doc__ += f'\n    * Used for variety {variety} (readback)'
 
         if write:
             _variety_to_widget_class[variety]['write'] = cls
+            if cls.__doc__ is not None:
+                cls.__doc__ += f'\n    * Used for variety {variety} (setpoint)'
 
         if not read and not write:
             raise ValueError('`write` or `read` must be set.')

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -1,0 +1,154 @@
+"""
+Typhos handling of "variety" metadata and related utilities.
+"""
+
+import inspect
+import logging
+
+logger = logging.getLogger(__name__)
+_variety_to_widget_class = {}
+
+
+def _warn_unhandled(instance, metadata_key, value):
+    if value is None:
+        return
+
+    logger.warning(
+        '%s: Not yet implemented variety handling: key=%s value=%s',
+        instance.__class__.__name__, metadata_key, value
+    )
+
+
+def _warn_unhandled_kwargs(instance, kwargs):
+    for key, value in kwargs.items():
+        _warn_unhandled(instance, key, value)
+
+
+def _set_variety_key_handler(key):
+    """
+    A method wrapper to mark a specific variety metadata key with the method.
+
+    Parameters
+    ----------
+    key : str
+        The variety key (e.g., 'delta')
+    """
+
+    def wrapper(method):
+        assert callable(method)
+        if not hasattr(method, '_variety_handler'):
+            method._variety_handler_keys = set()
+        method._variety_handler_keys.add(key)
+        return method
+
+    return wrapper
+
+
+def _get_variety_handlers(members):
+    handlers = {}
+    for attr, method in members:
+        for key in getattr(method, '_variety_handler_keys', []):
+            if key not in handlers:
+                handlers[key] = [method]
+            handlers[key].append(method)
+
+    return handlers
+
+
+def uses_variety_handler(cls):
+    """
+    Class wrapper to finish variety handler configuration.
+
+    Parameters
+    ----------
+    cls : class
+        The class to wrap.
+    """
+    cls._variety_handlers = _get_variety_handlers(inspect.getmembers(cls))
+    return cls
+
+
+def for_variety(variety, *, read=True, write=True):
+    """
+    A class wrapper to associate a specific variety with the class.
+
+    Defaults to registering for both read and write widgets.
+
+    Parameters
+    ----------
+    variety : str
+        The variety (e.g., 'command')
+
+    read : bool, optional
+        Use for readback widgets
+
+    write : bool, optional
+        Use for setpoint widgets
+    """
+
+    known_varieties = {
+        'array-histogram',
+        'array-image',
+        'array-nd',
+        'array-timeseries',
+        'bitmask',
+        'command',
+        'command-enum',
+        'command-proc',
+        'command-setpoint-tracks-readback',
+        'enum',
+        'scalar',
+        'scalar-range',
+        'scalar-tweakable',
+        'text',
+        'text-enum',
+        'text-multiline',
+    }
+
+    if variety not in known_varieties:
+        # NOTE: not kept in sync with pcdsdevices; so this wrapper may need
+        # updating.
+        raise ValueError(f'Not a known variety: {variety}')
+
+    def wrapper(cls):
+        if variety not in _variety_to_widget_class:
+            _variety_to_widget_class[variety] = {}
+
+        if read:
+            _variety_to_widget_class[variety]['read'] = cls
+
+        if write:
+            _variety_to_widget_class[variety]['write'] = cls
+
+        if not read and not write:
+            raise ValueError('`write` or `read` must be set.')
+
+        return cls
+
+    return wrapper
+
+
+def for_variety_read(variety):
+    """`for_variety` shorthand for setting the readback widget class."""
+    return for_variety(variety, read=True, write=False)
+
+
+def for_variety_write(variety):
+    """`for_variety` shorthand for setting the setpoint widget class."""
+    return for_variety(variety, read=False, write=True)
+
+
+def _get_widget_class_from_variety(desc, variety_md, read_only):
+    variety = variety_md['variety']  # a required key
+    read_key = 'read' if read_only else 'write'
+    try:
+        widget_cls = _variety_to_widget_class[variety].get(read_key)
+    except KeyError:
+        logger.error('Unsupported variety: %s (%s / %s)',
+                     variety_md['variety'], desc, variety_md)
+    else:
+        if widget_cls is None:
+            # TODO: remove
+            logger.error('TODO no widget?: %s (%s / %s)',
+                         variety_md['variety'], desc, variety_md)
+        return widget_cls

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -230,3 +230,13 @@ def create_variety_property():
 
     return property(fget, fset,
                     doc='Additional component variety metadata.')
+
+
+def get_enum_strings(enum_strings, enum_dict):
+    """Get enum strings from either `enum_strings` or `enum_dict`."""
+    if enum_dict:
+        max_value = max(enum_dict)
+        return [enum_dict.get(idx, '')
+                for idx in range(max_value + 1)]
+
+    return enum_strings

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -180,3 +180,53 @@ def get_referenced_signal(widget, name_or_component):
         name_or_component = name_or_component.attr
 
     return getattr(device, name_or_component)
+
+
+def create_variety_property():
+    """
+    Create a property for widgets that helps in setting variety metadata.
+
+    On setting variety metadata::
+
+        1. self._variety_metadata is updated
+        2. self._update_variety_metadata(**md) is called
+        3. All registered variety key handlers are called.
+    """
+
+    def fget(self):
+        return dict(self._variety_metadata)
+
+    def fset(self, metadata):
+        self._variety_metadata = dict(metadata or {})
+
+        # Catch-all handler for variety metadata.
+        try:
+            if hasattr(self, '_update_variety_metadata'):
+                self._update_variety_metadata(**self._variety_metadata)
+        except Exception:
+            logger.exception('Failed to set variety metadata for class %s: %s',
+                             type(self).__name__, metadata)
+
+        # Optionally, there may be 'handlers' for individual top-level keys.
+        handlers = getattr(self, '_variety_handlers', {})
+        for key, handler_list in handlers.items():
+            for unbound in handler_list:
+                handler = getattr(self, unbound.__name__)
+
+                info = self._variety_metadata.get(key)
+                if info is None:
+                    continue
+
+                try:
+                    if isinstance(info, dict):
+                        handler(**info)
+                    else:
+                        handler(info)
+                except Exception:
+                    logger.exception(
+                        'Failed to set variety metadata for class %s.%s %r: '
+                        '%s', type(self).__name__, handler.__name__, key, info
+                    )
+
+    return property(fget, fset,
+                    doc='Additional component variety metadata.')

--- a/typhos/variety.py
+++ b/typhos/variety.py
@@ -90,6 +90,7 @@ def use_for_variety(variety, *, read=True, write=True):
         'array-histogram',
         'array-image',
         'array-nd',
+        'array-tabular',
         'array-timeseries',
         'bitmask',
         'command',

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -21,6 +21,7 @@ from ophyd.signal import EpicsSignalBase
 from pydm.widgets.display_format import DisplayFormat
 
 from . import plugins, utils, variety
+from .textedit import TyphosTextEdit  # noqa: F401
 from .variety import use_for_variety_read, use_for_variety_write
 
 logger = logging.getLogger(__name__)
@@ -154,7 +155,6 @@ class TyphosComboBox(pydm.widgets.PyDMEnumComboBox):
 
 @use_for_variety_write('scalar')
 @use_for_variety_write('text')
-@use_for_variety_write('text-multiline')  # TODO: new class
 class TyphosLineEdit(pydm.widgets.PyDMLineEdit):
     """
     Reimplementation of PyDMLineEdit to set some custom defaults

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -155,7 +155,8 @@ class TogglePanel(QWidget):
 @use_for_variety_write('text-enum')
 class TyphosComboBox(pydm.widgets.PyDMEnumComboBox):
     """
-    TODO
+    Notes
+    -----
     """
 
 
@@ -164,6 +165,9 @@ class TyphosComboBox(pydm.widgets.PyDMEnumComboBox):
 class TyphosLineEdit(pydm.widgets.PyDMLineEdit):
     """
     Reimplementation of PyDMLineEdit to set some custom defaults
+
+    Notes
+    -----
     """
     def __init__(self, *args, display_format=None, **kwargs):
         self._setpoint_history_count = 5
@@ -298,6 +302,9 @@ class TyphosLineEdit(pydm.widgets.PyDMLineEdit):
 class TyphosLabel(pydm.widgets.PyDMLabel):
     """
     Reimplementation of PyDMLabel to set some custom defaults
+
+    Notes
+    -----
     """
     def __init__(self, *args, display_format=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -331,6 +338,9 @@ class TyphosLabel(pydm.widgets.PyDMLabel):
 class TyphosSidebarItem(ptypes.ParameterItem):
     """
     Class to display a Device or Tool in the sidebar
+
+    Notes
+    -----
     """
     def __init__(self, param, depth):
         super().__init__(param, depth)
@@ -516,7 +526,12 @@ class SignalDialogButton(QPushButton):
 
 @use_for_variety_read('array-image')
 class ImageDialogButton(SignalDialogButton):
-    """QPushButton to show a 2-d array"""
+    """
+    QPushButton to show a 2-d array.
+
+    Notes
+    -----
+    """
     text = 'Show Image'
     icon = 'fa.camera'
     parent_widget_class = QtWidgets.QMainWindow
@@ -530,7 +545,12 @@ class ImageDialogButton(SignalDialogButton):
 @use_for_variety_read('array-timeseries')
 @use_for_variety_read('array-histogram')  # TODO: histogram settings?
 class WaveformDialogButton(SignalDialogButton):
-    """QPushButton to show a 1-d array"""
+    """
+    QPushButton to show a 1-d array.
+
+    Notes
+    -----
+    """
     text = 'Show Waveform'
     icon = 'fa5s.chart-line'
     parent_widget_class = QtWidgets.QMainWindow
@@ -548,6 +568,9 @@ class WaveformDialogButton(SignalDialogButton):
 class TyphosCommandButton(pydm.widgets.PyDMPushButton):
     """
     TODO
+
+    Notes
+    -----
     """
 
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
@@ -588,6 +611,9 @@ class TyphosCommandButton(pydm.widgets.PyDMPushButton):
 class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
     """
     TODO
+
+    Notes
+    -----
     """
 
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
@@ -618,6 +644,9 @@ class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
 class TyphosByteIndicator(pydm.widgets.PyDMByteIndicator):
     """
     TODO
+
+    Notes
+    -----
     """
 
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
@@ -674,6 +703,9 @@ class TyphosByteSetpoint(TyphosByteIndicator,
                          pydm.widgets.base.PyDMWritableWidget):
     """
     TODO
+
+    Notes
+    -----
     """
 
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
@@ -752,6 +784,9 @@ class TyphosByteSetpoint(TyphosByteIndicator,
 class TyphosScalarRange(pydm.widgets.PyDMSlider):
     """
     TODO
+
+    Notes
+    -----
     """
 
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
@@ -867,6 +902,9 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
 class TyphosArrayTable(pydm.widgets.PyDMWaveformTable):
     """
     TODO
+
+    Notes
+    -----
     """
     # TODO this class will have to be redone; PyDMWaveformTable appears to be
     # for a different purpose

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -702,12 +702,15 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
 
         self._delta_value = value
         if self.minimum is not None and self.maximum is not None:
+            self._mute_internal_slider_changes = True
             try:
                 self.num_steps = (self.maximum - self.minimum) / value
             except Exception:
                 logger.exception('Failed to set number of steps with '
                                  'min=%s, max=%s, delta=%s', self.minimum,
                                  self.maximum, value)
+            finally:
+                self._mute_internal_slider_changes = False
 
     def connection_changed(self, connected):
         ret = super().connection_changed(connected)

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -21,7 +21,7 @@ from ophyd.signal import EpicsSignalBase
 from pydm.widgets.display_format import DisplayFormat
 
 from . import plugins, utils, variety
-from .variety import for_variety_read, for_variety_write
+from .variety import use_for_variety_read, use_for_variety_write
 
 logger = logging.getLogger(__name__)
 
@@ -146,15 +146,15 @@ class TogglePanel(QWidget):
                 self.contents.hide()
 
 
-@for_variety_write('enum')
-@for_variety_write('text-enum')
+@use_for_variety_write('enum')
+@use_for_variety_write('text-enum')
 class TyphosComboBox(pydm.widgets.PyDMEnumComboBox):
     ...
 
 
-@for_variety_write('scalar')
-@for_variety_write('text')
-@for_variety_write('text-multiline')  # TODO: new class
+@use_for_variety_write('scalar')
+@use_for_variety_write('text')
+@use_for_variety_write('text-multiline')  # TODO: new class
 class TyphosLineEdit(pydm.widgets.PyDMLineEdit):
     """
     Reimplementation of PyDMLineEdit to set some custom defaults
@@ -276,19 +276,19 @@ class TyphosLineEdit(pydm.widgets.PyDMLineEdit):
             self.displayFormat = DisplayFormat.Exponential
 
 
-@for_variety_read('array-nd')
-@for_variety_read('command')
-@for_variety_read('command-enum')
-@for_variety_read('command-proc')
-@for_variety_read('command-setpoint-tracks-readback')
-@for_variety_read('enum')
-@for_variety_read('scalar')
-@for_variety_read('scalar-range')
-@for_variety_read('scalar-tweakable')
-@for_variety_read('text')
-@for_variety_read('text-enum')
-@for_variety_read('text-multiline')
-@for_variety_write('array-nd')
+@use_for_variety_read('array-nd')
+@use_for_variety_read('command')
+@use_for_variety_read('command-enum')
+@use_for_variety_read('command-proc')
+@use_for_variety_read('command-setpoint-tracks-readback')
+@use_for_variety_read('enum')
+@use_for_variety_read('scalar')
+@use_for_variety_read('scalar-range')
+@use_for_variety_read('scalar-tweakable')
+@use_for_variety_read('text')
+@use_for_variety_read('text-enum')
+@use_for_variety_read('text-multiline')
+@use_for_variety_write('array-nd')
 class TyphosLabel(pydm.widgets.PyDMLabel):
     """
     Reimplementation of PyDMLabel to set some custom defaults
@@ -508,7 +508,7 @@ class SignalDialogButton(QPushButton):
         self.dialog.show()
 
 
-@for_variety_read('array-image')
+@use_for_variety_read('array-image')
 class ImageDialogButton(SignalDialogButton):
     """QPushButton to show a 2-d array"""
     text = 'Show Image'
@@ -521,8 +521,8 @@ class ImageDialogButton(SignalDialogButton):
             parent=self, image_channel=self.channel)
 
 
-@for_variety_read('array-timeseries')
-@for_variety_read('array-histogram')  # TODO: histogram settings?
+@use_for_variety_read('array-timeseries')
+@use_for_variety_read('array-histogram')  # TODO: histogram settings?
 class WaveformDialogButton(SignalDialogButton):
     """QPushButton to show a 1-d array"""
     text = 'Show Waveform'
@@ -535,24 +535,24 @@ class WaveformDialogButton(SignalDialogButton):
             init_y_channels=[self.channel], parent=self)
 
 
-@for_variety_write('command')
-@for_variety_write('command-proc')
-@for_variety_write('command-setpoint-tracks-readback')  # TODO
+@use_for_variety_write('command')
+@use_for_variety_write('command-proc')
+@use_for_variety_write('command-setpoint-tracks-readback')  # TODO
 class TyphosCommandButton(pydm.widgets.PyDMPushButton):
     ...
 
 
-@for_variety_write('command-enum')
+@use_for_variety_write('command-enum')
 class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
     ...
 
 
-@for_variety_read('bitmask')
+@use_for_variety_read('bitmask')
 class TyphosByteIndicator(pydm.widgets.PyDMByteIndicator):
     ...
 
 
-@for_variety_write('bitmask')
+@use_for_variety_write('bitmask')
 class TyphosByteSetpoint(pydm.widgets.PyDMByteIndicator):
     ...
 
@@ -607,8 +607,8 @@ def _create_variety_property():
                     doc='Additional component variety metadata.')
 
 
-@variety.uses_variety_handler
-@for_variety_write('scalar-range')
+@variety.uses_key_handlers
+@use_for_variety_write('scalar-range')
 class TyphosScalarRange(pydm.widgets.PyDMSlider):
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
                  **kwargs):
@@ -619,7 +619,7 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
 
     variety_metadata = _create_variety_property()
 
-    @variety._set_variety_key_handler('range')
+    @variety.key_handler('range')
     def _variety_key_handler_range(self, value, source, **kwargs):
         """Variety hook for the sub-dictionary "range"."""
         if source == 'value':
@@ -634,7 +634,7 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
 
         variety._warn_unhandled_kwargs(self, kwargs)
 
-    @variety._set_variety_key_handler('delta')
+    @variety.key_handler('delta')
     def _variety_key_handler_delta(self, value, source, signal=None, **kwargs):
         """Variety hook for the sub-dictionary "delta"."""
         if source == 'value':
@@ -646,7 +646,7 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
         # range_ = kwargs.pop('range')  # unhandled
         variety._warn_unhandled_kwargs(self, kwargs)
 
-    @variety._set_variety_key_handler('display_format')
+    @variety.key_handler('display_format')
     def _variety_key_handler_display_format(self, value):
         """Variety hook for the sub-dictionary "delta"."""
         self.displayFormat = getattr(DisplayFormat, value.capitalize(),
@@ -690,7 +690,7 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
         return ret
 
 
-@for_variety_write('scalar-tweakable')
+@use_for_variety_write('scalar-tweakable')
 class TyphosTweakable(TyphosScalarRange):
     ...
     # TODO tweak functionality from positioner?

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -25,6 +25,7 @@ from pydm.widgets.display_format import DisplayFormat
 
 from . import plugins, utils, variety
 from .textedit import TyphosTextEdit  # noqa: F401
+from .tweakable import TyphosTweakable  # noqa: F401
 from .variety import use_for_variety_read, use_for_variety_write
 
 logger = logging.getLogger(__name__)
@@ -153,7 +154,9 @@ class TogglePanel(QWidget):
 @use_for_variety_write('enum')
 @use_for_variety_write('text-enum')
 class TyphosComboBox(pydm.widgets.PyDMEnumComboBox):
-    ...
+    """
+    TODO
+    """
 
 
 @use_for_variety_write('scalar')
@@ -426,6 +429,10 @@ class HappiChannel(pydm.widgets.channel.PyDMChannel, QObject):
 
 
 class TyphosDesignerMixin(pydm.widgets.base.PyDMWidget):
+    """
+    TODO
+    """
+
     # Unused properties that we don't want visible in designer
     alarmSensitiveBorder = Property(bool, designable=False)
     alarmSensitiveContent = Property(bool, designable=False)
@@ -539,6 +546,10 @@ class WaveformDialogButton(SignalDialogButton):
 @use_for_variety_write('command-proc')
 @use_for_variety_write('command-setpoint-tracks-readback')  # TODO
 class TyphosCommandButton(pydm.widgets.PyDMPushButton):
+    """
+    TODO
+    """
+
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -575,6 +586,10 @@ class TyphosCommandButton(pydm.widgets.PyDMPushButton):
 @variety.uses_key_handlers
 @use_for_variety_write('command-enum')
 class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
+    """
+    TODO
+    """
+
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -601,6 +616,10 @@ class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
 @use_for_variety_read('bitmask')
 @variety.uses_key_handlers
 class TyphosByteIndicator(pydm.widgets.PyDMByteIndicator):
+    """
+    TODO
+    """
+
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -653,6 +672,10 @@ class ClickableBitIndicator(pydm.widgets.byte.PyDMBitIndicator):
 @use_for_variety_write('bitmask')
 class TyphosByteSetpoint(TyphosByteIndicator,
                          pydm.widgets.base.PyDMWritableWidget):
+    """
+    TODO
+    """
+
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
                  **kwargs):
         # NOTE: need to have these in the signature explicitly
@@ -727,6 +750,10 @@ class TyphosByteSetpoint(TyphosByteIndicator,
 @variety.uses_key_handlers
 @use_for_variety_write('scalar-range')
 class TyphosScalarRange(pydm.widgets.PyDMSlider):
+    """
+    TODO
+    """
+
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -777,8 +804,7 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
     @variety.key_handler('display_format')
     def _variety_key_handler_display_format(self, value):
         """Variety hook for the sub-dictionary "delta"."""
-        self.displayFormat = getattr(DisplayFormat, value.capitalize(),
-                                     DisplayFormat.Default)
+        self.displayFormat = variety.get_display_format(value)
 
     @property
     def delta_signal(self):
@@ -836,15 +862,12 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
         return ret
 
 
-@use_for_variety_write('scalar-tweakable')
-class TyphosTweakable(TyphosScalarRange):
-    ...
-    # TODO tweak functionality from positioner?
-
-
 @variety.uses_key_handlers
 @use_for_variety_write('array-tabular')
 class TyphosArrayTable(pydm.widgets.PyDMWaveformTable):
+    """
+    TODO
+    """
     # TODO this class will have to be redone; PyDMWaveformTable appears to be
     # for a different purpose
     def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
@@ -880,6 +903,9 @@ class TyphosArrayTable(pydm.widgets.PyDMWaveformTable):
 
 
 def _get_scalar_widget_class(desc, variety_md, read_only):
+    """
+    TODO
+    """
     # Check for enum_strs, if so create a QCombobox
     if read_only:
         return TyphosLabel
@@ -893,6 +919,9 @@ def _get_scalar_widget_class(desc, variety_md, read_only):
 
 
 def _get_ndimensional_widget_class(dimensions, desc, variety_md, read_only):
+    """
+    TODO
+    """
     if dimensions == 0:
         return _get_scalar_widget_class(desc, variety_md, read_only)
 

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -420,6 +420,7 @@ class HappiChannel(pydm.widgets.channel.PyDMChannel, QObject):
         Slot on widget to accept a dictionary of both the device and metadata
         information
     """
+
     def __init__(self, *, tx_slot, **kwargs):
         super().__init__(**kwargs)
         QObject.__init__(self)
@@ -440,7 +441,7 @@ class HappiChannel(pydm.widgets.channel.PyDMChannel, QObject):
 
 class TyphosDesignerMixin(pydm.widgets.base.PyDMWidget):
     """
-    TODO
+    A mixin class used to display Typhos widgets in the Qt designer.
     """
 
     # Unused properties that we don't want visible in designer
@@ -567,7 +568,11 @@ class WaveformDialogButton(SignalDialogButton):
 @use_for_variety_write('command-setpoint-tracks-readback')  # TODO
 class TyphosCommandButton(pydm.widgets.PyDMPushButton):
     """
-    TODO
+    A pushbutton widget which executes a command by sending a specific value.
+
+    See Also
+    --------
+    :class:`TyphosCommandEnumButton`
 
     Notes
     -----
@@ -610,7 +615,14 @@ class TyphosCommandButton(pydm.widgets.PyDMPushButton):
 @use_for_variety_write('command-enum')
 class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
     """
-    TODO
+    A group of buttons which represent several command options.
+
+    These options can come from directly from the control layer or can be
+    overridden with variety metadata.
+
+    See Also
+    --------
+    :class:`TyphosCommandButton`
 
     Notes
     -----
@@ -643,7 +655,7 @@ class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
 @variety.uses_key_handlers
 class TyphosByteIndicator(pydm.widgets.PyDMByteIndicator):
     """
-    TODO
+    Displays an integer value as individual, read-only bit indicators.
 
     Notes
     -----
@@ -702,7 +714,7 @@ class ClickableBitIndicator(pydm.widgets.byte.PyDMBitIndicator):
 class TyphosByteSetpoint(TyphosByteIndicator,
                          pydm.widgets.base.PyDMWritableWidget):
     """
-    TODO
+    Displays an integer value as individual, toggleable bit indicators.
 
     Notes
     -----
@@ -783,7 +795,7 @@ class TyphosByteSetpoint(TyphosByteIndicator,
 @use_for_variety_write('scalar-range')
 class TyphosScalarRange(pydm.widgets.PyDMSlider):
     """
-    TODO
+    A slider widget which displays a scalar value with an explicit range.
 
     Notes
     -----
@@ -901,7 +913,7 @@ class TyphosScalarRange(pydm.widgets.PyDMSlider):
 @use_for_variety_write('array-tabular')
 class TyphosArrayTable(pydm.widgets.PyDMWaveformTable):
     """
-    TODO
+    A table widget which reshapes and displays a given waveform value.
 
     Notes
     -----
@@ -942,7 +954,18 @@ class TyphosArrayTable(pydm.widgets.PyDMWaveformTable):
 
 def _get_scalar_widget_class(desc, variety_md, read_only):
     """
-    TODO
+    From a given description, return the widget to use.
+
+    Parameters
+    ----------
+    desc : dict
+        The object description.
+
+    variety_md : dict
+        The variety metadata.  Currently unused.
+
+    read_only : bool
+        Set if used for the readback widget.
     """
     # Check for enum_strs, if so create a QCombobox
     if read_only:
@@ -958,7 +981,21 @@ def _get_scalar_widget_class(desc, variety_md, read_only):
 
 def _get_ndimensional_widget_class(dimensions, desc, variety_md, read_only):
     """
-    TODO
+    From a given description and dimensionality, return the widget to use.
+
+    Parameters
+    ----------
+    dimensions : int
+        The number of dimensions (e.g., 0D or scalar, 1D array, ND array)
+
+    desc : dict
+        The object description.
+
+    variety_md : dict
+        The variety metadata.  Currently unused.
+
+    read_only : bool
+        Set if used for the readback widget.
     """
     if dimensions == 0:
         return _get_scalar_widget_class(desc, variety_md, read_only)

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -163,22 +163,22 @@ def for_variety(variety, *, read=True, write=True):
     """
 
     known_varieties = {
-        'command',
-        'command-proc',
-        'command-enum',
-        'command-setpoint-tracks-readback',
-        'tweakable',
-        'array-timeseries',
         'array-histogram',
         'array-image',
         'array-nd',
+        'array-timeseries',
+        'bitmask',
+        'command',
+        'command-enum',
+        'command-proc',
+        'command-setpoint-tracks-readback',
+        'enum',
         'scalar',
         'scalar-range',
-        'bitmask',
         'text',
-        'text-multiline',
         'text-enum',
-        'enum',
+        'text-multiline',
+        'tweakable',
     }
 
     if variety not in known_varieties:
@@ -344,18 +344,18 @@ class TyphosLineEdit(pydm.widgets.PyDMLineEdit):
             self.displayFormat = DisplayFormat.Exponential
 
 
-@for_variety_read('enum')
-@for_variety_read('scalar')
-@for_variety_read('scalar-range')
-@for_variety_read('tweakable')
-@for_variety_read('text')
-@for_variety_read('text-enum')
-@for_variety_read('text-multiline')
+@for_variety('array-nd')
 @for_variety_read('command')
 @for_variety_read('command-enum')
 @for_variety_read('command-proc')
 @for_variety_read('command-setpoint-tracks-readback')
-@for_variety('array-nd')
+@for_variety_read('enum')
+@for_variety_read('scalar')
+@for_variety_read('scalar-range')
+@for_variety_read('text')
+@for_variety_read('text-enum')
+@for_variety_read('text-multiline')
+@for_variety_read('tweakable')
 class TyphosLabel(pydm.widgets.PyDMLabel):
     """
     Reimplementation of PyDMLabel to set some custom defaults

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -548,12 +548,44 @@ class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
 
 
 @use_for_variety_read('bitmask')
+@variety.uses_key_handlers
 class TyphosByteIndicator(pydm.widgets.PyDMByteIndicator):
-    ...
+    def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ophyd_signal = ophyd_signal
+        self.variety_metadata = variety_metadata
+
+    variety_metadata = variety.create_variety_property()
+
+    def _update_variety_metadata(self, bits, orientation, first_bit, style,
+                                 **kwargs):
+        self.numBits = bits
+        self.orientation = {
+            'horizontal': Qt.Horizontal,
+            'vertical': Qt.Vertical,
+        }[orientation]
+        self.bigEndian = (first_bit == 'most-significant')
+        variety._warn_unhandled_kwargs(self, kwargs)
+
+    @variety.key_handler('style')
+    def _variety_key_handler_style(self, shape, on_color, off_color, **kwargs):
+        """Variety hook for the sub-dictionary "style"."""
+        on_color = QtGui.QColor(on_color)
+        if on_color is not None:
+            self.onColor = on_color
+
+        off_color = QtGui.QColor(off_color)
+        if off_color is not None:
+            self.offColor = off_color
+
+        self.circles = (shape == 'circle')
+
+        variety._warn_unhandled_kwargs(self, kwargs)
 
 
 @use_for_variety_write('bitmask')
-class TyphosByteSetpoint(pydm.widgets.PyDMByteIndicator):
+class TyphosByteSetpoint(TyphosByteIndicator):
     ...
 
 

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -336,27 +336,23 @@ class TyphosSidebarItem(ptypes.ParameterItem):
         self.toolbar.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.toolbar.setIconSize(QSize(15, 15))
         # Setup the action to open the widget
-        self.open_action = QAction(qta.icon('fa.square',
-                                            color='green'),
-                                   'Open', self.toolbar)
+        self.open_action = QAction(
+            qta.icon('fa.square', color='green'), 'Open', self.toolbar)
         self.open_action.triggered.connect(self.open_requested)
         # Setup the action to embed the widget
-        self.embed_action = QAction(qta.icon('fa.th-large',
-                                             color='yellow'),
-                                    'Embed', self.toolbar)
+        self.embed_action = QAction(
+            qta.icon('fa.th-large', color='yellow'), 'Embed', self.toolbar)
         self.embed_action.triggered.connect(self.embed_requested)
         # Setup the action to hide the widget
-        self.hide_action = QAction(qta.icon('fa.times-circle',
-                                            color='red'),
-                                   'Close', self.toolbar)
+        self.hide_action = QAction(
+            qta.icon('fa.times-circle', color='red'), 'Close', self.toolbar)
         self.hide_action.triggered.connect(self.hide_requested)
         self.hide_action.setEnabled(False)
         # Add actions to toolbars
         self.toolbar.addAction(self.open_action)
         self.toolbar.addAction(self.hide_action)
         if self.param.embeddable:
-            self.toolbar.insertAction(self.hide_action,
-                                      self.embed_action)
+            self.toolbar.insertAction(self.hide_action, self.embed_action)
 
     def open_requested(self, triggered):
         """Request to open display for sidebar item"""

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -544,9 +544,34 @@ class TyphosCommandButton(pydm.widgets.PyDMPushButton):
     ...
 
 
+@variety.uses_key_handlers
 @use_for_variety_write('command-enum')
 class TyphosCommandEnumButton(pydm.widgets.enum_button.PyDMEnumButton):
-    ...
+    def __init__(self, *args, variety_metadata=None, ophyd_signal=None,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ophyd_signal = ophyd_signal
+        self.variety_metadata = variety_metadata
+        self._forced_enum_strings = None
+
+    variety_metadata = variety.create_variety_property()
+
+    def enum_strings_changed(self, new_enum_strings):
+        return super().enum_strings_changed(
+            self._forced_enum_strings or new_enum_strings)
+
+    def _update_variety_metadata(self, *, value, enum_strings=None,
+                                 enum_dict=None, tags=None, **kwargs):
+        if enum_strings or enum_dict:
+            if enum_dict:
+                max_value = max(enum_dict)
+                enum_strings = [enum_dict.get(idx, '')
+                                for idx in range(max_value + 1)]
+
+            self._forced_enum_strings = tuple(enum_strings)
+            self.enum_strings_changed(None)  # force an update
+
+        variety._warn_unhandled_kwargs(self, kwargs)
 
 
 @use_for_variety_read('bitmask')
@@ -561,7 +586,7 @@ class TyphosByteIndicator(pydm.widgets.PyDMByteIndicator):
     variety_metadata = variety.create_variety_property()
 
     def _update_variety_metadata(self, *, bits, orientation, first_bit, style,
-                                 meaning=None, **kwargs):
+                                 meaning=None, tags=None, **kwargs):
         self.numBits = bits
         self.orientation = {
             'horizontal': Qt.Horizontal,


### PR DESCRIPTION
## Description

Variety metadata adds the possibility for distinguishing different types of signals from one another.
These different varieties of signals map differently onto typhos widgets.

This PR adds the framework and outlines examples for handling all of the currently defined varieties (pairing with https://github.com/pcdshub/pcdsdevices/pull/463)

While this adds a considerable amount of magic by way of decorators, I believe the sheer number of metadata keys, varieties, and classes justifies this. These additional decorators also allow for automatic annotation of class docstrings for documentation generation and such.

Note: For signals without variety designation (99.995% of them currently), this PR should have no effect.

## How Has This Been Tested?
Almost entirely locally. This could be considered an experimental feature.

Local testing has been with `variety_ioc` included in the test suite. It can be launched by way of: `TYPHOS_DEBUG=1 typhos 'variety.MyDevice[{"prefix":"variety:"}]'`

## Where Has This Been Documented?
Widget docstrings + some sphinx docs updates.

## Work-in-progress status
- [x] Link all varieties to widgets (placeholders for new ones)
- [ ] Implement new widgets (may be follow-up PRs for even basic functionality)
   - [x] Multiline text edit
   - [x] Support bitmask setpoints (not ideal, but it works)
   - [x] Support general tweakable (non positioner; basic work is in)
   - [ ] Histogram?
- [ ] Respect variety metadata as noted in planning document (will make an attempt here, may be follow-up PRs)
   - [ ] New widget functionality to support variety metadata
   - [x] Tweakable/scalar-range: delta source from signal/value
   - [x] Password prompts, confirmation for pushbuttons
   - [ ] Password prompts, confirmation for other widgets? Not natively supported by PyDM
- [x] Mixin / hook for generically setting metadata for new widgets
- [x] Use provided caproto IOC for interactive testing
- [ ] Use provided caproto IOC for continuous integration (may be in a follow-up PR)

## Screenshots
Updating a preview as I go through this (variety IOC; `typhos 'variety.MyDevice[{"prefix":"variety:"}]'`):

<details>
<summary>Attempt 1</summary>
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/5139267/85476495-4a401d80-b56d-11ea-9017-99cb1abbb2b7.png"> 
</details>

<details>
<summary>Attempt 2</summary>
<img width="878" alt="image" src="https://user-images.githubusercontent.com/5139267/85804284-1a744f80-b6fe-11ea-99b3-fe0832bd05f4.png">
</details>

<details>
<summary>Attempt 2.5?</summary>
<img width="954" alt="image" src="https://user-images.githubusercontent.com/5139267/85899798-8369cf00-b7b3-11ea-8a50-bc41bb181016.png">
</details>

<details>
<summary>Attempt 3</summary>
<img width="350" alt="image" src="https://user-images.githubusercontent.com/5139267/86032190-cc0bcd00-b9eb-11ea-94dd-ccc52bb0eee8.png">
</details>

Current attempt:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/5139267/86392869-02965180-bc51-11ea-8531-2a604314b135.png">