### PR TITLE
FIX: do not change setpoints when QComboBox is scrolled

### DIFF
--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -8,20 +8,20 @@ import inspect
 import logging
 
 import numpy as np
-import qtawesome as qta
-from pyqtgraph.parametertree import parameterTypes as ptypes
-from qtpy import QtGui, QtWidgets
-from qtpy.QtCore import Property, QObject, QSize, Qt, Signal, Slot
-from qtpy.QtWidgets import (QAction, QDialog, QDockWidget, QPushButton,
-                            QToolBar, QVBoxLayout, QWidget)
-
 import pydm
 import pydm.widgets
 import pydm.widgets.base
 import pydm.widgets.byte
 import pydm.widgets.enum_button
+import qtawesome as qta
+
 from ophyd.signal import EpicsSignalBase
 from pydm.widgets.display_format import DisplayFormat
+from pyqtgraph.parametertree import parameterTypes as ptypes
+from qtpy import QtGui, QtWidgets
+from qtpy.QtCore import Property, QObject, QSize, Qt, Signal, Slot
+from qtpy.QtWidgets import (QAction, QDialog, QDockWidget, QPushButton,
+                            QToolBar, QVBoxLayout, QWidget)
 
 from . import plugins, utils, variety
 from .textedit import TyphosTextEdit  # noqa: F401
@@ -158,6 +158,8 @@ class TyphosComboBox(pydm.widgets.PyDMEnumComboBox):
     Notes
     -----
     """
+    def wheelEvent(self, event: QtGui.QWheelEvent):
+        event.ignore()
 
 
 @use_for_variety_write('scalar')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Closes #369 
Plus some `isort`-related spam

## Motivation and Context
Inadvertently changing setpoints while scrolling through screens is not a good thing.

## How Has This Been Tested?
Locally.