### PR TITLE
CI: Fix docs build

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ codecov
 doctr
 doctr-versions-menu
 flake8
-ipython
+ipython>=7.16
 line_profiler
 pytest
 pytest-benchmark


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Set ipython version to the highest on conda forge that exists for python 3.6 in hopes of fixing the docs CI
Note: we should consider moving our docs builds to 3.8 or even 3.9

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Docs builds started failing because the ipython sphinx extension has a bug in a random old build, and that build gets picked with high priority whenever it is allowed for some reason.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The CI is the test, but I created a bunch of environments offline

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This is docs

<!--
## Screenshots (if appropriate):
-->
