### PR TITLE
ENH: add information to the loading widget indicating timeout details

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+        exclude: '^(conda-recipe/meta.yaml)$'
+    -   id: debug-statements
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.3.0
+    hooks:
+    -   id: isort

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -14,12 +14,11 @@ import functools
 import logging
 from functools import partial
 
-from qtpy import QtCore, QtWidgets
-from qtpy.QtCore import Q_ENUMS, Property
-
 import ophyd
 from ophyd import Kind
 from ophyd.signal import EpicsSignal, EpicsSignalRO
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Q_ENUMS, Property
 
 from . import display, utils
 from .cache import get_global_widget_type_cache
@@ -275,7 +274,17 @@ class SignalPanel(QtWidgets.QGridLayout):
         logger.debug("Adding signal %s (%s)", signal.name, name)
 
         label = self._create_row_label(name, name, tooltip)
-        row = self.add_row(label, utils.TyphosLoading())
+        loading = utils.TyphosLoading(
+            timeout_message=f'Connection timed out.'
+        )
+
+        loading_tooltip = ['Connecting to:'] + list(set(
+            getattr(signal, attr)
+            for attr in ('setpoint_pvname', 'pvname') if hasattr(signal, attr)
+        ))
+        loading.setToolTip('\n'.join(loading_tooltip))
+
+        row = self.add_row(label, loading)
         self.signal_name_to_info[signal.name] = dict(
             row=row,
             signal=signal,

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -275,7 +275,7 @@ class SignalPanel(QtWidgets.QGridLayout):
 
         label = self._create_row_label(name, name, tooltip)
         loading = utils.TyphosLoading(
-            timeout_message=f'Connection timed out.'
+            timeout_message='Connection timed out.'
         )
 
         loading_tooltip = ['Connecting to:'] + list(set(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Closes #355

## Motivation and Context
It's impossible with the current master to determine which PVs are failing to connect.

## How Has This Been Tested?
Locally.

## Screenshots (if appropriate):
Adds a tooltip, in case the PV itself is rather long:
<img width=300 src="https://user-images.githubusercontent.com/5139267/89444855-34df1700-d707-11ea-95f9-8f0fbb18e1ba.png" />

Also adds a context menu for easy copy/paste-ability:
<img width=300 src="https://user-images.githubusercontent.com/5139267/89444880-40324280-d707-11ea-9df6-6b22fad2bdcc.png" />

Copy either a single line or the entire tooltip to the clipboard.

This is a bit lacking in terms of UX discoverability, but I think it's a reasonable trade-off to weird reflowing issues we'd get listing the PVs in the timeout message. Agree?