### PR TITLE
MNT: remove confirmation to move AT2L0 filters as requested (LCLS-II/PCDS device screens)

### DIFF
--- a/typhos/ui/devices/AttenuatorCalculator_AT2L0_calc.ui
+++ b/typhos/ui/devices/AttenuatorCalculator_AT2L0_calc.ui
@@ -517,12 +517,6 @@
            <property name="channel" stdset="0">
             <string>ca://${prefix}:SYS:ApplyConfiguration</string>
            </property>
-           <property name="showConfirmDialog" stdset="0">
-            <bool>true</bool>
-           </property>
-           <property name="confirmMessage" stdset="0">
-            <string>Move the filters?</string>
-           </property>
            <property name="pressValue" stdset="0">
             <string>1</string>
            </property>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
User commented that the confirmation dialog is unnecessary due to the fact that there are several steps required to apply the configuration - this PR removes that confirmation dialog.

With https://github.com/pcdshub/solid-attenuator/pull/56, floor and ceiling calculations are no longer supported. These may be removed in future screens, but will be left in for now.

## Motivation and Context
Closes #409 

## How Has This Been Tested?
Locally with a simulated AT2L0.