### PR TITLE
FIX: write pv assumption

### DIFF
--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -644,7 +644,7 @@ def clear_error_in_background(device):
         except AttributeError:
             pass
         except Exception:
-            msg = 'Count not clear error!'
+            msg = "Could not clear error!"
             logger.error(msg)
             logger.debug(msg, exc_info=True)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
`_write_pv` and `_read_pv` are generally good assumptions for `EpicsSignalBase` and its subclasses. However, typhos should be lenient if/when access to these attributes fails.

pcdsdevices may also require adjustments to `PytmcSignalRO`, but that shouldn't affect this PR.

## Motivation and Context
Closes #474 
Closes #473 

## How Has This Been Tested?
Test suite and interactively with problematic `PytmcSignalRO` signal.

## Where Has This Been Documented?
Issue and PR text.