### PR TITLE
Disambiguate duplicate template filenames

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1118,14 +1118,14 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             duplicates = utils.find_duplicate_filenames_in_paths(filenames)
 
             for filename in filenames:
-                current_filename = os.path.split(filename)[-1]
+                current_filename = os.path.basename(filename)
 
                 def switch_template(*, filename=filename):
                     self.force_template = filename
                 if current_filename in duplicates:
                     action = menu.addAction(str(filename))
                 else:
-                    action = menu.addAction(os.path.split(filename)[-1])
+                    action = menu.addAction(current_filename)
                 action.triggered.connect(switch_template)
 
         refresh_action = base_menu.addAction("Refresh Templates")

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -419,11 +419,16 @@ class TyphosDisplaySwitcherButton(TyphosToolButton):
             return
 
         menu = QtWidgets.QMenu(parent=self)
+
+        duplicates = utils.find_duplicate_filenames_in_paths(self.templates)
+
         for template in self.templates:
             def selected(*, template=template):
                 self.template_selected.emit(template)
-
-            action = menu.addAction(template.name)
+            if template.name in duplicates:
+                action = menu.addAction(str(template))
+            else:
+                action = menu.addAction(template.name)
             action.triggered.connect(selected)
 
         return menu
@@ -1110,11 +1115,17 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
                 view = view.split('_screen')[0]
             menu = base_menu.addMenu(view.capitalize())
 
+            duplicates = utils.find_duplicate_filenames_in_paths(filenames)
+
             for filename in filenames:
+                current_filename = os.path.split(filename)[-1]
+
                 def switch_template(*, filename=filename):
                     self.force_template = filename
-
-                action = menu.addAction(os.path.split(filename)[-1])
+                if current_filename in duplicates:
+                    action = menu.addAction(str(filename))
+                else:
+                    action = menu.addAction(os.path.split(filename)[-1])
                 action.triggered.connect(switch_template)
 
         refresh_action = base_menu.addAction("Refresh Templates")

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -414,7 +414,8 @@ class TyphosDisplaySwitcherButton(TyphosToolButton):
         self.template_selected.emit(template)
 
     def generate_context_menu(self):
-        """Context menu request."""
+        """Context menu request.
+            Duplicate filenames will show full path. """
         if not self.templates:
             return
 
@@ -1109,7 +1110,10 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         self._scroll_area.setVisible(scrollable)
 
     def _generate_template_menu(self, base_menu):
-        """Generate the template switcher menu, adding it to ``base_menu``."""
+        """
+            Generate the template switcher menu, adding it to ``base_menu``.
+            Duplicate filenames will show full path.
+        """
         for view, filenames in self.templates.items():
             if view.endswith('_screen'):
                 view = view.split('_screen')[0]

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -137,7 +137,6 @@ def _get_display_paths():
 
 DISPLAY_PATHS = list(_get_display_paths())
 
-
 if hasattr(ophyd.signal, 'SignalRO'):
     SignalRO = ophyd.signal.SignalRO
 else:
@@ -268,6 +267,19 @@ def random_color():
     return QColor(random.randint(0, 255),
                   random.randint(0, 255),
                   random.randint(0, 255))
+
+
+def find_duplicate_filenames_in_paths(paths):
+    seen = set()
+    duplicates = []
+
+    for filename in paths:
+        candidate_filename = os.path.split(filename)[-1]
+        if candidate_filename in seen:
+            duplicates.append(candidate_filename)
+        else:
+            seen.add(candidate_filename)
+    return duplicates
 
 
 class TyphosLoading(QtWidgets.QLabel):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -274,7 +274,7 @@ def find_duplicate_filenames_in_paths(paths):
     duplicates = []
 
     for filename in paths:
-        candidate_filename = os.path.split(filename)[-1]
+        candidate_filename = os.path.basename(filename)
         if candidate_filename in seen:
             duplicates.append(candidate_filename)
         else:

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -270,6 +270,14 @@ def random_color():
 
 
 def find_duplicate_filenames_in_paths(paths):
+    """
+    Returns a list of duplicated filenames from a list of full path filenames.
+    Args:
+        paths (list[str]): list of fullpath filenames
+
+    Returns:
+        list[str]: list of filename duplicates
+    """
     seen = set()
     duplicates = []
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- add util `find_duplicate_filenames_in_paths`
- check for duplicate filenames in `generate_context_menu` and `_generate_template_menu`
- set duplicate file names to full path


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When two templates with the same name are found in two different directories, typhos displays identical names. This makes it impossible to tell which template is being selected.
<!--- If it fixes an open issue, please link to the issue here. -->
- closes #524 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I tested this using happi entry `mr2k4_kbo`. I put 3 screens in the `typhos` core ui directory using the keywords embedded, detailed, and engineering. I put identical named files into my local `pcdsdevices` ui directory. I added both my local libraries to the `$PYTHONPATH` and activated the current `pcds_conda`: pcds-5.6.0. I then ran `typhos mr2k4_kbo` and checked each of the four menu buttons by right clicking. Each right click showed full path for identical files, and filenames otherwise. I checked embedded, engineering, detailed, and the template button.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- added/updated doc strings in created/modified functions

<!--
## Screenshots (if appropriate):
-->
<img width="696" alt="typhos-context" src="https://user-images.githubusercontent.com/79480290/219169234-bc7ef696-799e-4632-a980-f7c68616bde3.png">

