### PR TITLE
MNT: work around init bug

### DIFF
--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -69,6 +69,7 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
         self._readback = None
         self._setpoint = None
         self._status_thread = None
+        self._initialized = False
 
         super().__init__(parent=parent)
 
@@ -442,8 +443,14 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
             if isinstance(self.ui.set_value, QtWidgets.QComboBox):
                 try:
                     idx = int(text)
-                    self.ui.set_value.setCurrentIndex(idx)
+                    # HACK: the first put is always during startup
+                    # This must be skipped
+                    if self._initialized:
+                        self.ui.set_value.setCurrentIndex(idx)
+                    else:
+                        self._initialized = True
                 except ValueError:
                     logger.debug('Failed to convert value to int. %s', text)
             else:
+                self._initialized = True
                 self.ui.set_value.setText(text)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Skip the first put to the combobox

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #383. We're currently putting to signals on startup which can be very disruptive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It doesn't raise an exception on startup any more. The state device still moves on the first combobox selection action.