### PR TITLE
ENH: help widget

### DIFF
--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -191,3 +191,29 @@ configured with :func:`typhos.use_stylesheet`. The operator can elect whether
 to use the "light" or "dark" stylesheets by using the optional ``dark``
 keyword. This method also handles setting the "Fusion" ``QStyle`` which helps
 make the interface have an operating system independent look and feel.
+
+
+Using the Documentation Widget
+==============================
+
+Typhos has a built-in documentation helper, which allows for the in-line
+linking and display of a user-provided website.
+
+To inform Typhos how to load documentation specific to your facility, please
+customize the following environment variables.
+
+1. ``TYPHOS_HELP_URL`` (str): The help URL format string.  The help URL will
+   be formatted with the ophyd device pertinent to the display, such that you
+   may access its name, PV prefix, happi metadata (if available), and so on.
+   For example, if a Confluence server exists at
+   ``https://my-confluence-site.example.com/Controls/`` with document names
+   that match your devices, ``TYPHOS_HELP_URL`` should be set to
+   ``https://my-confluence-site.example.com/Controls/{device.name}``.
+   If, perhaps, only top-level devices are guaranteed to have documentation,
+   consider using: ``device.root.name`` instead in the format string.
+2. ``TYPHOS_HELP_HEADERS`` (json): headers to pass to HELP_URL.  This should be
+   in a JSON format, such as ``{"my_key":"my_value"}``.
+3. ``TYPHOS_HELP_TOKEN`` (str): An optional token for the bearer authentication
+   scheme - e.g., personal access tokens with Confluence.  This is a shortcut
+   to add a header ``"Authorization"`` with the value
+   ``"Bearer ${TYPHOS_HELP_TOKEN}"``.

--- a/typhos/designer.py
+++ b/typhos/designer.py
@@ -1,7 +1,7 @@
 from pydm.widgets.qtplugin_base import qtplugin_factory
 
 from .display import (TyphosDeviceDisplay, TyphosDisplaySwitcher,
-                      TyphosDisplayTitle)
+                      TyphosDisplayTitle, TyphosHelpFrame)
 from .func import TyphosMethodButton
 from .panel import TyphosCompositeSignalPanel, TyphosSignalPanel
 from .positioner import TyphosPositionerWidget
@@ -21,3 +21,4 @@ TyphosDisplaySwitcherPlugin = qtplugin_factory(TyphosDisplaySwitcher,
                                                group=group_name)
 TyphosDisplayTitlePlugin = qtplugin_factory(TyphosDisplayTitle,
                                             group=group_name)
+TyphosHelpFramePlugin = qtplugin_factory(TyphosHelpFrame, group=group_name)

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -629,6 +629,7 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
     def show_help(self):
         """Show the help information in a QWebEngineView."""
         if self.help_web_view:
+            self.help_web_view.show()
             return
         self.help_web_view = QWebEngineView()
         if QWebEngineHttpRequest is not None:
@@ -653,21 +654,22 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         """Hide the help information QWebEngineView."""
         if not self.help_web_view:
             return
-        self.layout().removeWidget(self.help_web_view)
+        self.help_web_view.hide()
         if self._delete_timer is None:
             self._delete_timer = QtCore.QTimer()
             self._delete_timer.setInterval(20000)
             self._delete_timer.setSingleShot(True)
-            self._delete_timer.connect(self._delete_help_if_hidden)
+            self._delete_timer.timeout.connect(self._delete_help_if_hidden)
             self._delete_timer.start()
 
     def _delete_help_if_hidden(self):
         """
-        Slowly react to the help display removal, as setting it back up
-        can be slow and painful.
+        Slowly react to the help display removal, as setting it back up can be
+        slow and painful.
         """
         self._delete_timer = None
         if self.help_web_view and not self.help_web_view.isVisible():
+            self.layout().removeWidget(self.help_web_view)
             self.help_web_view.deleteLater()
             self.help_web_view = None
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -531,6 +531,7 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         super().__init__(parent=parent)
         self.help = None
         self.help_web_view = None
+        self._delete_timer = None
         self.python_docs_browser = None
 
         self.setContentsMargins(0, 0, 0, 0)
@@ -653,8 +654,22 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         if not self.help_web_view:
             return
         self.layout().removeWidget(self.help_web_view)
