### PR TITLE
MNT: fix newly found failure in get_native_methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
     - CONDA_PACKAGE="typhos"
     - CONDA_RECIPE_FOLDER="conda-recipe"
-    - CONDA_EXTRAS="pip pyqt=5 happi"
+    - CONDA_EXTRAS="pip pyqt=5 happi pcdsdevices"
     - CONDA_REQUIREMENTS="dev-requirements.txt"
 
     - BENCHMARK_PYTHON="3.8"

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -131,10 +131,10 @@ def get_native_methods(cls, module, *, native_methods=None, seen=None):
         try:
             if obj in seen:
                 continue
+            seen.add(obj)
         except TypeError:
             # Unhashable type, definitely not a class or function
             continue
-        seen.add(obj)
         if not is_native(obj, module):
             continue
         elif isclass(obj):

--- a/typhos/tests/conftest.py
+++ b/typhos/tests/conftest.py
@@ -6,6 +6,7 @@ from functools import wraps
 
 import numpy as np
 import ophyd.sim
+import pydm
 import pytest
 import qtpy
 from happi import Client
@@ -61,6 +62,15 @@ def qapp(pytestconfig):
         application = PyDMApplication(use_main_window=False)
     typhos.use_stylesheet(pytestconfig.getoption('--dark'))
     return application
+
+
+@pytest.fixture(scope='function', autouse=True)
+def noapp(monkeypatch):
+    monkeypatch.setattr(QtWidgets.QApplication, 'exec_', lambda x: 1)
+    monkeypatch.setattr(QtWidgets.QApplication, 'exit', lambda x: 1)
+    monkeypatch.setattr(
+        pydm.exception, 'raise_to_operator', lambda *_, **__: None
+    )
 
 
 @pytest.fixture(scope='session')

--- a/typhos/tests/test_cli.py
+++ b/typhos/tests/test_cli.py
@@ -10,14 +10,22 @@ from typhos.cli import typhos_cli
 from . import conftest
 
 
+@pytest.fixture(scope='function')
+def noapp(monkeypatch):
+    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+    monkeypatch.setattr(QApplication, 'exit', lambda x: 1)
+    monkeypatch.setattr(
+        pydm.exception, 'raise_to_operator', lambda *_, **__: None
+    )
+
+
 def test_cli_version(capsys):
     typhos_cli(['--version'])
     readout = capsys.readouterr()
     assert typhos.__version__ in readout.out
 
 
-def test_cli_happi_cfg(monkeypatch, qtbot, happi_cfg):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+def test_cli_happi_cfg(noapp, qtbot, happi_cfg):
     window = typhos_cli(['test_motor', '--happi-cfg', happi_cfg])
     qtbot.addWidget(window)
     assert window.isVisible()
@@ -29,19 +37,14 @@ def test_cli_bad_entry(qtbot, happi_cfg):
     assert window is None
 
 
-def test_cli_no_entry(monkeypatch, qtbot, happi_cfg):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+def test_cli_no_entry(noapp, qtbot, happi_cfg):
     window = typhos_cli(['--happi-cfg', happi_cfg])
     qtbot.addWidget(window)
     assert window.isVisible()
     assert window.centralWidget().devices == []
 
 
-def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
-    monkeypatch.setattr(
-        pydm.exception, 'raise_to_operator', lambda *_, **__: None
-    )
+def test_cli_stylesheet(noapp, qapp, qtbot, happi_cfg):
     with open('test.qss', 'w+') as handle:
         handle.write(
             "TyphosDeviceDisplay {qproperty-force_template: 'test.ui'}")
@@ -60,8 +63,7 @@ def test_cli_stylesheet(monkeypatch, qapp, qtbot, happi_cfg):
     ("ophyd.sim.SynAxis[]", "SynAxis"),
     ("ophyd.sim.SynAxis[{'name':'foo'}]", "foo")
 ])
-def test_cli_class(monkeypatch, qapp, qtbot, klass, name, happi_cfg):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+def test_cli_class(noapp, qapp, qtbot, klass, name, happi_cfg):
     window = typhos_cli([klass])
     qtbot.addWidget(window)
     assert window.isVisible()
@@ -78,8 +80,7 @@ def test_cli_class_invalid(qtbot):
     assert window is None
 
 
-def test_cli_profile_modules(monkeypatch, capsys, qapp, qtbot):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+def test_cli_profile_modules(noapp, capsys, qapp, qtbot):
     window = typhos_cli(['ophyd.sim.SynAxis[]', '--profile-modules',
                          'typhos.suite'])
     qtbot.addWidget(window)
@@ -87,9 +88,7 @@ def test_cli_profile_modules(monkeypatch, capsys, qapp, qtbot):
     assert 'add_device' in output.out
 
 
