### PR TITLE
ENH: add suite options for layouts, display types, scrollbars, and starting window size

### DIFF
--- a/typhos/app.py
+++ b/typhos/app.py
@@ -23,12 +23,14 @@ def get_qapp():
     return qapp
 
 
-def launch_suite(suite):
+def launch_suite(suite, initial_size=None):
     """Creates a main window and execs the application."""
     window = QMainWindow()
     window.setCentralWidget(suite)
     window.setWindowTitle(suite.windowTitle())
     window.setUnifiedTitleAndToolBarOnMac(True)
+    if initial_size is not None:
+        window.resize(initial_size)
     window.show()
     logger.info("Launching application ...")
     get_qapp().exec_()

--- a/typhos/app.py
+++ b/typhos/app.py
@@ -1,7 +1,8 @@
 """This module defines methods for launching full typhos applications."""
 import logging
+from typing import Optional
 
-from qtpy.QtCore import QTimer
+from qtpy.QtCore import QSize, QTimer
 from qtpy.QtWidgets import QApplication, QMainWindow
 
 from .suite import TyphosSuite
@@ -23,8 +24,30 @@ def get_qapp():
     return qapp
 
 
-def launch_suite(suite, initial_size=None):
-    """Creates a main window and execs the application."""
+def launch_suite(
+    suite: TyphosSuite,
+    initial_size: Optional[QSize] = None
+) -> QMainWindow:
+    """
+    Creates a main window and execs the application.
+
+    Parameters
+    ----------
+    suite : TyphosSuite
+        The suite that we'd like to launch.
+    initial_size : QSize, optional
+        If provided, the initial size for the full suite window.
+        This can be useful when creating launcher scripts when
+        the default window size isn't very good for that
+        particular suite (e.g. flow layouts)
+
+    Returns
+    -------
+    window : QMainWindow
+        The window that we created. This will not be returned until
+        after the application is done running. This is primarily
+        useful for unit tests.
+    """
     window = QMainWindow()
     window.setCentralWidget(suite)
     window.setWindowTitle(suite.windowTitle())

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -17,7 +17,7 @@ import typhos
 from typhos.app import get_qapp, launch_suite
 from typhos.benchmark.cases import run_benchmarks
 from typhos.benchmark.profile import profiler_context
-from typhos.display import DisplayType
+from typhos.display import DisplayTypes
 from typhos.utils import nullcontext
 
 logger = logging.getLogger(__name__)
@@ -177,11 +177,11 @@ class FixedColGrid(QtWidgets.QGridLayout):
 
 def get_display_type_from_cli(display_type):
     if 'embedded'.startswith(display_type):
-        return DisplayType.embedded_screen
+        return DisplayTypes.embedded_screen
     if 'detailed'.startswith(display_type):
-        return DisplayType.detailed_screen
+        return DisplayTypes.detailed_screen
     if 'engineering'.startswith(display_type):
-        return DisplayType.engineering_screen
+        return DisplayTypes.engineering_screen
     else:
         raise ValueError(
             f'{display_type} is not a valid display type. '
@@ -300,7 +300,7 @@ def typhos_cli(args):
                                cfg=args.happi_cfg,
                                fake_devices=args.fake_device,
                                layout=args.layout,
-                               cols=args.cols,
+                               cols=int(args.cols),
                                display_type=args.display_type,
                                )
         return suite

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -25,70 +25,111 @@ from typhos.utils import nullcontext
 logger = logging.getLogger(__name__)
 
 # Argument Parser Setup
-parser = argparse.ArgumentParser(description='Create a TyphosSuite for '
-                                             'device/s stored in a Happi '
-                                             'Database')
+parser = argparse.ArgumentParser(
+    description='Create a TyphosSuite for '
+    'device/s stored in a Happi '
+    'Database'
+)
 
