### PR TITLE
Ensure that test.qss is deleted regardless of CLI stylesheet test result

### DIFF
--- a/typhos/tests/test_cli.py
+++ b/typhos/tests/test_cli.py
@@ -37,15 +37,17 @@ def test_cli_stylesheet(qapp, qtbot, happi_cfg):
     with open('test.qss', 'w+') as handle:
         handle.write(
             "TyphosDeviceDisplay {qproperty-force_template: 'test.ui'}")
-    style = qapp.styleSheet()
-    window = typhos_cli(['test_motor', '--stylesheet', 'test.qss',
-                         '--happi-cfg', happi_cfg])
-    qtbot.addWidget(window)
-    suite = window.centralWidget()
-    dev_display = suite.get_subdisplay(suite.devices[0])
-    assert dev_display.force_template == 'test.ui'
-    qapp.setStyleSheet(style)
-    os.remove('test.qss')
+    try:
+        style = qapp.styleSheet()
+        window = typhos_cli(['test_motor', '--stylesheet', 'test.qss',
+                             '--happi-cfg', happi_cfg])
+        qtbot.addWidget(window)
+        suite = window.centralWidget()
+        dev_display = suite.get_subdisplay(suite.devices[0])
+        assert dev_display.force_template == 'test.ui'
+        qapp.setStyleSheet(style)
+    finally:
+        os.remove('test.qss')
 
 
 @pytest.mark.parametrize('klass, name', [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
I wrapped the body of `test_cli_stylesheet` in a try/finally block to ensure that test.qss is cleaned up when the test is completed, pass or fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses https://github.com/pcdshub/typhos/issues/428

If `test_cli_stylesheet` fails, the line `os.remove('test.qss') is never executed. Therefore, test.qss is left behind.
```py
def test_cli_stylesheet(qapp, qtbot, happi_cfg):
    with open('test.qss', 'w+') as handle:
        handle.write(
            "TyphosDeviceDisplay {qproperty-force_template: 'test.ui'}")
    style = qapp.styleSheet()
    window = typhos_cli(['test_motor', '--stylesheet', 'test.qss',
                         '--happi-cfg', happi_cfg])
    qtbot.addWidget(window)
    suite = window.centralWidget()
    dev_display = suite.get_subdisplay(suite.devices[0])
    assert dev_display.force_template == 'test.ui'
    qapp.setStyleSheet(style)
    os.remove('test.qss')
```

## How Has This Been Tested?
I ran `pytest --pyargs typhos\tests\test_cli.py -k test_cli_stylesheet` under two scenarios:
1. No extra code added to test_cli.py - test passed
2. `raise Exception()` added right below `try:` - test failed

In both cases, test.qss was deleted as expected.

## Where Has This Been Documented?
N/A
