### PR TITLE
BUG: Fix Positioner clipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Editors
+*.swp
+*~

--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -60,8 +60,8 @@
      </property>
      <property name="baseSize">
       <size>
-       <width>400</width>
-       <height>250</height>
+       <width>100</width>
+       <height>100</height>
       </size>
      </property>
      <property name="frameShape">

--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -473,7 +473,7 @@ Screen</string>
            <string/>
           </property>
           <property name="text">
-           <string/>
+           <string>error_label</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>

--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -47,12 +47,18 @@
    <item alignment="Qt::AlignHCenter">
     <widget class="QFrame" name="motion_frame">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="baseSize">
       <size>
        <width>400</width>
        <height>250</height>
@@ -467,7 +473,7 @@ Screen</string>
            <string/>
           </property>
           <property name="text">
-           <string>error_label</string>
+           <string/>
           </property>
           <property name="wordWrap">
            <bool>true</bool>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This changes the sizing strategy of the positioner widget from what was essentially fixed-width sizing to minimum size and expanding. This fixes cases where the positioner widget looked scrunched up or otherwise clipping.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was reported in RIX that large numbers in the limits fields (in this case, 12 visible digits) would get clipped at the ends when rendered on the 4K high-dpi displays in the control room.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only- need to run on the RIX control room machines to fully confirm.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Just this PR

## Screenshots (if appropriate):
I don't have a high-dpi monitor at my desk, so to simulate and test this I would set the font side of the limits fields that were clipping on the control room display from 8pt to 50pt to guarantee clipping.

Here is what it looked like before:
![before-yesclip](https://user-images.githubusercontent.com/10647860/169627195-ed0f5332-568d-4f34-818f-571efc40ebeb.PNG)

And after:
![after-noclip](https://user-images.githubusercontent.com/10647860/169627202-da291993-9ac9-4f69-93d2-73bf92924ad2.PNG)

