### PR TITLE
ENH: use the status text to report move/set errors

### DIFF
--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -168,9 +168,15 @@ class TyphosPositionerWidget(utils.TyphosBase, widgets.TyphosDesignerMixin):
             timeout = None
         logger.debug("Setting device %r to %r with timeout %r",
                      self.device, value, timeout)
-        # Send timeout through thread because status timeout stops the move
-        status = self.device.set(set_position)
-        self._start_status_thread(status, timeout)
+        try:
+            status = self.device.set(set_position)
+        except Exception as exc:
+            # Treat this exception as a status to use normal error reporting
+            # Usually this is e.g. limits error
+            self._status_finished(exc)
+        else:
+            # Send timeout through thread because status timeout stops the move
+            self._start_status_thread(status, timeout)
 
     @QtCore.Slot(int)
     def combo_set(self, index):

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -6,7 +6,7 @@ from ophyd import Signal
 from ophyd.device import Device
 from ophyd.positioner import SoftPositioner
 from ophyd.sim import SynAxis
-from ophyd.utils.errors import UnknownStatusFailure
+from ophyd.utils.errors import LimitError, UnknownStatusFailure
 
 from typhos.positioner import TyphosPositionerWidget
 from typhos.utils import SignalRO
@@ -33,7 +33,12 @@ class SimMotor(SynAxis):
 
     # PositionerBase has a timeout arg, SynAxis does not
     def set(self, value, timeout=None):
+        self.check_value(value)
         return super().set(value)
+
+    def check_value(self, pos: float):
+        if not self.low_limit.get() <= pos <= self.high_limit.get():
+            raise LimitError('Sim limits error')
 
 
 @pytest.fixture(scope='function')
@@ -216,3 +221,19 @@ def test_positioner_widget_clear_error(motor_widget, qtbot):
     motor, widget = motor_widget
     widget.clear_error()
     qtbot.waitUntil(lambda: motor.clear_error.called, timeout=500)
+
+
+def test_positioner_widget_move_error(motor_widget, qtbot):
+    motor, widget = motor_widget
+    bad_position = motor.high_limit.get() + 1
+
+    with pytest.raises(LimitError):
+        motor.check_value(bad_position)
+
+    assert widget.ui.status_label.text() == ''
+    widget._set(bad_position)
+
+    def has_limit_error():
+        assert 'LimitError' in widget.ui.status_label.text()
+
+    qtbot.waitUntil(has_limit_error, timeout=1000)

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -149,7 +149,7 @@ def test_positioner_widget_moving_property(motor_widget, qtbot):
     motor, widget = motor_widget
     assert not widget.moving
     motor.delay = 1.
-    widget.ui.set_value.setText('34')
+    widget.ui.set_value.setText('7')
     widget.set()
     qtbot.waitUntil(lambda: widget.moving, timeout=500)
     qtbot.waitUntil(lambda: not widget.moving, timeout=1000)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use the status text to report errors that were encountered in calling move/set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These are currently uncaught and then bubble up to become a pop-up message via the normal pydm mechanisms.
This is usually sufficient except:
- the error gets in your way and then you close it and then it's gone
- there are inconsistencies in where the error pop-up appears. For example, on my SLAC setup it appears between my two monitors, with half the text on the 4K monitor and the other half on the laptop screen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a unit test and tested interactively using some EPICS test motors

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It will be in the release notes

<!--
## Screenshots (if appropriate):
-->
