### PR TITLE
BUG: remove word wrap from alarm field to fix rendering issue in rix

### DIFF
--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -659,7 +659,7 @@ Screen</string>
              <set>Qt::AlignCenter</set>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
One small follow-up to the clipping fixes in #494 
"no alarm" is often rendering as "no", with alarm being clipped at the newline. Force "no alarm" to be one line by disabling word wrap on this QLabel.