-parser.add_argument('devices', nargs='*',
-                    help='Device names to load in the TyphosSuite or '
-                         'class name with parameters on the format: '
-                         'package.ClassName[{"param1":"val1",...}]')
-parser.add_argument('--layout', default='horizontal',
-                    help='Select a alternate layout for suites of many '
-                         'devices. Valid options are "horizontal" (default), '
-                         '"vertical", "grid", "flow", and any unique '
-                         'shortenings of those options.')
-parser.add_argument('--cols', default=3,
-                    help='The number of columns to use for the grid layout '
-                         'if selected in the layout argument. This will have '
-                         'no effect for other layouts.')
-parser.add_argument('--display-type', default='detailed',
-                    help='The kind of display to open for each device at '
-                         'initial load. Valid options are "embedded", '
-                         '"detailed" (default), "engineering", and any '
-                         'unique shortenings of those options.')
-parser.add_argument('--scrollable', default='auto',
-                    help='Whether or not to include the scrollbar. '
-                         'Valid options are "auto", "true", "false", '
-                         'and any unique shortenings of those options. '
-                         'Selecting "auto" will include a scrollbar for '
-                         'non-embedded layouts.')
-parser.add_argument('--size',
-                    help='A starting x,y size for the typhos suite. '
-                         'Useful if the default size is not suitable for '
-                         'your application. Example: --size 1000,1000')
-parser.add_argument('--happi-cfg',
-                    help='Location of happi configuration file '
-                         'if not specified by $HAPPI_CFG environment variable')
-parser.add_argument('--fake-device', action='store_true',
-                    help='Create fake devices with no EPICS connections. '
-                         'This does not yet work for happi devices. An '
-                         'example invocation: '
-                         'typhos --fake-device ophyd.EpicsMotor[]')
-parser.add_argument('--version', '-V', action='store_true',
-                    help='Current version and location '
-                         'of Typhos installation.')
-parser.add_argument('--verbose', '-v', action='store_true',
-                    help='Show the debug logging stream')
-parser.add_argument('--dark', action='store_true',
-                    help='Use the QDarkStyleSheet shipped with Typhos')
-parser.add_argument('--stylesheet',
-                    help='Additional stylesheet options')
-parser.add_argument('--profile-modules', nargs='*',
-                    help='Submodules to profile during the execution. '
-                         'If no specific modules are specified, '
-                         'profiles all submodules of typhos. '
-                         'Turns on line profiling.')
-parser.add_argument('--profile-output',
-                    help='Filename to output the profile results to. '
-                         'If omitted, prints results to stdout. '
-                         'Turns on line profiling.')
-parser.add_argument('--benchmark', nargs='*',
-                    help='Runs the specified benchmarking tests instead of '
-                         'launching a screen. '
-                         'If no specific tests are specified, '
-                         'runs all of them. '
-                         'Turns on line profiling.')
+parser.add_argument(
+    'devices',
+    nargs='*',
+    help='Device names to load in the TyphosSuite or '
+    'class name with parameters on the format: '
+    'package.ClassName[{"param1":"val1",...}]',
+)
+parser.add_argument(
+    '--layout',
+    default='horizontal',
+    help='Select a alternate layout for suites of many '
+    'devices. Valid options are "horizontal" (default), '
+    '"vertical", "grid", "flow", and any unique '
+    'shortenings of those options.',
+)
+parser.add_argument(
+    '--cols',
+    default=3,
+    help='The number of columns to use for the grid layout '
+    'if selected in the layout argument. This will have '
+    'no effect for other layouts.',
+)
+parser.add_argument(
+    '--display-type',
+    default='detailed',
+    help='The kind of display to open for each device at '
+    'initial load. Valid options are "embedded", '
+    '"detailed" (default), "engineering", and any '
+    'unique shortenings of those options.',
+)
+parser.add_argument(
+    '--scrollable',
+    default='auto',
+    help='Whether or not to include the scrollbar. '
+    'Valid options are "auto", "true", "false", '
+    'and any unique shortenings of those options. '
+    'Selecting "auto" will include a scrollbar for '
+    'non-embedded layouts.',
+)
+parser.add_argument(
+    '--size',
+    help='A starting x,y size for the typhos suite. '
+    'Useful if the default size is not suitable for '
+    'your application. Example: --size 1000,1000',
+)
+parser.add_argument(
+    '--happi-cfg',
+    help='Location of happi configuration file '
+    'if not specified by $HAPPI_CFG environment variable',
+)
+parser.add_argument(
+    '--fake-device',
+    action='store_true',
+    help='Create fake devices with no EPICS connections. '
+    'This does not yet work for happi devices. An '
+    'example invocation: '
+    'typhos --fake-device ophyd.EpicsMotor[]',
+)
+parser.add_argument(
+    '--version',
+    '-V',
+    action='store_true',
+    help='Current version and location ' 'of Typhos installation.',
+)
+parser.add_argument(
+    '--verbose',
+    '-v',
+    action='store_true',
+    help='Show the debug logging stream',
+)
+parser.add_argument(
+    '--dark',
+    action='store_true',
+    help='Use the QDarkStyleSheet shipped with Typhos',
+)
+parser.add_argument('--stylesheet', help='Additional stylesheet options')
+parser.add_argument(
+    '--profile-modules',
+    nargs='*',
+    help='Submodules to profile during the execution. '
+    'If no specific modules are specified, '
+    'profiles all submodules of typhos. '
+    'Turns on line profiling.',
+)
+parser.add_argument(
+    '--profile-output',
+    help='Filename to output the profile results to. '
+    'If omitted, prints results to stdout. '
+    'Turns on line profiling.',
+)
+parser.add_argument(
+    '--benchmark',
+    nargs='*',
+    help='Runs the specified benchmarking tests instead of '
+    'launching a screen. '
+    'If no specific tests are specified, '
+    'runs all of them. '
+    'Turns on line profiling.',
+)
 
 
 # Append to module docs
@@ -102,13 +143,14 @@ def typhos_cli_setup(args):
     shown_logger = logging.getLogger('typhos')
     if args.verbose:
         level = "DEBUG"
-        log_fmt = '[%(asctime)s] - %(levelname)s - Thread (%(thread)d - ' \
-                  '%(threadName)s ) - %(name)s -> %(message)s'
+        log_fmt = (
+            '[%(asctime)s] - %(levelname)s - Thread (%(thread)d - '
+            '%(threadName)s ) - %(name)s -> %(message)s'
+        )
     else:
         level = "INFO"
         log_fmt = '[%(asctime)s] - %(levelname)s - %(message)s'
-    coloredlogs.install(level=level, logger=shown_logger,
-                        fmt=log_fmt)
+    coloredlogs.install(level=level, logger=shown_logger, fmt=log_fmt)
     logger.debug("Set logging level of %r to %r", shown_logger.name, level)
 
     # Deal with stylesheet
