### PR TITLE
FIX: show python documentation when no web help is available

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -632,11 +632,17 @@ class TyphosHelpFrame(QtWidgets.QFrame, widgets.TyphosDesignerMixin):
             self.help_url.toString(), new=new, autoraise=autoraise
         )
 
-    def open_python_docs(self):
+    def open_python_docs(self, show: bool = True):
         """Open the Python docstring information in a new window."""
         if self.python_docs_browser is not None:
-            self.python_docs_browser.show()
-            self.python_docs_browser.raise_()
+            if show:
+                self.python_docs_browser.show()
+                self.python_docs_browser.raise_()
+            else:
+                self.python_docs_browser.hide()
+            return
+
+        if not show:
             return
 
         self.python_docs_browser = QtWidgets.QTextBrowser()

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -54,6 +54,8 @@ DEBUG_MODE = bool(os.environ.get('TYPHOS_DEBUG', False))
 # Help settings:
 # TYPHOS_HELP_URL (str): The help URL format string
 HELP_URL = os.environ.get('TYPHOS_HELP_URL', "").strip()
+HELP_WEB_ENABLED = bool(HELP_URL.strip())
+
 # TYPHOS_HELP_HEADERS (json): headers to pass to HELP_URL
 HELP_HEADERS = json.loads(os.environ.get('TYPHOS_HELP_HEADERS', "") or "{}")
 HELP_HEADERS_HOSTS = os.environ.get("TYPHOS_HELP_HEADERS_HOSTS", "").split(",")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Only show relevant help items when TYPHOS_HELP_URL is set
* Otherwise, show docstring-related information as it's still potentially useful

## Motivation and Context
Closes #452

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
Issue + PR text

## Screenshots (if appropriate):
<img width="685" alt="image" src="https://user-images.githubusercontent.com/5139267/170531240-2b621a4c-83c3-4325-a326-360ed2503ada.png">
<img width="521" alt="image" src="https://user-images.githubusercontent.com/5139267/170531856-d114ac9a-107a-4b49-9140-c5bb445b26df.png">
