### PR TITLE
FIX: use cached paths for finding class templates

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1551,9 +1551,12 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
         That is, screens that are not default Typhos-provided screens.
         """
+        paths = cache.get_global_display_path_cache().paths
         return [
-            template for template in utils.find_templates_for_class(
-                device_cls, 'detailed', utils.DISPLAY_PATHS)
+            template
+            for template in utils.find_templates_for_class(
+                device_cls, "detailed", paths
+            )
             if not utils.is_standard_template(template)
         ]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
`_get_specific_screens` was using the non-cached paths, duplicating the effort of the cached path mechanism.

## Motivation and Context
Hopefully address speed a bit more on slow network filesystems

## How Has This Been Tested?
Locally

## Where Has This Been Documented?
This PR text