@@ -143,7 +185,7 @@ def create_suite(
     layout: str = 'horizontal',
     cols: int = 3,
     display_type: str = 'detailed',
-    scroll_option: str = 'auto'
+    scroll_option: str = 'auto',
 ) -> TyphosSuite:
     """
     Create a TyphosSuite from a list of device names.
@@ -178,8 +220,9 @@ def create_suite(
         A suite that has been populated with devices.
     """
     if device_names:
-        devices = create_devices(device_names, cfg=cfg,
-                                 fake_devices=fake_devices)
+        devices = create_devices(
+            device_names, cfg=cfg, fake_devices=fake_devices
+        )
     else:
         devices = []
     if devices or not device_names:
@@ -191,7 +234,7 @@ def create_suite(
             content_layout=layout_obj,
             default_display_type=display_type_enum,
             scroll_option=scroll_enum,
-            )
+        )
 
 
 def get_layout_from_cli(
@@ -226,7 +269,7 @@ def get_layout_from_cli(
             f'{layout} is not a valid layout name. '
             'The allowed values are "horizontal", '
             '"vertical", "grid", and "flow".'
-            )
+        )
 
 
 class FixedColGrid(QtWidgets.QGridLayout):
@@ -239,6 +282,7 @@ class FixedColGrid(QtWidgets.QGridLayout):
     number of columns and fill devices in row-by-row, left-to-right
     first and then top-to-bottom.
     """
+
     def __init__(
         self,
         *args,
@@ -273,7 +317,7 @@ def get_display_type_from_cli(display_type: str) -> DisplayTypes:
             f'{display_type} is not a valid display type. '
             'The allowed values are "embedded", "detailed", '
             'and "engineering".'
-            )
+        )
 
 
 def get_scrollable_from_cli(scrollable: str) -> ScrollOptions:
@@ -289,7 +333,7 @@ def get_scrollable_from_cli(scrollable: str) -> ScrollOptions:
             f'{scrollable} is not a valid scroll option. '
             'The allowed values are "auto", "true", '
             'and "false".'
-            )
+        )
 
 
 def create_devices(device_names, cfg=None, fake_devices=False):
@@ -337,22 +381,28 @@ def create_devices(device_names, cfg=None, fake_devices=False):
                 devices.append(device)
 
             except Exception:
-                logger.exception("Unable to load class entry: %s with args %s",
-                                 klass, args)
+                logger.exception(
+                    "Unable to load class entry: %s with args %s", klass, args
+                )
                 continue
         else:
             if not happi_client:
-                logger.error("Happi not available. Unable to load entry: %r",
-                             device_name)
+                logger.error(
+                    "Happi not available. Unable to load entry: %r",
+                    device_name,
+                )
                 continue
             if fake_devices:
-                raise NotImplementedError("Fake devices from happi not "
-                                          "supported yet")
+                raise NotImplementedError(
+                    "Fake devices from happi not " "supported yet"
+                )
             try:
                 device = happi_client.load_device(name=device_name)
                 devices.append(device)
             except Exception:
-                logger.exception("Unable to load Happi entry: %r", device_name)
+                logger.exception(
+                    "Unable to load Happi entry: %r", device_name
+                )
         if fake_devices:
             clear_fake_device(device)
     return devices
@@ -412,7 +462,7 @@ def typhos_run(
             cols=cols,
             display_type=display_type,
             scroll_option=scroll_option,
-            )
+        )
     if suite:
         if initial_size is not None:
             try:
@@ -435,11 +485,18 @@ def typhos_cli(args):
         print(f'Typhos: Version {typhos.__version__} from {typhos.__file__}')
         return
 
-    if any((args.profile_modules is not None, args.profile_output,
-            args.benchmark is not None)):
+    if any(
+        (
+            args.profile_modules is not None,
+            args.profile_output,
+            args.benchmark is not None,
+        )
+    ):
         if args.profile_modules:
-            context = profiler_context(module_names=args.profile_modules,
-                                       filename=args.profile_output)
+            context = profiler_context(
+                module_names=args.profile_modules,
+                filename=args.profile_output,
+            )
         else:
             context = profiler_context(filename=args.profile_output)
     else:
@@ -452,15 +509,16 @@ def typhos_cli(args):
             suite = run_benchmarks(args.benchmark)
         else:
 
-            suite = typhos_run(args.devices,
-                               cfg=args.happi_cfg,
-                               fake_devices=args.fake_device,
-                               layout=args.layout,
-                               cols=int(args.cols),
-                               display_type=args.display_type,
-                               scroll_option=args.scrollable,
-                               initial_size=args.size,
-                               )
+            suite = typhos_run(
+                args.devices,
+                cfg=args.happi_cfg,
+                fake_devices=args.fake_device,
+                layout=args.layout,
+                cols=int(args.cols),
+                display_type=args.display_type,
+                scroll_option=args.scrollable,
+                initial_size=args.size,
+            )
         return suite
 
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -51,7 +51,7 @@ parser.add_argument('--scrollable', default='auto',
                          'and any unique shortenings of those options. '
                          'Selecting "auto" will include a scrollbar for '
                          'non-embedded layouts.')
-parser.add_argument('--size', 
+parser.add_argument('--size',
                     help='A starting x,y size for the typhos suite. '
                          'Useful if the default size is not suitable for '
                          'your application. Example: --size 1000,1000')

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -40,7 +40,7 @@ parser.add_argument('--cols', default=3,
                     help='The number of columns to use for the grid layout '
                          'if selected in the layout argument. This will have '
                          'no effect for other layouts.')
-parser.add_argument('--display_type', default='detailed',
+parser.add_argument('--display-type', default='detailed',
                     help='The kind of display to open for each device at '
                          'initial load. Valid options are "embedded", '
                          '"detailed" (default), "engineering", and any '

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -26,68 +26,83 @@ logger = logging.getLogger(__name__)
 
 # Argument Parser Setup
 parser = argparse.ArgumentParser(
-    description='Create a TyphosSuite for '
-    'device/s stored in a Happi '
-    'Database'
+    description=(
+        'Create a TyphosSuite for device/s stored in a Happi Database'
+    ),
 )
 
 parser.add_argument(
     'devices',
     nargs='*',
-    help='Device names to load in the TyphosSuite or '
-    'class name with parameters on the format: '
-    'package.ClassName[{"param1":"val1",...}]',
+    help=(
+        'Device names to load in the TyphosSuite or class name with '
+        'parameters on the format: package.ClassName[{"param1":"val1",...}]'
+    ),
 )
 parser.add_argument(
     '--layout',
     default='horizontal',
-    help='Select a alternate layout for suites of many '
-    'devices. Valid options are "horizontal" (default), '
-    '"vertical", "grid", "flow", and any unique '
-    'shortenings of those options.',
+    help=(
+        'Select a alternate layout for suites of many '
+        'devices. Valid options are "horizontal" (default), '
+        '"vertical", "grid", "flow", and any unique '
+        'shortenings of those options.'
+    ),
 )
 parser.add_argument(
     '--cols',
     default=3,
-    help='The number of columns to use for the grid layout '
-    'if selected in the layout argument. This will have '
-    'no effect for other layouts.',
+    help=(
+        'The number of columns to use for the grid layout '
+        'if selected in the layout argument. This will have '
+        'no effect for other layouts.'
+    ),
 )
 parser.add_argument(
     '--display-type',
     default='detailed',
-    help='The kind of display to open for each device at '
-    'initial load. Valid options are "embedded", '
-    '"detailed" (default), "engineering", and any '
-    'unique shortenings of those options.',
+    help=(
+        'The kind of display to open for each device at '
+        'initial load. Valid options are "embedded", '
+        '"detailed" (default), "engineering", and any '
+        'unique shortenings of those options.'
+    ),
 )
 parser.add_argument(
     '--scrollable',
     default='auto',
-    help='Whether or not to include the scrollbar. '
-    'Valid options are "auto", "true", "false", '
-    'and any unique shortenings of those options. '
-    'Selecting "auto" will include a scrollbar for '
-    'non-embedded layouts.',
+    help=(
+        'Whether or not to include the scrollbar. '
+        'Valid options are "auto", "true", "false", '
+        'and any unique shortenings of those options. '
+        'Selecting "auto" will include a scrollbar for '
+        'non-embedded layouts.'
+    ),
 )
 parser.add_argument(
     '--size',
-    help='A starting x,y size for the typhos suite. '
-    'Useful if the default size is not suitable for '
-    'your application. Example: --size 1000,1000',
+    help=(
+        'A starting x,y size for the typhos suite. '
+        'Useful if the default size is not suitable for '
+        'your application. Example: --size 1000,1000'
+    ),
 )
 parser.add_argument(
     '--happi-cfg',
-    help='Location of happi configuration file '
-    'if not specified by $HAPPI_CFG environment variable',
+    help=(
+        'Location of happi configuration file '
+        'if not specified by $HAPPI_CFG environment variable'
+    ),
 )
 parser.add_argument(
     '--fake-device',
     action='store_true',
-    help='Create fake devices with no EPICS connections. '
-    'This does not yet work for happi devices. An '
-    'example invocation: '
-    'typhos --fake-device ophyd.EpicsMotor[]',
+    help=(
+        'Create fake devices with no EPICS connections. '
+        'This does not yet work for happi devices. An '
+        'example invocation: '
+        'typhos --fake-device ophyd.EpicsMotor[]'
+    ),
 )
 parser.add_argument(
     '--version',
@@ -110,25 +125,31 @@ parser.add_argument('--stylesheet', help='Additional stylesheet options')
 parser.add_argument(
     '--profile-modules',
     nargs='*',
-    help='Submodules to profile during the execution. '
-    'If no specific modules are specified, '
-    'profiles all submodules of typhos. '
-    'Turns on line profiling.',
+    help=(
+        'Submodules to profile during the execution. '
+        'If no specific modules are specified, '
+        'profiles all submodules of typhos. '
+        'Turns on line profiling.'
+    ),
 )
 parser.add_argument(
     '--profile-output',
-    help='Filename to output the profile results to. '
-    'If omitted, prints results to stdout. '
-    'Turns on line profiling.',
+    help=(
+        'Filename to output the profile results to. '
+        'If omitted, prints results to stdout. '
+        'Turns on line profiling.'
+    ),
 )
 parser.add_argument(
     '--benchmark',
     nargs='*',
-    help='Runs the specified benchmarking tests instead of '
-    'launching a screen. '
-    'If no specific tests are specified, '
-    'runs all of them. '
-    'Turns on line profiling.',
+    help=(
+        'Runs the specified benchmarking tests instead of '
+        'launching a screen. '
+        'If no specific tests are specified, '
+        'runs all of them. '
+        'Turns on line profiling.'
+    ),
 )
 
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -327,34 +327,34 @@ class FixedColGrid(QtWidgets.QGridLayout):
 
 def get_display_type_from_cli(display_type: str) -> DisplayTypes:
     """Convert the cli string to the appropriate DisplayTypes enum."""
+    display_type = display_type.lower()
     if 'embedded'.startswith(display_type):
         return DisplayTypes.embedded_screen
     if 'detailed'.startswith(display_type):
         return DisplayTypes.detailed_screen
     if 'engineering'.startswith(display_type):
         return DisplayTypes.engineering_screen
-    else:
-        raise ValueError(
-            f'{display_type} is not a valid display type. '
-            'The allowed values are "embedded", "detailed", '
-            'and "engineering".'
-        )
+    raise ValueError(
+        f'{display_type} is not a valid display type. '
+        'The allowed values are "embedded", "detailed", '
+        'and "engineering".'
+    )
 
 
 def get_scrollable_from_cli(scrollable: str) -> ScrollOptions:
     """Convert the cli string to the appropriate ScrollOptions enum."""
+    scrollable = scrollable.lower()
     if 'auto'.startswith(scrollable):
         return ScrollOptions.auto
     if 'true'.startswith(scrollable):
         return ScrollOptions.scrollbar
     if 'false'.startswith(scrollable):
         return ScrollOptions.no_scroll
-    else:
-        raise ValueError(
-            f'{scrollable} is not a valid scroll option. '
-            'The allowed values are "auto", "true", '
-            'and "false".'
-        )
+    raise ValueError(
+        f'{scrollable} is not a valid scroll option. '
+        'The allowed values are "auto", "true", '
+        'and "false".'
+    )
 
 
 def create_devices(device_names, cfg=None, fake_devices=False):

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -28,6 +28,10 @@ parser.add_argument('devices', nargs='*',
                     help='Device names to load in the TyphosSuite or '
                          'class name with parameters on the format: '
                          'package.ClassName[{"param1":"val1",...}]')
+parser.add_argument('--embed', action='store_true',
+                    help='Load the embedded templates instead of the '
+                         'detailed templates. Good for suites with many '
+                         'devices.')
 parser.add_argument('--happi-cfg',
                     help='Location of happi configuration file '
                          'if not specified by $HAPPI_CFG environment variable')
@@ -107,7 +111,7 @@ def _create_happi_client(cfg):
     return happi.Client.from_config(cfg=cfg)
 
 
-def create_suite(device_names, cfg=None, fake_devices=False):
+def create_suite(device_names, cfg=None, fake_devices=False, embedded=False):
     """Create a TyphosSuite from a list of device names."""
     if device_names:
         devices = create_devices(device_names, cfg=cfg,
@@ -115,7 +119,7 @@ def create_suite(device_names, cfg=None, fake_devices=False):
     else:
         devices = []
     if devices or not device_names:
-        return typhos.TyphosSuite.from_devices(devices)
+        return typhos.TyphosSuite.from_devices(devices, embedded=embedded)
 
 
 def create_devices(device_names, cfg=None, fake_devices=False):
@@ -184,10 +188,15 @@ def create_devices(device_names, cfg=None, fake_devices=False):
     return devices
 
 
-def typhos_run(device_names, cfg=None, fake_devices=False):
+def typhos_run(device_names, cfg=None, fake_devices=False, embedded=False):
     """Run the central typhos part of typhos."""
     with typhos.utils.no_device_lazy_load():
-        suite = create_suite(device_names, cfg=cfg, fake_devices=fake_devices)
+        suite = create_suite(
+            device_names,
+            cfg=cfg,
+            fake_devices=fake_devices,
+            embedded=embedded,
+            )
     if suite:
         return launch_suite(suite)
 
@@ -216,8 +225,11 @@ def typhos_cli(args):
             # Note: actually a list of suites
             suite = run_benchmarks(args.benchmark)
         else:
-            suite = typhos_run(args.devices, cfg=args.happi_cfg,
-                               fake_devices=args.fake_device)
+            suite = typhos_run(args.devices,
+                               cfg=args.happi_cfg,
+                               fake_devices=args.fake_device,
+                               embedded=args.embed,
+                               )
         return suite
 
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -84,10 +84,13 @@ def normalize_display_type(
     """
     try:
         return DisplayTypes(display_type)
