### PR TITLE
Allow use of sig:// protocol in typhos templates

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -21,6 +21,7 @@ from . import cache
 from . import panel as typhos_panel
 from . import utils, web, widgets
 from .jira import TyphosJiraIssueWidget
+from .plugins.core import register_signal
 
 logger = logging.getLogger(__name__)
 
@@ -1362,6 +1363,10 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
            3. The argument ``macros`` is then used to fill/update the final
               macro dictionary.
 
+        This will also register the device's signals in the sig:// plugin.
+        This means that any templates can refer to their device's signals by
+        name.
+
         Parameters
         ----------
         device : ophyd.Device
@@ -1376,6 +1381,9 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             self.devices.clear()
         # Add the device to the cache
         super().add_device(device)
+        logger.debug("Registering signals from device %s", device.name)
+        for component_walk in device.walk_signals():
+            register_signal(component_walk.item)
         self._searched = False
         self.macros = self._build_macros_from_device(device, macros=macros)
         self.load_best_template()

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -18,7 +18,7 @@ from qtpy import QtCore, QtWidgets
 from . import utils, widgets
 from .display import DisplayTypes, ScrollOptions, TyphosDeviceDisplay
 from .tools import TyphosConsole, TyphosLogDisplay, TyphosTimePlot
-from .utils import TyphosBase, clean_name, flatten_tree, save_suite
+from .utils import TyphosBase, clean_attr, clean_name, flatten_tree, save_suite
 
 logger = logging.getLogger(__name__)
 # Use non-None sentinel value since None means no tools
@@ -70,7 +70,8 @@ class SidebarParameter(parametertree.Parameter):
         return any(
             (device in self.devices,
              device in getattr(self.value(), 'devices', []),
-             self.name() == device
+             self.name() == device,
+             isinstance(device, str) and self.name() == clean_attr(device),
              )
         )
 

--- a/typhos/tests/conftest.py
+++ b/typhos/tests/conftest.py
@@ -230,7 +230,7 @@ class MockDevice(Device):
 
 @pytest.fixture(scope='function')
 def device():
-    dev = MockDevice('Tst:This', name='Simulated Device')
+    dev = MockDevice('Tst:This', name='simulated_device')
     yield dev
     clear_handlers(dev)
 
@@ -261,6 +261,7 @@ def happi_cfg():
     return path
 
 
+@pytest.fixture(scope='function', autouse=True)
 def reset_signal_plugin():
     """
     Completely restart the sig:// plugin.

--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pydm.utilities
-from ophyd import Signal
+from ophyd import Component as Cpt
+from ophyd import Device, Signal
 from pydm.widgets import PyDMLineEdit
 
+from typhos.plugins.core import (SignalConnection, SignalPlugin,
+                                 register_signal, signal_registry)
+
 from ..conftest import DeadSignal, RichSignal
-from typhos.plugins.core import (SignalPlugin, SignalConnection,
-                                 register_signal)
 
 
 def test_signal_connection(qapp, qtbot):
@@ -50,6 +52,16 @@ def test_signal_connection(qapp, qtbot):
     widget.send_value_signal.emit(1)
     qapp.processEvents()
     assert sig.get() == 3
+
+
+def test_dotted_name():
+    class TestDevice(Device):
+        test = Cpt(Signal)
+
+    device = TestDevice(name='test')
+    register_signal(device.test)
+
+    assert 'test.test' in signal_registry
 
 
 def test_metadata(qapp, qtbot):

--- a/typhos/tests/test_display.py
+++ b/typhos/tests/test_display.py
@@ -147,7 +147,6 @@ def test_display_with_py_file(display, motor):
 def test_display_with_sig_template(display, device, qapp):
     display.force_template = str(conftest.MODULE_PATH / 'utils' / 'sig.ui')
     display.add_device(device)
-    print(display.macros)
     qapp.processEvents()
     for num in range(10):
         device.setpoint.put(num)

--- a/typhos/tests/test_display.py
+++ b/typhos/tests/test_display.py
@@ -142,3 +142,14 @@ def test_display_with_py_file(display, motor):
     display.load_best_template()
     assert isinstance(display.display_widget, Display)
     assert getattr(display.display_widget, 'is_from_test_file', False)
+
+
+def test_display_with_sig_template(display, device, qapp):
+    display.force_template = str(conftest.MODULE_PATH / 'utils' / 'sig.ui')
+    display.add_device(device)
+    print(display.macros)
+    qapp.processEvents()
+    for num in range(10):
+        device.setpoint.put(num)
+        qapp.processEvents()
+        assert display.display_widget.ui.setpoint.text() == str(num)

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -8,7 +8,7 @@ from ophyd.sim import SynAxis
 from typhos.positioner import TyphosPositionerWidget
 from typhos.utils import SignalRO
 
-from .conftest import RichSignal, reset_signal_plugin, show_widget
+from .conftest import RichSignal, show_widget
 
 
 class SimMotor(SynAxis):
@@ -35,7 +35,6 @@ class SimMotor(SynAxis):
 
 @pytest.fixture(scope='function')
 def motor_widget(qtbot):
-    reset_signal_plugin()
     motor = SimMotor(name='test')
     widget = TyphosPositionerWidget()
     widget.readback_attribute = 'readback'

--- a/typhos/tests/utils/sig.ui
+++ b/typhos/tests/utils/sig.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>94</width>
+    <height>35</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="PyDMLabel" name="setpoint">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="channel" stdset="0">
+      <string>sig://${name}.setpoint</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Register a device's signals when it is added to a `TyphosDeviceDisplay` so that device templates can include channels like `sig://${name}.setpoint` that refer to named signals on the device.

Fix a bug where suites could not find subdisplays for certain devices with underscores in their names in certain situations.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need to make typhos templates easier to construct from device definitions and more flexible for non-EPICS devices.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added some tests
Needs interactive testing before merge

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet
<!--
## Screenshots (if appropriate):
-->
