### PR TITLE
FIX: stop causing unknown status error from user stop

### DIFF
--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -225,7 +225,7 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
     def stop(self):
         """Stop device"""
         for device in self.devices:
-            device.stop()
+            device.stop(success=True)
 
     @QtCore.Slot()
     def clear_error(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make sure we call stop with success=True in the positioner widget when the user clicks on the stop button.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we call stop with success=False, it marks the status as failed and gives us an unknown status error. This is a problem because we can confuse ourselves immediately. The screen should not report planned stops as unknown errors.

`success` is an expected keyword in the `bluesky` hardware interfaces: https://blueskyproject.io/bluesky/hardware.html#bluesky.protocols.Stoppable.stop

Here is the ophyd source path where the status gets marked as failed if we call with success=False (the default):
- https://github.com/bluesky/ophyd/blob/0e8acb3df3d17e0ab7aa2cc924831f4a0c580449/ophyd/positioner.py#L107
- https://github.com/bluesky/ophyd/blob/master/ophyd/positioner.py#L218-L220
- https://github.com/bluesky/ophyd/blob/0e8acb3df3d17e0ab7aa2cc924831f4a0c580449/ophyd/positioner.py#L209
- https://github.com/bluesky/ophyd/blob/0e8acb3df3d17e0ab7aa2cc924831f4a0c580449/ophyd/status.py#L374-L381

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I'll find a way to test this

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet, I need to check to see if this warrants a docs addition.

<!--
## Screenshots (if appropriate):
-->
