### PR TITLE
FIX: suite side popbar width

### DIFF
--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -198,6 +198,12 @@ class TyphosSuite(TyphosBase):
         self._bar = pcdsutils.qt.QPopBar(title='Suite', parent=self,
                                          widget=self._tree, pin=pin)
 
+        self._tree.setSizePolicy(
+            QtWidgets.QSizePolicy.MinimumExpanding,
+            QtWidgets.QSizePolicy.MinimumExpanding
+        )
+        self._tree.setMinimumSize(250, 150)
+
         self._content_frame = QtWidgets.QFrame(self)
         self._content_frame.setObjectName("content")
         self._content_frame.setFrameShape(QtWidgets.QFrame.StyledPanel)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Initial attempt at fixing the suite sidebar

## Motivation and Context
The device tree isn't really visible, presumably due to either typhos refactoring or pyqtgraph changes relating to Qt sizing/layouts.

I think this isn't the correct solution, but it'll work as a temporary solution as I investigate further.
This also doesn't affect the overlay not being sized properly (when hovering over the popbar but not pinning it). That remains broken as of the first commit.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots (if appropriate):

### Master
<img width="727" alt="image" src="https://user-images.githubusercontent.com/5139267/170537839-bd9c1ab6-b92a-41c8-8a99-8576d2280536.png">


### This PR
<img width="727" alt="image" src="https://user-images.githubusercontent.com/5139267/170537719-3716d148-c5a4-466f-8fb5-b50db4680d0a.png">
