### PR TITLE
FIX: show templates even for non-signal panel displays

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -360,12 +360,12 @@ class TyphosDisplayConfigButton(TyphosToolButton):
         if not display:
             return base_menu
 
+        base_menu.addSection('Templates')
+        display._generate_template_menu(base_menu)
+
         panels = display.findChildren(typhos_panel.TyphosSignalPanel) or []
         if not panels:
             return base_menu
-
-        base_menu.addSection('Templates')
-        display._generate_template_menu(base_menu)
 
         base_menu.addSection('Filters')
         filter_menu = base_menu.addMenu("&Kind filter")

--- a/typhos/tests/variety_ioc.py
+++ b/typhos/tests/variety_ioc.py
@@ -7,9 +7,10 @@ from caproto.server import PVGroup, ioc_arg_parser, pvproperty, run
 from ophyd import Component as Cpt
 from ophyd import EpicsSignal
 
-pytest.importorskip('pcdsdevices')
-
-from pcdsdevices.variety import set_metadata  # noqa: E402
+try:
+    from pcdsdevices.variety import set_metadata  # noqa: E402
+except Exception:
+    pytest.skip(reason="Unable to import pcdsdevices for testing")
 
 
 class Variants(ophyd.Device):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Currently, for a screen like at2l0's calculator under its `detailed_tree` display, the configuration menu is defunct
* Clicking the configuration menu does not result in any behavior
* With this change, the menu displays correctly

## Motivation and Context
Fixes long-standing bug for custom screens.

## How Has This Been Tested?
Interactively.

## Where Has This Been Documented?
This PR text.

## Screenshots (if appropriate):
<img width="845" alt="image" src="https://user-images.githubusercontent.com/5139267/161600683-0f1a8fda-3c3e-43a5-82dd-80d3c47c9534.png">
