### PR TITLE
MNT: hide stop only on attribute error to avoid bluesky trap

### DIFF
--- a/docs/source/templates.rst
+++ b/docs/source/templates.rst
@@ -7,7 +7,7 @@ browse the ``typhos/ui/core`` and ``typhos/ui/devices`` directories.
 .. note::
 
    This repo originally had a large number of LCLS-specific device templates.
-   These have been moved to :ref:`pcdsdevices.ui <pcdsdevices:ui>`.
+   These have been moved to pcdsdevices.ui.
 
 
 You can define your own templates outside of typhos to customize the behavior

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -50,7 +50,11 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
                    expected to take a ``float`` and return a ``status`` object
                    that indicates the motion completeness. Must be implemented.
 
-    Stop           Device.stop()
+    Stop           ``Device.stop()``, if available, otherwise hide the button.
+                   If you have a non-functional ``stop`` method inherited from
+                   a parent device, you can hide it from ``typhos`` by
+                   overriding it with a property that raises
+                   ``AttributeError`` on access.
 
     Move Indicator The ``moving_attribute`` property is used, which defaults
                    to ``motor_is_moving``. Linked to UI element
@@ -60,11 +64,13 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
                    defaults to ``error_message``. Linked to UI element
                    ``error_label``.
 
-    Clear Error    Device.clear_error()
+    Clear Error    ``Device.clear_error()``, if applicable. This also clears
+                   any visible error messages from the status returned by
+                   ``Device.set``.
 
-    Alarm Circle   Uses the TyphosAlarmCircle widget to summarize the alarm
-                   state of all of the device's ``normal`` and ``hinted``
-                   signals.
+    Alarm Circle   Uses the ``TyphosAlarmCircle`` widget to summarize the
+                   alarm state of all of the device's ``normal`` and
+                   ``hinted`` signals.
     ============== ===========================================================
     """
 

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -375,11 +375,10 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
         self._link_low_limit_switch()
         self._link_high_limit_switch()
 
+        # If the stop method is missing, hide the button
         try:
-            if device.stop is None:
-                self.ui.stop_button.hide()
-            else:
-                self.ui.stop_button.show()
+            device.stop
+            self.ui.stop_button.show()
         except AttributeError:
             self.ui.stop_button.hide()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove the option to set stop to None
Require stop to raise AttributeError to remove the button
Get it in before the v2.0.0 tag
In the last tag: the stop button would appear no matter what, so this won't be an API break except on master.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bluesky logs at the exception level if a call to stop() fails, as it should.
The API here for typhos should not encourage anyone to get into that state.
It's also really messy to override a function with None.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Need to add a docs page suggesting how to override with attribute error
<!--
## Screenshots (if appropriate):
-->