-def test_cli_benchmark(monkeypatch, capsys, qapp, qtbot):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
-    monkeypatch.setattr(QApplication, 'exit', lambda x: 1)
+def test_cli_benchmark(noapp, capsys, qapp, qtbot):
     windows = typhos_cli(['ophyd.sim.SynAxis[]', '--benchmark',
                           'flat_soft'])
     qtbot.addWidget(windows[0])
@@ -97,8 +96,7 @@ def test_cli_benchmark(monkeypatch, capsys, qapp, qtbot):
     assert 'add_device' in output.out
 
 
-def test_cli_profile_output(monkeypatch, capsys, qapp, qtbot):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
+def test_cli_profile_output(noapp, capsys, qapp, qtbot):
     path_obj = conftest.MODULE_PATH / 'artifacts' / 'prof'
     if not path_obj.parent.exists():
         path_obj.parent.mkdir(parents=True)

--- a/typhos/tests/test_cli.py
+++ b/typhos/tests/test_cli.py
@@ -1,22 +1,11 @@
 import os
 
-import pydm
 import pytest
 
 import typhos
-from typhos.app import QApplication
 from typhos.cli import typhos_cli
 
 from . import conftest
-
-
-@pytest.fixture(scope='function')
-def noapp(monkeypatch):
-    monkeypatch.setattr(QApplication, 'exec_', lambda x: 1)
-    monkeypatch.setattr(QApplication, 'exit', lambda x: 1)
-    monkeypatch.setattr(
-        pydm.exception, 'raise_to_operator', lambda *_, **__: None
-    )
 
 
 def test_cli_version(capsys):
@@ -25,7 +14,7 @@ def test_cli_version(capsys):
     assert typhos.__version__ in readout.out
 
 
-def test_cli_happi_cfg(noapp, qtbot, happi_cfg):
+def test_cli_happi_cfg(qtbot, happi_cfg):
     window = typhos_cli(['test_motor', '--happi-cfg', happi_cfg])
     qtbot.addWidget(window)
     assert window.isVisible()
@@ -37,14 +26,14 @@ def test_cli_bad_entry(qtbot, happi_cfg):
     assert window is None
 
 
-def test_cli_no_entry(noapp, qtbot, happi_cfg):
+def test_cli_no_entry(qtbot, happi_cfg):
     window = typhos_cli(['--happi-cfg', happi_cfg])
     qtbot.addWidget(window)
     assert window.isVisible()
     assert window.centralWidget().devices == []
 
 
-def test_cli_stylesheet(noapp, qapp, qtbot, happi_cfg):
+def test_cli_stylesheet(qapp, qtbot, happi_cfg):
     with open('test.qss', 'w+') as handle:
         handle.write(
             "TyphosDeviceDisplay {qproperty-force_template: 'test.ui'}")
@@ -63,7 +52,7 @@ def test_cli_stylesheet(noapp, qapp, qtbot, happi_cfg):
     ("ophyd.sim.SynAxis[]", "SynAxis"),
     ("ophyd.sim.SynAxis[{'name':'foo'}]", "foo")
 ])
-def test_cli_class(noapp, qapp, qtbot, klass, name, happi_cfg):
+def test_cli_class(qtbot, klass, name, happi_cfg):
     window = typhos_cli([klass])
     qtbot.addWidget(window)
     assert window.isVisible()
@@ -80,7 +69,7 @@ def test_cli_class_invalid(qtbot):
     assert window is None
 
 
-def test_cli_profile_modules(noapp, capsys, qapp, qtbot):
+def test_cli_profile_modules(capsys, qtbot):
     window = typhos_cli(['ophyd.sim.SynAxis[]', '--profile-modules',
                          'typhos.suite'])
     qtbot.addWidget(window)
@@ -88,7 +77,7 @@ def test_cli_profile_modules(noapp, capsys, qapp, qtbot):
     assert 'add_device' in output.out
 
 
-def test_cli_benchmark(noapp, capsys, qapp, qtbot):
+def test_cli_benchmark(capsys, qtbot):
     windows = typhos_cli(['ophyd.sim.SynAxis[]', '--benchmark',
                           'flat_soft'])
     qtbot.addWidget(windows[0])
@@ -96,7 +85,7 @@ def test_cli_benchmark(noapp, capsys, qapp, qtbot):
     assert 'add_device' in output.out
 
 
-def test_cli_profile_output(noapp, capsys, qapp, qtbot):
+def test_cli_profile_output(capsys, qtbot):
     path_obj = conftest.MODULE_PATH / 'artifacts' / 'prof'
     if not path_obj.parent.exists():
         path_obj.parent.mkdir(parents=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix the CI to run two tests that were accidentally skipped
- Bring the `set.add` call into the `TypeError` try/except block that is intended to catch us trying to add an unhashable type to the set.
- Make the application handling in test_cli more consistent to avoid a hanging test suite

I don't know why this was working before or is failing now. The new object that passed the first check and made it to the add method was a `dict[str, str]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Two tests were failing silently because there were accidentally skipped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests pass, change seems innocuous

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Will be in the release notes

<!--
## Screenshots (if appropriate):
-->
