### PR TITLE
DOC: Add doctr_versions_menu extension to properly render version menu.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 caproto
 codecov
 doctr
+doctr-versions-menu
 flake8
 ipython
 line_profiler

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,6 +45,7 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
+    'doctr_versions_menu',
     'sphinx.ext.githubpages']
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
BLD: Add doctr-versions-menu to dev-requirements.txt.

<!--- Provide a general summary of your changes in the Title above -->
## Description
This morning while looking to the nice new feature to show someone how we use versioned docs with GitHub Pages I was surprised that I could not see it as I could at the `testproject1234` (See https://hhslepicka.github.io/testproject1234/master/).
Comparing both, I noticed that we need to add the `doctr-versions-menu` extension at the conf.py for docs.

It is a Draft for now as it depends on https://github.com/conda-forge/staged-recipes/pull/12250 to be merged and available via Conda-forge.

## Motivation and Context
To properly render the versioned docs.

## Where Has This Been Documented?
It is documentation.
