### PR TITLE
Log "Unable to add device..." as an error instead of an exception

### DIFF
--- a/typhos/tools/console.py
+++ b/typhos/tools/console.py
@@ -186,7 +186,7 @@ class TyphosConsole(utils.TyphosBase):
             script = utils.code_from_device(device)
             self.execute(script)
         except Exception:
-            logger.exception("Unable to add device %r to TyphosConsole.",
+            logger.error("Unable to add device %r to TyphosConsole.",
                              device.name)
         else:
             self.device_added.emit(device)

--- a/typhos/tools/console.py
+++ b/typhos/tools/console.py
@@ -186,8 +186,9 @@ class TyphosConsole(utils.TyphosBase):
             script = utils.code_from_device(device)
             self.execute(script)
         except Exception:
+            # Prevent traceback from being displayed
             logger.error("Unable to add device %r to TyphosConsole.",
-                             device.name)
+                         device.name)
         else:
             self.device_added.emit(device)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adding an ophyd device declared outside of a module to typhos triggers an exception along with a traceback. With @klauer's guidance, I changed the logging method to `error` to suppress the traceback.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was attempting to run the Getting Started code with my own device that talks to pydm's testing IOC (see https://github.com/slaclab/pydm-examples). The generated display loaded successfully but many errors were spewed.

My test code:
```py
import sys
from ophyd import Device, Component, EpicsSignal
from qtpy.QtWidgets import QApplication
import typhos


# Create our device
class MTest(Device):
    """
    Test device from pydm-testing-ioc
    """
    run = Component(EpicsSignal, 'Run')


my_device = MTest('MTEST:', name='my_device', read_attrs=['run'])

# Create our application
app = QApplication.instance() or QApplication(sys.argv)
typhos.use_stylesheet()  # Optional
suite = typhos.TyphosSuite.from_device(my_device)

# Launch
suite.show()
app.exec_()
```

The error messages:
```
ERROR:typhos.tools.console:Unable to add device 'my_device' to TyphosConsole.
Traceback (most recent call last):
  File "C:\Users\anle\PycharmProjects\typhos\typhos\tools\console.py", line 186, in _add_device
    script = utils.code_from_device(device)
  File "C:\Users\anle\PycharmProjects\typhos\typhos\utils.py", line 737, in code_from_device
    return code_from_device_repr(device)
  File "C:\Users\anle\PycharmProjects\typhos\typhos\utils.py", line 695, in code_from_device_repr
    raise ValueError('Device class must be in a module')
ValueError: Device class must be in a module
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I reran the above code and verified that only `ERROR:typhos.tools.console:Unable to add device 'my_device' to TyphosConsole.` was displayed.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
In tools/console.py as a comment

<!--
## Screenshots (if appropriate):
-->
