### PR TITLE
REF: direct-to-PV vs signal protocol by way of cl

### DIFF
--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -1042,6 +1042,9 @@ def _get_ndimensional_widget_class(dimensions, desc, variety_md, read_only):
     }.get(dimensions, TyphosLabel)
 
 
+DIRECT_CONTROL_LAYERS = {"pyepics", "caproto"}
+
+
 def widget_type_from_description(signal, desc, read_only=False):
     """
     Determine which widget class should be used for the given signal
@@ -1064,7 +1067,14 @@ def widget_type_from_description(signal, desc, read_only=False):
     kwargs : dict
         Keyword arguments for the class
     """
-    if isinstance(signal, EpicsSignalBase):
+    use_pv_directly = (
+        # We can use PyDM's data source directly with EpicsSignalBase:
+        isinstance(signal, EpicsSignalBase) and
+        # So long as its underlying control layer is a supported ophyd-provided
+        # one, at least.
+        getattr(signal.cl, "name", "") in DIRECT_CONTROL_LAYERS
+    )
+    if use_pv_directly:
         # Still re-route EpicsSignal through the ca:// plugin
         pv = (signal._read_pv
               if read_only else signal._write_pv)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Typhos supports two paths to get data from ophyd Signals.
1. Peeking into the `EpicsSignal` to see which PVs it is using and passing that along to PyDM
2. Directly through the ophyd subscription mechanism

This PR allows for an escape hatch for (1) in scenarios where we want typhos to use method (2).
This escape hatch comes in the form of a control layer `cl` check to see if the user has customized it beyond what ophyd supports.

## Motivation and Context
Related to https://github.com/pcdshub/atef/pull/17
Where we want archived data to be sourced rather than live data

## How Has This Been Tested?
Interactively, so far

## Where Has This Been Documented?
This PR text.

## Screenshots (if appropriate):
This is a typhos screen using this PR that gets data from the EPICS archiver:
<img width="684" alt="image" src="https://user-images.githubusercontent.com/5139267/142488392-c4bd7c59-5baf-44ea-a0b9-aeb8b368ecbd.png">
