### PR TITLE
TST: fix ophyd signal value deprecation warning

### DIFF
--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -117,4 +117,4 @@ def test_array_signal_put_value(qapp, qtbot):
     widget.channel = 'sig://my_array_write'
     widget.send_value_signal[np.ndarray].emit(np.zeros(4))
     qapp.processEvents()
-    assert all(sig.value == np.zeros(4))
+    assert all(sig.get() == np.zeros(4))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Removes deprecated and annoying `.value` access in test suite for ophyd

## Motivation and Context
Pulled out of #491 to isolate its issues

## How Has This Been Tested?
Test suite

## Where Has This Been Documented?
This PR text