### PR TITLE
FIX: missing and extra device fills

### DIFF
--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1324,12 +1324,24 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         device = self.device
         display = self._display_widget
         designer = display.findChildren(widgets.TyphosDesignerMixin) or []
-        bases = display.findChildren(utils.TyphosBase) or []
+        bases = display.findChildren(utils.TyphosObject) or []
 
         for widget in set(bases + designer):
+            # No device yet or the existing device: add (or re-add) the device
+            # Some other device or channel is already here: leave it alone
             if device and hasattr(widget, 'add_device'):
-                widget.add_device(device)
+                try:
+                    has_other_device = widget.devices and device not in widget.devices
+                except AttributeError:
+                    has_other_device = False
+                try:
+                    has_other_channel = widget.channel is not None
+                except AttributeError:
+                    has_other_channel = False
+                if not has_other_device and not has_other_channel:
+                    widget.add_device(device)
 
+            # Used e.g. in TyphosDeviceDisplay to give widgets display control
             if hasattr(widget, 'set_device_display'):
                 widget.set_device_display(self)
 

--- a/typhos/tests/test_display.py
+++ b/typhos/tests/test_display.py
@@ -152,3 +152,10 @@ def test_display_with_sig_template(display, device, qapp):
         device.setpoint.put(num)
         qapp.processEvents()
         assert display.display_widget.ui.setpoint.text() == str(num)
+
+
+def test_display_with_subdevice_templates(display, device, qapp):
+    display.force_template = str(conftest.MODULE_PATH / 'utils' / 'subdevice.ui')
+    display.add_device(device)
+    qapp.processEvents()
+    # Need to finish this test after making it easier to make templates

--- a/typhos/tests/utils/subdevice.ui
+++ b/typhos/tests/utils/subdevice.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1109</width>
+    <height>588</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="TyphosAlarmRectangle" name="main_alarm">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="TyphosPositionerWidget" name="x_pos">
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="TyphosPositionerWidget" name="y_pos">
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="TyphosPositionerWidget" name="z_pos">
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="TyphosAlarmCircle" name="happi_alarm">
+     <property name="toolTip">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TyphosAlarmCircle</class>
+   <extends>QWidget</extends>
+   <header>typhos.alarm</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosAlarmRectangle</class>
+   <extends>QWidget</extends>
+   <header>typhos.alarm</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosDisplayTitle</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosPositionerWidget</class>
+   <extends>QWidget</extends>
+   <header>typhos.positioner</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- In templates, alarm shapes auto-fill the template's device now
- When loading a template, avoid overwriting user-set happi channels and other similar devices

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/LCLSPC-653

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I will add a test prior to asking for reviewers

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Comments, and later, release notes

<!--
## Screenshots (if appropriate):
-->
