### PR TITLE
FIX: set self._channel to avoid AttributeError

### DIFF
--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -170,6 +170,7 @@ class TyphosLineEdit(pydm.widgets.PyDMLineEdit):
     -----
     """
     def __init__(self, *args, display_format=None, **kwargs):
+        self._channel = None
         self._setpoint_history_count = 5
         self._setpoint_history = collections.deque(
             [],  self._setpoint_history_count)


### PR DESCRIPTION
Closes #386 

Did not dive into the source of it, but this appears to stop the exception.