### PR TITLE
BUG: do not wait for lazy connections in SignalPanel

### DIFF
--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -611,7 +611,8 @@ class SignalPanel(QtWidgets.QGridLayout):
 
         if self._should_show(kind, dotted_name, **self._filter_settings):
             try:
-                signal = getattr(device, dotted_name)
+                with ophyd.do_not_wait_for_lazy_connection(device):
+                    signal = getattr(device, dotted_name)
             except Exception as ex:
                 logger.warning('Failed to get signal %r from device %s: %s',
                                dotted_name, device.name, ex, exc_info=True)


### PR DESCRIPTION
## Description
- Do not wait for lazy signals when creating a `SignalPanel`

## Motivation and Context
Found in working with lightpath that devices with area detectors would wait for every signal to time out when creating a detailed screen. https://github.com/pcdshub/lightpath/issues/161

The issue could be solved by enforcing no_lazy_wait_for_connection at device creation, but this catches devices regardless of how they were created

## How Has This Been Tested?
Works in lightpath interactively. 
Test suite passed locally, but severely slowed the typing of this pr text

## Where Has This Been Documented?
This PR text.