-    except Exception as ex:
-        if display_type in DisplayTypes.names:
-            return getattr(DisplayTypes, display_type)
-        raise ValueError(f'Unrecognized display type: {display_type}') from ex
+    except ValueError:
+        try:
+            return DisplayTypes[display_type]
+        except KeyError:
+            raise ValueError(
+                f'Unrecognized display type: {display_type}'
+            )
 
 
 def normalize_scroll_option(
@@ -113,12 +116,13 @@ def normalize_scroll_option(
     """
     try:
         return ScrollOptions(scroll_option)
-    except Exception as ex:
-        if scroll_option in ScrollOptions.names:
-            return getattr(ScrollOptions, scroll_option)
-        raise ValueError(
-            f'Unrecognized scroll option: {scroll_option}'
-        ) from ex
+    except ValueError:
+        try:
+            return ScrollOptions[scroll_option]
+        except KeyError:
+            raise ValueError(
+                f'Unrecognized scroll option: {scroll_option}'
+            )
 
 
 class TyphosToolButton(QtWidgets.QToolButton):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1168,7 +1168,10 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             return widget.size()
 
         # sizeHint is not defined so we suggest the widget size
-        widget.sizeHint = size_hint
+        try:
+            widget.sizeHint
+        except AttributeError:
+            widget.sizeHint = size_hint
 
         # We should _move_display_to_layout as soon as it is created. This
         # allow us to speed up since if the widget is too complex it takes

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1176,10 +1176,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             return widget.size()
 
         # sizeHint is not defined so we suggest the widget size
-        try:
-            widget.sizeHint
-        except AttributeError:
-            widget.sizeHint = size_hint
+        widget.sizeHint = size_hint
 
         # We should _move_display_to_layout as soon as it is created. This
         # allow us to speed up since if the widget is too complex it takes

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1034,14 +1034,14 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             return
 
         widget.setParent(None)
-        if self._scroll_option == ScrollOptions.auto:
+        if self.scroll_option == ScrollOptions.auto:
             if self.display_type == DisplayTypes.embedded_screen:
                 scrollable = False
             else:
                 scrollable = True
-        elif self._scroll_option == ScrollOptions.scrollbar:
+        elif self.scroll_option == ScrollOptions.scrollbar:
             scrollable = True
-        elif self._scroll_option == ScrollOptions.no_scroll:
+        elif self.scroll_option == ScrollOptions.no_scroll:
             scrollable = False
         else:
             scrollable = True

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -994,7 +994,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             else:
                 self.scroll_option = ScrollOptions.no_scroll
 
-
     @Property(bool)
     def composite_heuristics(self):
         """Allow composite screen to be suggested first by heuristics."""

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1440,7 +1440,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             obj = pcdsutils.utils.get_instance_by_name(klass, **kwargs)
         except Exception:
             logger.exception('Failed to generate TyphosDeviceDisplay from '
-                             'device %s', obj)
+                             'class %s', klass)
             return None
 
         return cls.from_device(obj, template=template, macros=macros)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -7,11 +7,11 @@ import os
 import textwrap
 from functools import partial
 
+import pcdsutils.qt
+from pydm.widgets.template_repeater import FlowLayout
 from pyqtgraph.parametertree import ParameterTree
 from pyqtgraph.parametertree import parameterTypes as ptypes
 from qtpy import QtCore, QtWidgets
-
-import pcdsutils.qt
 
 from . import utils, widgets
 from .display import TyphosDeviceDisplay
@@ -175,7 +175,7 @@ class TyphosSuite(TyphosBase):
         self._content_frame = QtWidgets.QFrame(self)
         self._content_frame.setObjectName("content")
         self._content_frame.setFrameShape(QtWidgets.QFrame.StyledPanel)
-        self._content_frame.setLayout(QtWidgets.QHBoxLayout())
+        self._content_frame.setLayout(FlowLayout())
 
         # Horizontal box layout: [PopBar] [Content Frame]
         layout = QtWidgets.QHBoxLayout()

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -332,6 +332,8 @@ class TyphosSuite(TyphosBase):
         dock.setWidget(widget)
         # Add to layout
         self._content_frame.layout().addWidget(dock)
+        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignHCenter)
+        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignTop)
 
     @QtCore.Slot(str)
     @QtCore.Slot(object)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -332,8 +332,6 @@ class TyphosSuite(TyphosBase):
         dock.setWidget(widget)
         # Add to layout
         self._content_frame.layout().addWidget(dock)
-        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignHCenter)
-        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignTop)
 
     @QtCore.Slot(str)
     @QtCore.Slot(object)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -342,6 +342,8 @@ class TyphosSuite(TyphosBase):
         dock.setWidget(widget)
         # Add to layout
         self._content_frame.layout().addWidget(dock)
+        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignHCenter)
+        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignTop)
 
     @QtCore.Slot(str)
     @QtCore.Slot(object)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -345,8 +345,12 @@ class TyphosSuite(TyphosBase):
         content_layout = self._content_frame.layout()
         content_layout.addWidget(dock)
         if isinstance(content_layout, QtWidgets.QGridLayout):
-            self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignHCenter)
-            self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignTop)
+            self._content_frame.layout().setAlignment(
+                dock, QtCore.Qt.AlignHCenter
+            )
+            self._content_frame.layout().setAlignment(
+                dock, QtCore.Qt.AlignTop
+            )
 
     @QtCore.Slot(str)
     @QtCore.Slot(object)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -342,9 +342,11 @@ class TyphosSuite(TyphosBase):
         widget.load_best_template()
         dock.setWidget(widget)
         # Add to layout
-        self._content_frame.layout().addWidget(dock)
-        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignHCenter)
-        self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignTop)
+        content_layout = self._content_frame.layout()
+        content_layout.addWidget(dock)
+        if isinstance(content_layout, QtWidgets.QGridLayout):
+            self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignHCenter)
+            self._content_frame.layout().setAlignment(dock, QtCore.Qt.AlignTop)
 
     @QtCore.Slot(str)
     @QtCore.Slot(object)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -13,7 +13,7 @@ from pyqtgraph.parametertree import parameterTypes as ptypes
 from qtpy import QtCore, QtWidgets
 
 from . import utils, widgets
-from .display import DisplayTypes, TyphosDeviceDisplay
+from .display import DisplayTypes, ScrollOptions, TyphosDeviceDisplay
 from .tools import TyphosConsole, TyphosLogDisplay, TyphosTimePlot
 from .utils import TyphosBase, clean_name, flatten_tree, save_suite
 
@@ -152,6 +152,12 @@ class TyphosSuite(TyphosBase):
         DisplayType enum that determines the type of display to open when we
         add a device to the suite. Defaults to DisplayType.detailed_screen.
 
+    scroll_option : ScrollOptions, optional
+        ScrollOptions enum that determines the behavior of scrollbars
+        in the suite. Default is ScrollOptions.auto, which enables
+        scrollbars for detailed and engineering screens but not for
+        embedded displays.
+
     Attributes
     ----------
     default_tools : dict
@@ -167,7 +173,8 @@ class TyphosSuite(TyphosBase):
                      'Console': TyphosConsole}
 
     def __init__(self, parent=None, *, pin=False, content_layout=None,
-                 default_display_type=DisplayTypes.detailed_screen):
+                 default_display_type=DisplayTypes.detailed_screen,
+                 scroll_option=ScrollOptions.auto):
         super().__init__(parent=parent)
 
         self._update_title()
@@ -201,6 +208,7 @@ class TyphosSuite(TyphosBase):
 
         self.embedded_dock = None
         self.default_display_type = default_display_type
+        self.scroll_option = scroll_option
 
     def add_subdisplay(self, name, display, category):
         """
@@ -326,6 +334,8 @@ class TyphosSuite(TyphosBase):
         self._show_sidebar(widget, dock)
         # Add the widget to the dock
         logger.debug("Showing widget %r ...", widget)
+        if hasattr(widget, 'scroll_option'):
+            widget.scroll_option = self.scroll_option
         if hasattr(widget, 'display_type'):
             widget.display_type = self.default_display_type
         widget.setVisible(True)
@@ -462,6 +472,7 @@ class TyphosSuite(TyphosBase):
     def from_device(cls, device, parent=None, tools=DEFAULT_TOOLS, pin=False,
                     content_layout=None,
                     default_display_type=DisplayTypes.detailed_screen,
+                    scroll_option=ScrollOptions.auto,
                     **kwargs):
         """
         Create a new :class:`TyphosSuite` from an :class:`ophyd.Device`.
@@ -494,18 +505,26 @@ class TyphosSuite(TyphosBase):
             we add a device to the suite. Defaults to
             DisplayTypes.detailed_screen.
 
+        scroll_option : ScrollOptions, optional
+            ScrollOptions enum that determines the behavior of scrollbars
+            in the suite. Default is ScrollOptions.auto, which enables
+            scrollbars for detailed and engineering screens but not for
+            embedded displays.
+
         **kwargs :
             Passed to :meth:`TyphosSuite.add_device`
         """
         return cls.from_devices([device], parent=parent, tools=tools, pin=pin,
                                 content_layout=content_layout,
                                 default_display_type=default_display_type,
+                                scroll_option=scroll_option,
                                 **kwargs)
 
     @classmethod
     def from_devices(cls, devices, parent=None, tools=DEFAULT_TOOLS, pin=False,
                      content_layout=None,
                      default_display_type=DisplayTypes.detailed_screen,
+                     scroll_option=ScrollOptions.auto,
                      **kwargs):
         """
         Create a new TyphosSuite from an iterator of :class:`ophyd.Device`
@@ -537,6 +556,12 @@ class TyphosSuite(TyphosBase):
             we add a device to the suite. Defaults to
             DisplayTypes.detailed_screen.
 
+        scroll_option : ScrollOptions, optional
+            ScrollOptions enum that determines the behavior of scrollbars
+            in the suite. Default is ScrollOptions.auto, which enables
+            scrollbars for detailed and engineering screens but not for
+            embedded displays.
+
         **kwargs :
             Passed to :meth:`TyphosSuite.add_device`
         """
@@ -545,6 +570,7 @@ class TyphosSuite(TyphosBase):
             pin=pin,
             content_layout=content_layout,
             default_display_type=default_display_type,
+            scroll_option=scroll_option,
             )
         if tools is not None:
             logger.info("Loading Tools ...")

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -334,11 +334,12 @@ class TyphosSuite(TyphosBase):
         self._show_sidebar(widget, dock)
         # Add the widget to the dock
         logger.debug("Showing widget %r ...", widget)
-        if hasattr(widget, 'scroll_option'):
-            widget.scroll_option = self.scroll_option
         if hasattr(widget, 'display_type'):
             widget.display_type = self.default_display_type
+        if hasattr(widget, 'scroll_option'):
+            widget.scroll_option = self.scroll_option
         widget.setVisible(True)
+        widget.load_best_template()
         dock.setWidget(widget)
         # Add to layout
         self._content_frame.layout().addWidget(dock)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -1,13 +1,16 @@
 """
 The high-level Typhos Suite, which bundles tools and panels.
 """
+from __future__ import annotations
 
 import logging
 import os
 import textwrap
 from functools import partial
+from typing import Dict, List, Optional, Union
 
 import pcdsutils.qt
+from ophyd import Device
 from pyqtgraph import parametertree
 from pyqtgraph.parametertree import parameterTypes as ptypes
 from qtpy import QtCore, QtWidgets
@@ -143,7 +146,7 @@ class TyphosSuite(TyphosBase):
     pin : bool, optional
         Pin the parameter tree on startup.
 
-    layout : QLayout, optional
+    content_layout : QLayout, optional
         Sets the layout for when we have multiple subdisplays
         open in the suite. This will have a horizontal layout by
         default but can be changed as needed for the use case.
@@ -172,9 +175,15 @@ class TyphosSuite(TyphosBase):
                      'StripTool': TyphosTimePlot,
                      'Console': TyphosConsole}
 
