### PR TITLE
MNT: remove codecov following security breach

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 </p>
 
 [![Build Status](https://travis-ci.org/pcdshub/typhos.svg?branch=master)](https://travis-ci.org/pcdshub/typhos)
-[![codecov.io](https://codecov.io/github/pcdshub/typhos/coverage.svg?branch=master)](https://codecov.io/github/pcdshub/typhos?branch=master)
 
 > **WARNING**: This package was renamed.
 >

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 caproto
-codecov
 doctr
 doctr-versions-menu
 flake8


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove codecov. We aren't using it and they had a security breach