### PR TITLE
MNT: add parents for internal uses of TyphosStatusThread

### DIFF
--- a/typhos/func.py
+++ b/typhos/func.py
@@ -580,7 +580,9 @@ class TyphosMethodButton(QPushButton, TyphosDesignerMixin):
             logger.debug("Setting up new status thread ...")
             self._status_thread = TyphosStatusThread(
                 status, start_delay=self._min_visible_operation,
-                timeout=self._max_allowed_operation)
+                timeout=self._max_allowed_operation,
+                parent=self,
+            )
 
             def status_started():
                 self.setEnabled(False)

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -123,7 +123,8 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
         """Start the status monitoring thread for the given status object."""
         self._status_thread = thread = TyphosStatusThread(
             status, start_delay=self._min_visible_operation,
-            timeout=timeout
+            timeout=timeout,
+            parent=self,
         )
         thread.status_started.connect(self.move_changed)
         thread.status_finished.connect(self._status_finished)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Set parent=self for each of the uses of `TyphosStatusThread`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I don't think these thread objects get cleaned up properly due to being orphaned, so this might cause weird on-shutdown behavior that interferes with e.g. the `lightpath` test suite. It's not really clear though.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A
Kind of just hoping the unit tests still pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