-    def __init__(self, parent=None, *, pin=False, content_layout=None,
-                 default_display_type=DisplayTypes.detailed_screen,
-                 scroll_option=ScrollOptions.auto):
+    def __init__(
+        self,
+        parent: Optional[QtWidgets.QWidget] = None,
+        *,
+        pin: bool = False,
+        content_layout: Optional[QtWidgets.QLayout] = None,
+        default_display_type: DisplayTypes = DisplayTypes.detailed_screen,
+        scroll_option: ScrollOptions = ScrollOptions.auto,
+    ):
         super().__init__(parent=parent)
 
         self._update_title()
@@ -478,11 +487,17 @@ class TyphosSuite(TyphosBase):
                                  device.name, type(tool))
 
     @classmethod
-    def from_device(cls, device, parent=None, tools=DEFAULT_TOOLS, pin=False,
-                    content_layout=None,
-                    default_display_type=DisplayTypes.detailed_screen,
-                    scroll_option=ScrollOptions.auto,
-                    **kwargs):
+    def from_device(
+        cls,
+        device: Device,
+        parent: Optional[QtWidgets.QWidget] = None,
+        tools: Union[Dict[str, type], None, DEFAULT_TOOLS] = DEFAULT_TOOLS,
+        pin: bool = False,
+        content_layout: Optional[QtWidgets.QLayout] = None,
+        default_display_type: DisplayTypes = DisplayTypes.detailed_screen,
+        scroll_option: ScrollOptions = ScrollOptions.auto,
+        **kwargs,
+    ) -> TyphosSuite:
         """
         Create a new :class:`TyphosSuite` from an :class:`ophyd.Device`.
 
@@ -530,11 +545,17 @@ class TyphosSuite(TyphosBase):
                                 **kwargs)
 
     @classmethod
-    def from_devices(cls, devices, parent=None, tools=DEFAULT_TOOLS, pin=False,
-                     content_layout=None,
-                     default_display_type=DisplayTypes.detailed_screen,
-                     scroll_option=ScrollOptions.auto,
-                     **kwargs):
+    def from_devices(
+        cls,
+        devices: List[Device],
+        parent: Optional[QtWidgets.QWidget] = None,
+        tools: Union[Dict[str, type], None, DEFAULT_TOOLS] = DEFAULT_TOOLS,
+        pin: bool = False,
+        content_layout: Optional[QtWidgets.QLayout] = None,
+        default_display_type: DisplayTypes = DisplayTypes.detailed_screen,
+        scroll_option: ScrollOptions = ScrollOptions.auto,
+        **kwargs,
+    ) -> TyphosSuite:
         """
         Create a new TyphosSuite from an iterator of :class:`ophyd.Device`
 

