### PR TITLE
BUG: Workaround for C++ Wrapped Exception

### DIFF
--- a/typhos/alarm.py
+++ b/typhos/alarm.py
@@ -313,11 +313,18 @@ class TyphosAlarm(TyphosObject, PyDMDrawing, _KindLevel, _AlarmLevel):
         else:
             new_alarm = max(info.alarm for info in self.signal_info.values())
         if new_alarm != self.alarm_summary:
-            self.alarm_changed.emit(new_alarm)
-            logger.debug(
-                f'Updated alarm from {self.alarm_summary} to {new_alarm} '
-                f'on alarm widget with channel {self.channels()[0]}'
+            try:
+                self.alarm_changed.emit(new_alarm)
+            except RuntimeError:
+                # Widget was destroyed and not properly cleaned up
+                logger.debug('Dangling reference to alarm widget!')
+                return
+            else:
+                logger.debug(
+                    f'Updated alarm from {self.alarm_summary} to {new_alarm} '
+                    f'on alarm widget with channel {self.channels()[0]}'
                 )
+
         self.alarm_summary = new_alarm
 
     def set_alarm_color(self, alarm_level):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -333,8 +333,8 @@ class TyphosLoading(QtWidgets.QLabel):
 
 class TyphosObject:
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.devices = list()
+        super().__init__(*args, **kwargs)
 
     def add_device(self, device):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Simply ignore this error when it pops up.
For background on why this happens, see https://github.com/slaclab/pydm/issues/798

If we do fix how the cleanup happens here, this PR is still needed because it's possible for a race condition to hit this line at a bad time anyway.

I snuck a side change in about setting up the devices list earlier because it helped me in the debugging process by fixing some of the reprs during the initial load.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #470 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It'll be in the release notes
<!--
## Screenshots (if appropriate):
-->
