### PR TITLE
REF: lazy load all tools and hopefully improve performance

### DIFF
--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -159,6 +159,14 @@ parser.add_argument(
         'Turns on line profiling.'
     ),
 )
+parser.add_argument(
+    '--exit-after',
+    type=float,
+    help=(
+        "(For profiling purposes) Exit typhos after the provided number of "
+        "seconds"
+    ),
+)
 
 
 # Append to module docs
@@ -453,6 +461,7 @@ def typhos_run(
     scroll_option: str = 'auto',
     initial_size: Optional[str] = None,
     show_displays: bool = True,
+    exit_after: Optional[float] = None,
 ) -> QtWidgets.QMainWindow:
     """
     Run the central typhos part of typhos.
@@ -514,6 +523,17 @@ def typhos_run(
                     "Invalid --size argument. Expected a two-element pair "
                     "of comma-separated integers, e.g. --size 1000,1000"
                 ) from exc
+
+        def exit_early():
+            logger.warning(
+                "Exiting typhos early due to --exit-after=%s CLI argument.",
+                exit_after
+            )
+            sys.exit(0)
+
+        if exit_after is not None and exit_after >= 0:
+            QtCore.QTimer.singleShot(exit_after * 1000.0, exit_early)
+
         return launch_suite(suite, initial_size=initial_size)
 
 
@@ -559,7 +579,9 @@ def typhos_cli(args):
                 scroll_option=args.scrollable,
                 initial_size=args.size,
                 show_displays=not args.hide_displays,
+                exit_after=args.exit_after,
             )
+
         return suite
 
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1214,7 +1214,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
     def load_best_template(self):
         """Load the best available template for the current display type."""
-        print("load best template", self.device.name)
         if self.layout() is None:
             # If we are not fully initialized yet do not try and add anything
             # to the layout. This will happen if the QApplication has a
@@ -1222,7 +1221,6 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             # display
             return
 
-        print("OK load best template", self.device.name)
         if not self._searched:
             self.search_for_templates()
 

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1214,6 +1214,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
     def load_best_template(self):
         """Load the best available template for the current display type."""
+        print("load best template", self.device.name)
         if self.layout() is None:
             # If we are not fully initialized yet do not try and add anything
             # to the layout. This will happen if the QApplication has a
@@ -1221,6 +1222,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             # display
             return
 
+        print("OK load best template", self.device.name)
         if not self._searched:
             self.search_for_templates()
 

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -198,6 +198,12 @@ class TyphosSuite(TyphosBase):
         self._bar = pcdsutils.qt.QPopBar(title='Suite', parent=self,
                                          widget=self._tree, pin=pin)
 
+        self._tree.setSizePolicy(
+            QtWidgets.QSizePolicy.MinimumExpanding,
+            QtWidgets.QSizePolicy.MinimumExpanding
+        )
+        self._tree.setMinimumSize(250, 150)
+
         self._content_frame = QtWidgets.QFrame(self)
         self._content_frame.setObjectName("content")
         self._content_frame.setFrameShape(QtWidgets.QFrame.StyledPanel)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -404,8 +404,8 @@ class TyphosSuite(TyphosBase):
         logger.debug("Showing widget %r ...", widget)
         if hasattr(widget, 'scroll_option'):
             widget.scroll_option = self.scroll_option
-        widget.setVisible(True)
         dock.setWidget(widget)
+        widget.setVisible(True)
 
         if hasattr(widget, "display_type"):
             # Setting a display_type implicitly loads the best template.
@@ -414,7 +414,6 @@ class TyphosSuite(TyphosBase):
         # Add to layout
         content_layout = self._content_frame.layout()
         content_layout.addWidget(dock)
-        print("show subdisplay", widget, dock)
         if isinstance(content_layout, QtWidgets.QGridLayout):
             self._content_frame.layout().setAlignment(
                 dock, QtCore.Qt.AlignHCenter

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -446,12 +446,10 @@ class TyphosSuite(TyphosBase):
         logger.debug("Showing widget %r ...", widget)
         if hasattr(widget, 'scroll_option'):
             widget.scroll_option = self.scroll_option
-        dock.setWidget(widget)
-        widget.setVisible(True)
-
         if hasattr(widget, "display_type"):
             # Setting a display_type implicitly loads the best template.
             widget.display_type = self.default_display_type
+        dock.setWidget(widget)
 
         # Add to layout
         content_layout = self._content_frame.layout()

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -91,7 +91,7 @@ class LazySubdisplay(QtWidgets.QWidget):
 
     widget_cls: Type[QtWidgets.QWidget]
     widget: Optional[QtWidgets.QWidget]
-    label: QtWidgets.QLabel
+    devices: List[ophyd.Device]
 
     def __init__(self, widget_cls: Type[QtWidgets.QWidget]):
         super().__init__()
@@ -117,7 +117,6 @@ class LazySubdisplay(QtWidgets.QWidget):
             return
 
         self.widget = self.widget_cls()
-        self.layout().removeWidget(self.label)
         self.layout().addWidget(self.widget)
         self.setSizePolicy(self.widget.sizePolicy())
 
@@ -133,11 +132,13 @@ class LazySubdisplay(QtWidgets.QWidget):
         return super().showEvent(event)
 
     def minimumSizeHint(self):
+        """Minimum size hint forwarder from the embedded widget."""
         if self.widget is not None:
             return self.widget.minimumSizeHint()
         return self.sizeHint()
 
     def sizeHint(self):
+        """Size hint forwarder from the embedded widget."""
         if self.widget is not None:
             return self.widget.sizeHint()
         return QtCore.QSize(100, 100)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -579,7 +579,7 @@ class TyphosSuite(TyphosBase):
         # Grab children
         for child in flatten_tree(dev_param)[1:]:
             self._add_to_sidebar(child)
-        # # Add a device to all the tool displays
+        # Add a device to all the tool displays
         for tool in self.tools:
             try:
                 tool.add_device(device)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -105,7 +105,6 @@ class LazySubdisplay(QtWidgets.QWidget):
     def add_device(self, device: ophyd.Device):
         """Hook for adding a device from the suite."""
         self.devices.append(device)
-        self.label.setText(", ".join(device.name for device in self.devices))
 
     def hideEvent(self, event: QtGui.QHideEvent):
         """Hook for when the tool is hidden."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* All suite tools are now lazily loaded
* Miscellaneous performance fixes as I found that:
    * We call `load_best_template` twice (due to a setattr in a property and then an explicit call)
    * We call `setVisible` on displays and then move them into a new layout - effectively doing a show/hide/show event under the hood
* Preliminary results indicate a pretty big speed-up, but I'd like to run more tests before making any claims about percentages

## Motivation and Context
* Speed is important
* Tools are rarely used but heavy

## How Has This Been Tested?
* Interactively
* TODO: based on another branch because I was trying to fix that and lazily did not check out master again

## Where Has This Been Documented?
This PR text

## Screenshots (if appropriate):