--- a/typhos/ui/devices/PositionerBase.embedded.ui
+++ b/typhos/ui/devices/PositionerBase.embedded.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>337</width>
+    <width>343</width>
     <height>258</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -66,6 +66,9 @@
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
      <property name="toolTip">
       <string/>
+     </property>
+     <property name="show_switcher" stdset="0">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/typhos/ui/devices/PositionerBase.embedded.ui
+++ b/typhos/ui/devices/PositionerBase.embedded.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>343</width>
+    <width>337</width>
     <height>258</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -66,9 +66,6 @@
     <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
      <property name="toolTip">
       <string/>
-     </property>
-     <property name="show_switcher" stdset="0">
-      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the following options to the CLI and their corresponding handlers in the library:
- `--layout`: pick between horizontal (default), vertical, grid, or flow layouts. The flow layout is lifted from PyDM and allows the user to resize the window and have the widgets populate the space as needed, e.g. a semi-dynamic grid.
- `--cols`: select how many columns the grid layout has
- `--display-type`: pick between embedded, detailed (default), or engineering screen as the kind of display to open at the start.
- `--scrollable`: pick between auto (default), true, and false to control whether the screen can have scrollbars or not. While auto is the default, this is actually new behavior: allows scrollbars for detailed and engineering screens, but not for embedded screens.
- `--size`: pick a starting size for the window. The default is whatever the window's size hint is (I think?)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- TMO has been using a horizontal layout of ~17 detailed screens in a suite which takes up a ton of horizontal space and needs some clicking around to make them all embedded.
- In general, some options for how to arrange these gives us ways to quickly generate reasonable groups of screens.
- The grid and flow layouts are probably most appropriate for showing lots of embedded screens.
- The vertical layout may not be so useful, but it felt weird to omit it.
- Some screens have users clicking into the embedded mode for all elements, it would be better if they started in the display type that the user wanted.
- Scrollbars can render strangely in the grid layout and for embedded widgets, so I added some options to handle these cases.
- Some windows (flow layouts in particular) open at strange sizes, presumably because there isn't a good way to guess what the user is going to want. For a suite launcher script, being able to specify a starting size improves convenience.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only interactively so far, but it did not break existing tests.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only in docstrings and in the `--help` text. There isn't a good user-facing page in the docs right now for the CLI.

## Screenshots (if appropriate):
See comments for the most up-to-date screenshots.