### PR TITLE
ENH: add option to hide displays in suite at start

### DIFF
--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -88,6 +88,14 @@ parser.add_argument(
     ),
 )
 parser.add_argument(
+    '--hide-displays',
+    action='store_true',
+    help=(
+        'Option to start with subdisplays hidden instead '
+        'of shown.'
+    )
+)
+parser.add_argument(
     '--happi-cfg',
     help=(
         'Location of happi configuration file '
@@ -207,6 +215,7 @@ def create_suite(
     cols: int = 3,
     display_type: str = 'detailed',
     scroll_option: str = 'auto',
+    show_displays: bool = True,
 ) -> TyphosSuite:
     """
     Create a TyphosSuite from a list of device names.
@@ -255,6 +264,7 @@ def create_suite(
             content_layout=layout_obj,
             default_display_type=display_type_enum,
             scroll_option=scroll_enum,
+            show_displays=show_displays,
         )
 
 
@@ -438,6 +448,7 @@ def typhos_run(
     display_type: str = 'detailed',
     scroll_option: str = 'auto',
     initial_size: Optional[str] = None,
+    show_displays: bool = True,
 ) -> QtWidgets.QMainWindow:
     """
     Run the central typhos part of typhos.
@@ -483,6 +494,7 @@ def typhos_run(
             cols=cols,
             display_type=display_type,
             scroll_option=scroll_option,
+            show_displays=show_displays,
         )
     if suite:
         if initial_size is not None:
@@ -539,6 +551,7 @@ def typhos_cli(args):
                 display_type=args.display_type,
                 scroll_option=args.scrollable,
                 initial_size=args.size,
+                show_displays=not args.hide_displays,
             )
         return suite
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -243,6 +243,9 @@ def create_suite(
         cli help for valid options.
     scroll_option : str, optional
         Options for the scrollbar. See the cli help for valid options.
+    show_displays : bool, optional
+        If True (default), open all the included device displays.
+        If False, do not open any of the displays.
 
     Returns
     -------
@@ -479,6 +482,9 @@ def typhos_run(
         Options for the scrollbar. See the cli help for valid options.
     initial_size : str, optional
         Specification for the starting width,height of the window.
+    show_displays : bool, optional
+        If True (default), open all the included device displays.
+        If False, do not open any of the displays.
 
     Returns
     -------

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -265,6 +265,7 @@ def create_suite(
             default_display_type=display_type_enum,
             scroll_option=scroll_enum,
             show_displays=show_displays,
+            pin=not show_displays,
         )
 
 

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -496,6 +496,7 @@ class TyphosSuite(TyphosBase):
         content_layout: Optional[QtWidgets.QLayout] = None,
         default_display_type: DisplayTypes = DisplayTypes.detailed_screen,
         scroll_option: ScrollOptions = ScrollOptions.auto,
+        show_displays: bool = True,
         **kwargs,
     ) -> TyphosSuite:
         """
@@ -535,6 +536,10 @@ class TyphosSuite(TyphosBase):
             scrollbars for detailed and engineering screens but not for
             embedded displays.
 
+        show_displays : bool, optional
+            If True (default), open all the included device displays.
+            If False, do not open any of the displays.
+
         **kwargs :
             Passed to :meth:`TyphosSuite.add_device`
         """
@@ -542,6 +547,7 @@ class TyphosSuite(TyphosBase):
                                 content_layout=content_layout,
                                 default_display_type=default_display_type,
                                 scroll_option=scroll_option,
+                                show_displays=show_displays,
                                 **kwargs)
 
     @classmethod

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -554,7 +554,7 @@ class TyphosSuite(TyphosBase):
         content_layout: Optional[QtWidgets.QLayout] = None,
         default_display_type: DisplayTypes = DisplayTypes.detailed_screen,
         scroll_option: ScrollOptions = ScrollOptions.auto,
-        show_displays: bool = False,
+        show_displays: bool = True,
         **kwargs,
     ) -> TyphosSuite:
         """

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -554,6 +554,7 @@ class TyphosSuite(TyphosBase):
         content_layout: Optional[QtWidgets.QLayout] = None,
         default_display_type: DisplayTypes = DisplayTypes.detailed_screen,
         scroll_option: ScrollOptions = ScrollOptions.auto,
+        show_displays: bool = False,
         **kwargs,
     ) -> TyphosSuite:
         """
@@ -592,6 +593,10 @@ class TyphosSuite(TyphosBase):
             scrollbars for detailed and engineering screens but not for
             embedded displays.
 
+        show_displays : bool, optional
+            If True (default), open all the included device displays.
+            If False, do not open any of the displays.
+
         **kwargs :
             Passed to :meth:`TyphosSuite.add_device`
         """
@@ -617,7 +622,8 @@ class TyphosSuite(TyphosBase):
         for device in devices:
             try:
                 suite.add_device(device, **kwargs)
-                suite.show_subdisplay(device)
+                if show_displays:
+                    suite.show_subdisplay(device)
             except Exception:
                 logger.exception("Unable to add %r to TyphosSuite",
                                  device.name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `--hide-displays` option to open a typhos suite with all displays hidden.

![image](https://user-images.githubusercontent.com/10647860/152894650-8720f71b-ef3d-4ffd-b80b-cc680c44bd15.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If there are too many devices, the typhos suite is hard to use when everything opens immediately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet
<!--
## Screenshots (if appropriate):
-->