-        self.help_web_view.deleteLater()
-        self.help_web_view = None
+        if self._delete_timer is None:
+            self._delete_timer = QtCore.QTimer()
+            self._delete_timer.setInterval(20000)
+            self._delete_timer.setSingleShot(True)
+            self._delete_timer.connect(self._delete_help_if_hidden)
+            self._delete_timer.start()
+
+    def _delete_help_if_hidden(self):
+        """
+        Slowly react to the help display removal, as setting it back up
+        can be slow and painful.
+        """
+        self._delete_timer = None
+        if self.help_web_view and not self.help_web_view.isVisible():
+            self.help_web_view.deleteLater()
+            self.help_web_view = None
 
     def toggle_help(self, show):
         """

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -15,6 +15,7 @@ import pydm.utilities
 from pcdsutils.qt import forward_property
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Q_ENUMS, Property, Qt, Slot
+from qtpy.QtWebEngineCore import QWebEngineHttpRequest
 from qtpy.QtWebEngineWidgets import QWebEngineView
 
 from . import cache
@@ -572,13 +573,23 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
             return QtCore.QUrl("about:blank")
 
         device, *_ = self.devices
-        return QtCore.QUrl(f"https://www.google.com/search?q={device.name}")
+        return QtCore.QUrl(
+            utils.CONFLUENCE_URL.format(device=device.name)
+        )
 
     def show_help(self):
         if self.help_web_view:
             return
         self.help_web_view = QWebEngineView()
-        self.help_web_view.setUrl(self.help_url)
+        request = QWebEngineHttpRequest()
+        request.setUrl(self.help_url)
+        if utils.CONFLUENCE_TOKEN is not None:
+            request.setHeader(
+                "Authorization",
+                f"Bearer {utils.CONFLUENCE_TOKEN}"
+            )
+        print(request.headers())
+        self.help_web_view.load(request)
         self.help_web_view.setEnabled(True)
         self.help_web_view.setMinimumSize(QtCore.QSize(100, 400))
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -493,7 +493,10 @@ class TyphosHelpToggleButton(TyphosToolButton):
         # TODO: later versions of qt will support setMarkdown
         help_document.setPlainText(contents)
         self._help.setWindowTitle(first_line)
-        self._help.setFont(QtGui.QFontDatabase.FixedFont)
+        font = QtGui.QFont("Monospace")
+        font.setStyleHint(QtGui.QFont.TypeWriter)
+        # font.setStyleHint(QtGui.QFont.Monospace)
+        self._help.setFont(font)
         self._help.setDocument(help_document)
         self._help.show()
 
@@ -535,7 +538,12 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
 
     def _get_tooltip(self):
         tooltip = []
-        for device in self.devices:
+        # BUG: I'm seeing two devices in `self.devices` for
+        # $ typhos --fake-device 'ophyd.EpicsMotor[{"prefix":"b"}]'
+        for device in sorted(
+            set(self.devices),
+            key=lambda dev: self.devices.index(dev)
+        ):
             heading = device.name or type(device).__name__
             tooltip.extend([
                 heading,
@@ -548,7 +556,7 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
                 inspect.getdoc(type(device)) or
                 "No docstring"
             )
-            tooltip.extend([""] * 3)
+            tooltip.append("")
 
         return "\n".join(tooltip)
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -708,25 +708,32 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         self.underline.setFrameShadow(self.underline.Plain)
         self.underline.setLineWidth(10)
 
-        self.help = TyphosHelpFrame()
-        self.switcher.help_toggle_button.toggle_help.connect(
-            self.help.toggle_help
-        )
-        self.switcher.help_toggle_button.open_in_browser.connect(
-            self.help.open_in_browser
-        )
-        self.switcher.help_toggle_button.open_python_docs.connect(
-            self.help.open_python_docs
-        )
-        self.help.tooltip_updated.connect(
-            self.switcher.help_toggle_button.setToolTip
-        )
-
         self.grid_layout = QtWidgets.QGridLayout()
         self.grid_layout.addWidget(self.label, 0, 0)
         self.grid_layout.addWidget(self.switcher, 0, 1, Qt.AlignRight)
         self.grid_layout.addWidget(self.underline, 1, 0, 1, 2)
-        self.grid_layout.addWidget(self.help, 2, 0, 1, 2)
+
+        if not utils.HELP_URL:
+            # The help widget is entirely optional, based on environment
+            # settings.
+            self.help = None
+        else:
+            self.help = TyphosHelpFrame()
+            self.switcher.help_toggle_button.toggle_help.connect(
+                self.help.toggle_help
+            )
+            self.switcher.help_toggle_button.open_in_browser.connect(
+                self.help.open_in_browser
+            )
+            self.switcher.help_toggle_button.open_python_docs.connect(
+                self.help.open_python_docs
+            )
+            self.help.tooltip_updated.connect(
+                self.switcher.help_toggle_button.setToolTip
+            )
+
+            self.grid_layout.addWidget(self.help, 2, 0, 1, 2)
+
         self.grid_layout.setSizeConstraint(self.grid_layout.SetMinimumSize)
         self.setLayout(self.grid_layout)
 
@@ -749,7 +756,8 @@ class TyphosDisplayTitle(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
         if not self.label.text():
             self.label.setText(device.name)
 
-        self.help.add_device(device)
+        if self.help is not None:
+            self.help.add_device(device)
 
     @QtCore.Property(bool)
     def show_underline(self):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -7,6 +7,7 @@ import functools
 import importlib.util
 import inspect
 import io
+import json
 import logging
 import operator
 import os
@@ -40,17 +41,19 @@ ui_core_dir = ui_dir / 'core'
 GrabKindItem = collections.namedtuple('GrabKindItem',
                                       ('attr', 'component', 'signal'))
 DEBUG_MODE = bool(os.environ.get('TYPHOS_DEBUG', False))
-CONFLUENCE_TOKEN = os.environ.get('TYPHOS_CONFLUENCE_TOKEN', None)
-CONFLUENCE_URL = os.environ.get(
-    'TYPHOS_CONFLUENCE_URL', "https://www.google.com/search?q={device.name}"
-)
-if CONFLUENCE_TOKEN:
-    CONFLUENCE_HEADERS = {
-        "Authorization": f"Bearer {CONFLUENCE_TOKEN}"
-    }
-else:
-    CONFLUENCE_HEADERS = {}
 
+# Help settings:
+# TYPHOS_HELP_URL (str): The help URL format string
+HELP_URL = os.environ.get(
+    'TYPHOS_HELP_URL', "https://www.google.com/search?q={device.name}"
+)
+# TYPHOS_HELP_HEADERS (json): headers to pass to HELP_URL
+HELP_HEADERS = json.loads(os.environ.get('TYPHOS_HELP_HEADERS', "") or "{}")
+# TYPHOS_HELP_TOKEN (str): An optional token for the bearer authentication
+# scheme - e.g., personal access tokens with Confluence
+HELP_TOKEN = os.environ.get('TYPHOS_HELP_TOKEN', None)
+if HELP_TOKEN:
+    HELP_HEADERS["Authorization"] = f"Bearer {HELP_TOKEN}"
 
 if happi is None:
     logger.info("happi is not installed; some features may be unavailable")

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -44,9 +44,7 @@ DEBUG_MODE = bool(os.environ.get('TYPHOS_DEBUG', False))
 
 # Help settings:
 # TYPHOS_HELP_URL (str): The help URL format string
-HELP_URL = os.environ.get(
-    'TYPHOS_HELP_URL', "https://www.google.com/search?q={device.name}"
-)
+HELP_URL = os.environ.get('TYPHOS_HELP_URL', "").strip()
 # TYPHOS_HELP_HEADERS (json): headers to pass to HELP_URL
 HELP_HEADERS = json.loads(os.environ.get('TYPHOS_HELP_HEADERS', "") or "{}")
 # TYPHOS_HELP_TOKEN (str): An optional token for the bearer authentication

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -44,6 +44,12 @@ CONFLUENCE_TOKEN = os.environ.get('TYPHOS_CONFLUENCE_TOKEN', None)
 CONFLUENCE_URL = os.environ.get(
     'TYPHOS_CONFLUENCE_URL', "https://www.google.com/search?q={device.name}"
 )
+if CONFLUENCE_TOKEN:
+    CONFLUENCE_HEADERS = {
+        "Authorization": f"Bearer {CONFLUENCE_TOKEN}"
+    }
+else:
+    CONFLUENCE_HEADERS = {}
 
 
 if happi is None:

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -40,6 +40,10 @@ ui_core_dir = ui_dir / 'core'
 GrabKindItem = collections.namedtuple('GrabKindItem',
                                       ('attr', 'component', 'signal'))
 DEBUG_MODE = bool(os.environ.get('TYPHOS_DEBUG', False))
+CONFLUENCE_TOKEN = os.environ.get('TYPHOS_CONFLUENCE_TOKEN', None)
+CONFLUENCE_URL = os.environ.get(
+    'TYPHOS_CONFLUENCE_URL', "https://www.google.com/search?q={device.name}"
+)
 
 
 if happi is None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
A sketch of a help widget, with the start of confluence integration.

Assumes environment variables are set appropriately:
* `TYPHOS_HELP_URL` (confluence, in our case)
* `TYPHOS_HELP_HEADERS` JSON headers for the help get request
* `TYPHOS_HELP_TOKEN` Shorthand for specifying bearer authorization in the get request without the JSON above (we have a general user with read-only access now; access via token not shared password)

Notes:
* If `TYPHOS_HELP_URL` is unset, this feature is a no-op compared to master. You won't see the `?` button even. 
* Confluence tokens are only on dev confluence for now. Not sure when it'll be updated on production.

## Motivation and Context
Initial step toward closing #114 

## How Has This Been Tested?
Interactively.

## Screenshots (if appropriate):
### New, toggle-able help section
<img width="229" alt="image" src="https://user-images.githubusercontent.com/5139267/123877708-8c274080-d8f2-11eb-86b7-0ef57b2d6f37.png">

### Tooltip and pop-out docstring info
<img width="466" alt="image" src="https://user-images.githubusercontent.com/5139267/123877726-977a6c00-d8f2-11eb-8add-6b9ed97beb76.png">

<img width="584" alt="image" src="https://user-images.githubusercontent.com/5139267/123877923-f809a900-d8f2-11eb-87a8-f55bfbd074a0.png">

### Context menu
<img width="229" alt="image" src="https://user-images.githubusercontent.com/5139267/123877740-a103d400-d8f2-11eb-8302-1b5e852f41d9.png">

### Confluence integration (click "?" to toggle in-line visibility)
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/5139267/125860779-7b64c1d4-9ff1-4085-9976-9f0564106874.png">
