### PR TITLE
ENH/FIX: respect ophyd signal enum_strs and metadata updates

### DIFF
--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -89,6 +89,8 @@ class _GlobalDescribeCache(QtCore.QObject):
         except Exception:
             logger.error("Unable to connect to %r during widget creation",
                          obj.name)
+            logger.debug("Unable to connect to %r during widget creation",
+                         obj.name, exc_info=True)
         return {}
 
     def _worker_describe(self, obj):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Enum strings may change - or be clarified - during the life of a signal in typhos.

Signals in which we override the EPICS-level enum strings with more descriptive values at the Python layer are a feature of https://github.com/pcdshub/pcdsdevices/pull/899. This PR allows for those customized strings to be used.

## Motivation and Context
Updated enum string information provided by ophyd signals is currently ignored.

Pairs with https://github.com/pcdshub/pcdsdevices/pull/899

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?

## Screenshots (if appropriate):
<img src="https://user-images.githubusercontent.com/5139267/138002435-24f673ba-989d-4352-9277-7bd23bc159f4.png"/>

See linked PR for implementation details.