### PR TITLE
ENH: add designer property for configuring positioner alarm circle

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ jinja2<3.1
 line_profiler
 pytest
 pytest-benchmark
-pytest-qt<4.0.0
+pytest-qt
 pytest-timeout
 sphinx<4.0.0
 sphinx_rtd_theme

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -6,12 +6,17 @@ from pydm.widgets.channel import PyDMChannel
 from qtpy import QtCore, QtWidgets, uic
 
 from . import utils, widgets
+from .alarm import KindLevel, _KindLevel
 from .status import TyphosStatusThread
 
 logger = logging.getLogger(__name__)
 
 
-class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
+class TyphosPositionerWidget(
+    utils.TyphosBase,
+    widgets.TyphosDesignerMixin,
+    _KindLevel,
+):
     """
     Widget to interact with a :class:`ophyd.Positioner`.
 
@@ -73,6 +78,8 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
                    ``hinted`` signals.
     ============== ===========================================================
     """
+    QtCore.Q_ENUMS(_KindLevel)
+    KindLevel = KindLevel
 
     ui_template = os.path.join(utils.ui_dir, 'widgets', 'positioner.ui')
     _readback_attr = 'user_readback'
@@ -568,6 +575,15 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
             self.ui.expert_button.show()
         else:
             self.ui.expert_button.hide()
+
+    @QtCore.Property(_KindLevel, designable=True)
+    def alarmKindLevel(self) -> KindLevel:
+        return self.ui.alarm_circle.kindLevel
+
+    @alarmKindLevel.setter
+    def alarmKindLevel(self, kind_level: KindLevel):
+        if kind_level != self.alarmKindLevel:
+            self.ui.alarm_circle.kindLevel = kind_level
 
     def move_changed(self):
         """Called when a move is begun"""

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -8,6 +8,7 @@ from ophyd.positioner import SoftPositioner
 from ophyd.sim import SynAxis
 from ophyd.utils.errors import UnknownStatusFailure
 
+from typhos.alarm import KindLevel
 from typhos.positioner import TyphosPositionerWidget
 from typhos.utils import SignalRO
 
@@ -210,6 +211,17 @@ def test_positioner_widget_alarm_text_changes(motor_widget, qtbot):
 
     for text in alarm_texts:
         assert alarm_texts.count(text) == 1
+
+
+def test_positioner_widget_alarm_kind_level(motor_widget, qtbot):
+    motor, widget = motor_widget
+    # Alarm widget has its own tests
+    # Just make sure the levels match when set
+    assert widget.alarmKindLevel == widget.ui.alarm_circle.kindLevel
+    for kind_level in KindLevel:
+        widget.alarmKindLevel = kind_level
+        assert widget.alarmKindLevel == kind_level
+        assert widget.ui.alarm_circle.kindLevel == kind_level
 
 
 def test_positioner_widget_clear_error(motor_widget, qtbot):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add the `alarmKindLevel` on `PositionerWidget` to configure the embedded alarm widget's `kindLevel` in designer.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed in one of my screens that I wanted to adjust this knob and it wasn't available.

This is a configurable that decides how many signals are checked for the alarm status. The default value remains as before: keep all ophyd signals at "normal" level and higher. If you want to include fewer or additional signals in the alarm summary this will help you do that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests + verified interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes only

<!--
## Screenshots (if appropriate):
-->
