### PR TITLE
FIX: atexit hook to clean up cache threads, TyphosSuite garbage collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - BENCHMARK_PYTHON="3.8"
     - BENCHMARK_COMMAND="--benchmark-only"
 
-    - PIP_EXTRAS="PyQt5 happi"
+    - PIP_EXTRAS="PyQt5<5.15 happi"
 
 jobs:
   allow_failures:

--- a/typhos/cache.py
+++ b/typhos/cache.py
@@ -74,6 +74,7 @@ class _GlobalDescribeCache(QtCore.QObject):
         self.connect_thread = utils.ObjectConnectionMonitorThread(parent=self)
         self.connect_thread.connection_update.connect(
             self._connection_update, QtCore.Qt.QueuedConnection)
+
         self.connect_thread.start()
 
     def clear(self):

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -780,7 +780,7 @@ class TyphosSuite(TyphosBase):
             for item in sidebar.items:
                 item._mark_shown()
             # Make sure we react if the dock is closed outside of our menu
-            self._connect_partial(
+            self._connect_partial_weakly(
                 dock, dock.closing, self.hide_subdisplay, sidebar
             )
         else:
@@ -808,14 +808,14 @@ class TyphosSuite(TyphosBase):
             widget.setHidden(True)
 
         logger.debug("Connecting parameter signals ...")
-        self._connect_partial(
+        self._connect_partial_weakly(
             parameter, parameter.sigOpen, self.show_subdisplay, parameter
         )
-        self._connect_partial(
+        self._connect_partial_weakly(
             parameter, parameter.sigHide, self.hide_subdisplay, parameter
         )
         if parameter.embeddable:
-            self._connect_partial(
+            self._connect_partial_weakly(
                 parameter, parameter.sigEmbed, self.embed_subdisplay, parameter
             )
         return parameter

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -571,6 +571,7 @@ class TyphosSuite(TyphosBase):
             Category of device. By default, all devices will just be added to
             the "Devices" group
         """
+
         super().add_device(device)
         self._update_title(device)
         # Create DeviceParameter and add to top level category
@@ -779,7 +780,9 @@ class TyphosSuite(TyphosBase):
             for item in sidebar.items:
                 item._mark_shown()
             # Make sure we react if the dock is closed outside of our menu
-            dock.closing.connect(partial(self.hide_subdisplay, sidebar))
+            self._connect_partial(
+                dock.closing, self.hide_subdisplay, sidebar
+            )
         else:
             logger.warning("Unable to find sidebar item for %r", widget)
 
@@ -805,13 +808,14 @@ class TyphosSuite(TyphosBase):
             widget.setHidden(True)
 
         logger.debug("Connecting parameter signals ...")
-        parameter.sigOpen.connect(partial(self.show_subdisplay, parameter),
-                                  QtCore.Qt.QueuedConnection)
-        parameter.sigHide.connect(partial(self.hide_subdisplay, parameter),
-                                  QtCore.Qt.QueuedConnection)
+        self._connect_partial(
+            parameter.sigOpen, self.show_subdisplay, parameter
+        )
+        self._connect_partial(
+            parameter.sigHide, self.hide_subdisplay, parameter
+        )
         if parameter.embeddable:
-            parameter.sigEmbed.connect(
-                partial(self.embed_subdisplay, parameter),
-                QtCore.Qt.QueuedConnection
+            self._connect_partial(
+                parameter.sigEmbed, self.embed_subdisplay, parameter
             )
         return parameter

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -781,7 +781,7 @@ class TyphosSuite(TyphosBase):
                 item._mark_shown()
             # Make sure we react if the dock is closed outside of our menu
             self._connect_partial(
-                dock.closing, self.hide_subdisplay, sidebar
+                dock, dock.closing, self.hide_subdisplay, sidebar
             )
         else:
             logger.warning("Unable to find sidebar item for %r", widget)
@@ -809,13 +809,13 @@ class TyphosSuite(TyphosBase):
 
         logger.debug("Connecting parameter signals ...")
         self._connect_partial(
-            parameter.sigOpen, self.show_subdisplay, parameter
+            parameter, parameter.sigOpen, self.show_subdisplay, parameter
         )
         self._connect_partial(
-            parameter.sigHide, self.hide_subdisplay, parameter
+            parameter, parameter.sigHide, self.hide_subdisplay, parameter
         )
         if parameter.embeddable:
             self._connect_partial(
-                parameter.sigEmbed, self.embed_subdisplay, parameter
+                parameter, parameter.sigEmbed, self.embed_subdisplay, parameter
             )
         return parameter

--- a/typhos/tests/test_benchmark.py
+++ b/typhos/tests/test_benchmark.py
@@ -24,6 +24,13 @@ def test_benchmark(unit_test_name, qapp, qtbot, benchmark, monkeypatch):
     suite = benchmark(inner_benchmark, unit_tests[unit_test_name], qtbot)
     save_image(suite, 'test_benchmark_' + unit_test_name)
 
+    for idx, window in enumerate(list(qapp.allWindows())):
+        print(idx, window, window.title())
+        window.close()
+        window.deleteLater()
+
+    assert len(qapp.allWindows()) == 0
+
 
 def inner_benchmark(unit_test, qtbot):
     suite, context = unit_test()

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -404,16 +404,14 @@ class WeakPartialMethodSlot:
         self.partial_kwargs = kwargs
 
     def _cleanup(self):
-        print("disconnecting", self)
-        try:
-            self.signal.disconnect(self._call)
-        except Exception:
-            print("failed to disconnect", self.signal)
-
-        self.signal = None
         self.method = None
         self.partial_args = []
         self.partial_kwargs = {}
+        try:
+            self.signal.disconnect(self._call)
+        except Exception:
+            ...
+        self.signal = None
 
     def _call(self, *new_args):
         method = self.method()

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions for typhos
 """
+import atexit
 import collections
 import contextlib
 import functools
@@ -988,12 +989,9 @@ class DeviceConnectionMonitorThread(QtCore.QThread):
         self.include_lazy = include_lazy
         self._update_event = threading.Event()
 
-        app = QtWidgets.QApplication.instance()
-        assert app is not None
+        atexit.register(self.stop)
 
-        app.aboutToQuit.connect(self.stop)
-
-    def stop(self, wait_ms: int = 1000):
+    def stop(self, *, wait_ms: int = 1000):
         """
         Stop the background thread and clean up.
 
@@ -1045,12 +1043,9 @@ class ObjectConnectionMonitorThread(QtCore.QThread):
         self.lock = threading.Lock()
         self._update_event = threading.Event()
 
-        app = QtWidgets.QApplication.instance()
-        assert app is not None
+        atexit.register(self.stop)
 
-        app.aboutToQuit.connect(self.stop)
-
-    def stop(self, wait_ms: int = 1000):
+    def stop(self, *, wait_ms: int = 1000):
         """
         Stop the background thread and clean up.
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -481,7 +481,7 @@ class TyphosBase(TyphosObject, QWidget):
         self._weak_partials_ = []
         super().__init__(*args, **kwargs)
 
-    def _connect_partial(
+    def _connect_partial_weakly(
         self,
         signal_owner: QtCore.QObject,
         signal: QtCore.Signal,
@@ -490,7 +490,8 @@ class TyphosBase(TyphosObject, QWidget):
         **kwargs
     ):
         """
-        Connect the provided signal to an instance method.
+        Connect the provided signal to an instance method via
+        WeakPartialMethodSlot.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add cleanup for background threads
* Add replacement for `functools.partial` usage in methods as this was causing TyphosSuite from getting garbage collected


## Motivation and Context
* Dangling cache daemon threads appear to cause a segfault on pip-installed PyQt5 but not conda-forge PyQt5
* I tried the signal `QApplication.aboutToQuit` instead of `atexit`, thinking it'd be better to clean up when the QApplication does. I found that the slot wasn't getting called and fell back to `atexit`.
* The garbage collection issue led to the test suite failing in a very strange way:
    *  The benchmarks in `test_benchmark` are configured to run and create very nested device displays. These device displays were supposed to get garbage collected between tests, but they were not. 
    * Once the test suite reached `test_cli`, typhos instructed Qt to reload stylesheets for every widget in the application.
    * This caused massive amounts of recursive updates of style sheets on a ton (?) of widgets from every previous test. This bogged the test suite down so much that it used to take over 20 minutes to run.  This proposal should hopefully fix that.

## How Has This Been Tested?
* Running the lightpath test suite in a Docker container closely resembling Travis CI (https://github.com/pcdshub/lightpath/pull/156)
* And the test suite itself

## Where Has This Been Documented?
PRs and issues