### PR TITLE
BUG: fix issue where combobox positioners can dangerously trigger moves via mousewheel

### DIFF
--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -154,7 +154,7 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
         """Inner `set` routine - call device.set() and monitor the status."""
         self._clear_status_thread()
         self._last_move = None
-        if isinstance(self.ui.set_value, QtWidgets.QComboBox):
+        if isinstance(self.ui.set_value, widgets.NoScrollComboBox):
             set_position = value
         else:
             set_position = float(value)
@@ -182,7 +182,7 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
             return
 
         try:
-            if isinstance(self.ui.set_value, QtWidgets.QComboBox):
+            if isinstance(self.ui.set_value, widgets.NoScrollComboBox):
                 value = self.ui.set_value.currentText()
             else:
                 value = self.ui.set_value.text()
@@ -344,7 +344,7 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
             selection = False
 
         if selection:
-            self.ui.set_value = QtWidgets.QComboBox()
+            self.ui.set_value = widgets.NoScrollComboBox()
             self.ui.set_value.addItems(setpoint_signal.enum_strs)
             # Activated signal triggers only when the user selects an option
             self.ui.set_value.activated.connect(self.set)
@@ -608,7 +608,7 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
 
         # Update set_value if it's not being edited.
         if not self.ui.set_value.hasFocus():
-            if isinstance(self.ui.set_value, QtWidgets.QComboBox):
+            if isinstance(self.ui.set_value, widgets.NoScrollComboBox):
                 try:
                     idx = int(text)
                     self.ui.set_value.setCurrentIndex(idx)

--- a/typhos/widgets.py
+++ b/typhos/widgets.py
@@ -188,6 +188,14 @@ class TyphosComboBox(pydm.widgets.PyDMEnumComboBox):
         event.ignore()
 
 
+class NoScrollComboBox(QtWidgets.QComboBox):
+    """
+    A combobox disconnected from direct EPICS/ophyd with scrolling ignored.
+    """
+    def wheelEvent(self, event: QtGui.QWheelEvent):
+        event.ignore()
+
+
 @use_for_variety_write('scalar')
 @use_for_variety_write('text')
 class TyphosLineEdit(pydm.widgets.PyDMLineEdit):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Follow-up to #389 
Copy that fix over to the combo boxes used for the positioner widget so that when you scroll over the motor destination you don't accidentally trigger a move, e.g. if you are scrolling up and down a long screen.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This causes unintended moves which can and do lead to lost beam time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with no write access to the real PVs, comparing before and after the patch.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
