### PR TITLE
FIX: include pydm and user pydm stylesheets

### DIFF
--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -210,12 +210,13 @@ loaded.
 
     from ophyd.sim import motor
     from qtpy.QtWidgets import QApplication
-    import typhos
+    from typhos.suite import TyphosSuite
+    from typhos.utils import compose_stylesheet
 
     # Create our application
     app = QApplication([])
-    typhos.use_stylesheet()  # Optional
-    suite = typhos.TyphosSuite.from_device(motor)
+    compose_stylesheet()  # Optional
+    suite = TyphosSuite.from_device(motor)
 
     # Launch
     suite.show()
@@ -224,11 +225,31 @@ loaded.
 
 Using the StyleSheet
 ====================
-While it is no means a requirement, Typhos ships with two stylesheets to
-improve the look of the widgets. By default this isn't activated, but can be
-configured with :func:`typhos.use_stylesheet`. The operator can elect whether
-to use the "light" or "dark" stylesheets by using the optional ``dark``
-keyword. This method also handles setting the "Fusion" ``QStyle`` which helps
+Typhos ships with two stylesheets to improve the look and feel of the widgets.
+When invoking ``typhos`` from the CLI as normal, you can pass
+the ``--dark`` flag to use the dark stylesheet instead of the light mode,
+and a ``--stylesheet-add`` argument to use your own stylesheet in addition to Typhos's.
+If you want to completely ignore Typhos's normal stylesheet loading and use your own,
+you can pass the ``--stylesheet-override`` argument.
+
+Typhos also uses the same stylesheet environment variables as PyDM to load additional
+stylesheets. The PyDM environment variables respected here are:
+
+- ``PYDM_STYLESHEET``, a path-like variable that should contain file paths to qss
+  stylesheets if set.
+- ``PYDM_STYLESHEET_INCLUDE_DEFAULT``, which should be set to 1 to include the
+  default PyDM stylesheet or unset to not include it.
+
+The priority order for stylesheets in the case of conflicts is:
+
+1. The explicit ``styleSheet`` property on the display template
+2. The style elements from ``--stylesheet-add``
+3. User stylesheets from ``PYDM_STYLESHEET_INCLUDE_DEFAULT``
+4. Typhos's stylesheet (either the dark or the light variant)
+5. The built-in PyDM stylesheet
+
+Outside of the CLI, the stylesheets can be applied using :func:`typhos.compose_stylesheet`.
+This function also handles setting the "Fusion" ``QStyle`` which helps
 make the interface have an operating system independent look and feel.
 
 

--- a/docs/source/basic_usage.rst
+++ b/docs/source/basic_usage.rst
@@ -211,11 +211,11 @@ loaded.
     from ophyd.sim import motor
     from qtpy.QtWidgets import QApplication
     from typhos.suite import TyphosSuite
-    from typhos.utils import compose_stylesheet
+    from typhos.utils import apply_standard_stylesheets
 
     # Create our application
     app = QApplication([])
-    compose_stylesheet()  # Optional
+    apply_standard_stylesheets()  # Optional
     suite = TyphosSuite.from_device(motor)
 
     # Launch
@@ -230,7 +230,8 @@ When invoking ``typhos`` from the CLI as normal, you can pass
 the ``--dark`` flag to use the dark stylesheet instead of the light mode,
 and a ``--stylesheet-add`` argument to use your own stylesheet in addition to Typhos's.
 If you want to completely ignore Typhos's normal stylesheet loading and use your own,
-you can pass the ``--stylesheet-override`` argument.
+you can pass the ``--stylesheet-override`` argument. You can pass these arguments
+multiple times to include multiple stylesheets.
 
 Typhos also uses the same stylesheet environment variables as PyDM to load additional
 stylesheets. The PyDM environment variables respected here are:
@@ -248,7 +249,7 @@ The priority order for stylesheets in the case of conflicts is:
 4. Typhos's stylesheet (either the dark or the light variant)
 5. The built-in PyDM stylesheet
 
-Outside of the CLI, the stylesheets can be applied using :func:`typhos.compose_stylesheet`.
+Outside of the CLI, the stylesheets can be applied using :func:`typhos.apply_standard_stylesheets`.
 This function also handles setting the "Fusion" ``QStyle`` which helps
 make the interface have an operating system independent look and feel.
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -20,7 +20,7 @@ from typhos.benchmark.cases import run_benchmarks
 from typhos.benchmark.profile import profiler_context
 from typhos.display import DisplayTypes, ScrollOptions
 from typhos.suite import TyphosSuite
-from typhos.utils import nullcontext
+from typhos.utils import compose_stylesheets, nullcontext
 
 logger = logging.getLogger(__name__)
 
@@ -190,15 +190,12 @@ def typhos_cli_setup(args):
     coloredlogs.install(level=level, logger=shown_logger, fmt=log_fmt)
     logger.debug("Set logging level of %r to %r", shown_logger.name, level)
 
-    # Deal with stylesheet
-    qapp = get_qapp()
-
     logger.debug("Applying stylesheet ...")
-    typhos.use_stylesheet(dark=args.dark)
-    if args.stylesheet:
-        logger.info("Loading QSS file %r ...", args.stylesheet)
-        with open(args.stylesheet) as handle:
-            qapp.setStyleSheet(handle.read())
+    compose_stylesheets(
+        dark=args.dark,
+        path=args.stylesheet,
+        widget=get_qapp(),
+    )
 
 
 def _create_happi_client(cfg):

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -20,7 +20,8 @@ from typhos.benchmark.cases import run_benchmarks
 from typhos.benchmark.profile import profiler_context
 from typhos.display import DisplayTypes, ScrollOptions
 from typhos.suite import TyphosSuite
-from typhos.utils import compose_stylesheets, nullcontext
+from typhos.utils import (apply_standard_stylesheets, compose_stylesheets,
+                          nullcontext)
 
 logger = logging.getLogger(__name__)
 
@@ -131,10 +132,12 @@ parser.add_argument(
 )
 parser.add_argument(
     "--stylesheet-override", "--stylesheet",
+    type="append",
     help="Override all built-in stylesheets, using this stylesheet instead.",
 )
 parser.add_argument(
     "--stylesheet-add",
+    type="append",
     help=(
         "Include an additional stylesheet in the loading process. "
         "This stylesheet will take priority over all built-in stylesheets, "
@@ -204,13 +207,18 @@ def typhos_cli_setup(args):
     qapp = get_qapp()
     logger.debug("Applying stylesheet ...")
     if args.stylesheet_override:
-        logger.info("Loading QSS file %r ...", args.stylesheet_override)
-        with open(args.stylesheet_override) as handle:
-            qapp.setStyleSheet(handle.read())
+        # Includes some non-stylesheet style settings
+        apply_standard_stylesheets(
+            include_pydm=False,
+            widget=qapp,
+        )
+        for filename in args.stylesheet_override:
+            logger.info("Loading QSS file %r ...", filename)
+        qapp.setStyleSheet(compose_stylesheets(args.stylesheet_override))
     else:
-        compose_stylesheets(
+        apply_standard_stylesheets(
             dark=args.dark,
-            path=args.stylesheet_add,
+            paths=args.stylesheet_add,
             widget=qapp,
         )
 

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -132,12 +132,12 @@ parser.add_argument(
 )
 parser.add_argument(
     "--stylesheet-override", "--stylesheet",
-    type="append",
+    action="append",
     help="Override all built-in stylesheets, using this stylesheet instead.",
 )
 parser.add_argument(
     "--stylesheet-add",
-    type="append",
+    action="append",
     help=(
         "Include an additional stylesheet in the loading process. "
         "This stylesheet will take priority over all built-in stylesheets, "

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -129,7 +129,18 @@ parser.add_argument(
     action='store_true',
     help='Use the QDarkStyleSheet shipped with Typhos',
 )
-parser.add_argument('--stylesheet', help='Additional stylesheet options')
+parser.add_argument(
+    "--stylesheet-override", "--stylesheet",
+    help="Override all built-in stylesheets, using this stylesheet instead.",
+)
+parser.add_argument(
+    "--stylesheet-add",
+    help=(
+        "Include an additional stylesheet in the loading process. "
+        "This stylesheet will take priority over all built-in stylesheets, "
+        "but not over a template or widget's styleSheet property."
+    )
+)
 parser.add_argument(
     '--profile-modules',
     nargs='*',
@@ -190,12 +201,18 @@ def typhos_cli_setup(args):
     coloredlogs.install(level=level, logger=shown_logger, fmt=log_fmt)
     logger.debug("Set logging level of %r to %r", shown_logger.name, level)
 
+    qapp = get_qapp()
     logger.debug("Applying stylesheet ...")
-    compose_stylesheets(
-        dark=args.dark,
-        path=args.stylesheet,
-        widget=get_qapp(),
-    )
+    if args.stylesheet_override:
+        logger.info("Loading QSS file %r ...", args.stylesheet_override)
+        with open(args.stylesheet_override) as handle:
+            qapp.setStyleSheet(handle.read())
+    else:
+        compose_stylesheets(
+            dark=args.dark,
+            path=args.stylesheet_add,
+            widget=qapp,
+        )
 
 
 def _create_happi_client(cfg):

--- a/typhos/tests/test_utils.py
+++ b/typhos/tests/test_utils.py
@@ -98,8 +98,8 @@ def test_compose_stylesheets(qtbot, qapp):
     ],
 )
 @pytest.mark.parametrize(
-    "explicit_path",
-    [None, str(conftest.MODULE_PATH / "utils" / "tiny_stylesheet.qss")],
+    "explicit_paths",
+    [None, [str(conftest.MODULE_PATH / "utils" / "tiny_stylesheet.qss")]],
 )
 def test_stylesheet(
     qtbot,
@@ -108,7 +108,7 @@ def test_stylesheet(
     include_pydm: bool,
     pydm_include_default: bool,
     pydm_stylesheet: str,
-    explicit_path: str | None,
+    explicit_paths: list[str] | None,
 ):
     widget = QWidget()
     qtbot.addWidget(widget)
@@ -120,7 +120,7 @@ def test_stylesheet(
 
     apply_standard_stylesheets(
         dark=dark,
-        paths=[explicit_path],
+        paths=explicit_paths,
         include_pydm=include_pydm,
         widget=widget,
     )
@@ -142,7 +142,7 @@ def test_stylesheet(
     else:
         assert "ApertureValve" not in new_stylesheet, "PyDM user stylesheet loaded unexpectedly"
 
-    if explicit_path:
+    if explicit_paths is not None:
         assert "tiny test stylesheet" in new_stylesheet, "Explicit user stylesheet did not load"
     else:
         assert "tiny test stylesheet" not in new_stylesheet, "Explicit user stylesheet loaded unexpectedly"

--- a/typhos/tests/utils/big_stylesheet.qss
+++ b/typhos/tests/utils/big_stylesheet.qss
@@ -1,0 +1,687 @@
+/*################################*/
+/* Valves and Shutters*/
+/*################################*/
+
+/*#ApperatureValve - vgc*/
+
+ApertureValve #icon {
+    qproperty-penStyle: "Qt::SolidLine";
+    qproperty-penColor: black;
+    qproperty-penWidth: 2;
+}
+ApertureValve[interlocked="true"] #icon{
+    border: 2px solid black;
+    qproperty-penWidth: 2;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+ApertureValve[interlocked="false"] #icon{
+    border: 0px;
+}
+ApertureValve[state="OPEN"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+ApertureValve[state="MOVING"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: yellow;
+}
+ApertureValve[state="CLOSED"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: black;
+}
+ApertureValve[state="INVALID"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+ApertureValve[state="OPEN_F"] #icon {
+    qproperty-penColor: red;
+    qproperty-brush: #00FF00;
+}
+ApertureValve[error="Vented"] #icon {
+    qproperty-interlockBrush: red;
+}
+ApertureValve[error="At Vacuum"] #icon {
+    qproperty-interlockBrush: #00FF00;
+}
+ApertureValve[error="Lost Vacuum"] #icon {
+    qproperty-interlockBrush: red;
+}
+ApertureValve[error="Ext Fault"] #icon {
+    qproperty-interlockBrush: red;
+}
+/*################################*/
+
+/* PnumaticValve - vrc, vgc (use vrc)*/
+
+PneumaticValve #icon {
+    qproperty-penStyle: "Qt::SolidLine";
+    qproperty-penColor: black;
+    qproperty-penWidth: 2;
+    qproperty-interlockBrush: #00FF00;
+}
+PneumaticValve[interlocked="true"] #icon{
+    border: 2px solid black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+PneumaticValve[interlocked="false"] #icon{
+    border: 0px;
+    qproperty-brush: #00FF00;
+}
+PneumaticValve[state="OPEN"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+PneumaticValve[state="MOVING"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: yellow;
+}
+PneumaticValve[state="CLOSED"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: black;
+}
+PneumaticValve[state="INVALID"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+PneumaticValve[state="OPEN_F"] #icon {
+    qproperty-penColor: red;
+    qproperty-brush: #00FF00;
+}
+PneumaticValve[error="Vented"] #icon {
+    qproperty-interlockBrush: red;
+}
+PneumaticValve[error="Lost Vacuum"] #icon {
+   qproperty-interlockBrush: red;
+}
+PneumaticValve[error="At Vacuum"] #icon {
+   qproperty-interlockBrush: #00FF00;
+}
+PneumaticValve[error="Ext Fault"] #icon {
+    qproperty-interlockBrush: red;
+}
+
+/*################################*/
+
+/* PnumaticValveNO - vrc, vgc (use vrc)*/
+
+PneumaticValveNO #icon {
+    qproperty-penStyle: "Qt::SolidLine";
+    qproperty-penColor: black;
+    qproperty-penWidth: 2;
+    qproperty-interlockBrush: #00FF00;
+}
+PneumaticValveNO[interlocked="true"] #icon{
+    border: 2px solid black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+PneumaticValveNO[interlocked="false"] #icon{
+    border: 0px;
+    qproperty-brush: #00FF00;
+}
+PneumaticValveNO[state="OPEN"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+PneumaticValveNO[state="MOVING"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: yellow;
+}
+PneumaticValveNO[state="CLOSED"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: black;
+}
+PneumaticValveNO[state="INVALID"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+PneumaticValveNO[state="OPEN_F"] #icon {
+    qproperty-penColor: red;
+    qproperty-brush: #00FF00;
+}
+PneumaticValveNO[error="Vented"] #icon {
+    qproperty-interlockBrush: red;
+}
+PneumaticValveNO[error="Lost Vacuum"] #icon {
+   qproperty-interlockBrush: red;
+}
+PneumaticValveNO[error="At Vacuum"] #icon {
+   qproperty-interlockBrush: #00FF00;
+}
+PneumaticValveNO[error="Ext Fault"] #icon {
+    qproperty-interlockBrush: red;
+}
+
+/*################################*/
+
+/* PnumaticValveDA - dual acting vgc*/
+
+PneumaticValveDA #icon {
+    qproperty-penStyle: "Qt::SolidLine";
+    qproperty-penColor: black;
+    qproperty-penWidth: 2;
+    qproperty-interlockBrush: #00FF00;
+}
+PneumaticValveDA[interlocked="true"] #icon{
+    border: 2px solid black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+PneumaticValveDA[interlocked="false"] #icon{
+    border: 0px;
+    qproperty-brush: #00FF00;
+}
+PneumaticValveDA[state="OPEN"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+PneumaticValveDA[state="MOVING"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: yellow;
+}
+PneumaticValveDA[state="CLOSED"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: black;
+}
+PneumaticValveDA[state="INVALID"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+PneumaticValveDA[state="OPEN_F"] #icon {
+    qproperty-penColor: red;
+    qproperty-brush: #00FF00;
+}
+PneumaticValveDA[error="Vented"] #icon {
+    qproperty-interlockBrush: red;
+}
+PneumaticValveDA[error="Lost Vacuum"] #icon {
+   qproperty-interlockBrush: red;
+}
+PneumaticValveDA[error="At Vacuum"] #icon {
+   qproperty-interlockBrush: #00FF00;
+}
+PneumaticValveDA[error="Ext Fault"] #icon {
+    qproperty-interlockBrush: red;
+}
+
+/*###############################*/
+
+/* Fast Shutter - vfs*/
+
+FastShutter #icon {
+    qproperty-penStyle: "Qt::SolidLine";
+    qproperty-penColor: black;
+    qproperty-penWidth: 1;
+}
+FastShutter[interlocked="true"] #icon{
+    border: 2px solid black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+FastShutter[interlocked="false"] #icon{
+    border: 0px;
+    qproperty-brush: #00FF00;
+}
+FastShutter[state="OPEN"] #icon {
+    qproperty-brush: #00FF00;
+}
+FastShutter[state="MOVING"] #icon {
+    qproperty-brush: yellow;
+}
+FastShutter[state="CLOSED"] #icon {
+    qproperty-brush: black;
+}
+FastShutter[state="INVALID"] #icon {
+    qproperty-brush: red;
+}
+FastShutter[error="At Vacuum"] #icon {
+    qproperty-arrowBrush: #00FF00;
+}
+
+/*bug in lcls-twincat-vac has both `At Vacuum` and `AT Vacuum`*/
+
+FastShutter[error="AT Vacuum"] #icon {
+    qproperty-arrowBrush: #00FF00;
+}
+
+FastShutter[error="Triggered"] #icon {
+    qproperty-arrowBrush: yellow;
+}
+FastShutter[error="Vacuum Fault"] #icon {
+    qproperty-arrowBrush: red;
+}
+FastShutter[error="Close Timeout"] #icon {
+    qproperty-arrowBrush: red;
+}
+FastShutter[error="Open Timeout"] #icon {
+    qproperty-arrowBrush: red;
+}
+
+FastShutter[error="Ext Fault"] #icon {
+    qproperty-arrowBrush: red;
+}
+
+/*###############################*/
+
+/* Control Only Valve Normally Closed - vvcNC*/
+
+ControlOnlyValveNC #icon {
+    qproperty-penStyle: "Qt::SolidLine";
+    qproperty-penColor: black;
+    qproperty-penWidth: 2;
+}
+ControlOnlyValveNC[interlocked="true"] #icon{
+    border: 2px solid black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+ControlOnlyValveNC[interlocked="false"] #icon{
+    border: 0px;
+}
+ControlOnlyValveNC[state="One"] #icon {
+    qproperty-brush: #00FF00;
+}
+ControlOnlyValveNC[state="Zero"] #icon {
+    qproperty-brush: black;
+}
+ControlOnlyValveNC[state="Open"] #icon {
+    qproperty-brush:#00FF00;
+}
+ControlOnlyValveNC[state="Closed"] #icon {
+    qproperty-brush: black;
+}
+
+ControlOnlyValveNC[state="CLOSE"] #icon {
+    qproperty-penStyle: "QT::SolidLine";
+    qproperty-penColor: gray;
+    qproperty-penWidth: 2;
+	qproperty-brush: black;
+}
+
+ControlOnlyValveNC[state="OPEN"] #icon {
+    qproperty-penStyle: "QT::SolidLine";
+    qproperty-penColor: gray;
+    qproperty-penWidth: 2;
+	qproperty-brush: #00FF00;
+}
+
+
+/*##################################*/
+
+/* Control Only Valve Normally Open - vvcNO*/
+
+ControlOnlyValveNO #icon {
+    qproperty-penStyle: "Qt::SolidLine";
+    qproperty-penColor: black;
+    qproperty-penWidth: 2;
+}
+ControlOnlyValveNO[interlocked="true"] #icon{
+    border: 2px solid black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+ControlOnlyValveNO[interlocked="false"] #icon{
+    border: 0px;
+}
+ControlOnlyValveNO[state="One"] #icon {
+    qproperty-brush: #00FF00;
+}
+ControlOnlyValveNO[state="Zero"] #icon {
+    qproperty-brush: black;
+}
+ControlOnlyValveNO[state="Open"] #icon {
+    qproperty-brush:#00FF00;
+}
+ControlOnlyValveNO[state="Closed"] #icon {
+    qproperty-brush: black;
+}
+
+/*##################################*/
+
+/* Needle Valve - vcn*/
+
+NeedleValve[interlocked="true"] #icon{
+    border: 2px solid black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+NeedleValve[interlocked="false"] #icon{
+    border: 0px;
+}
+NeedleValve[state="Close"] #icon {
+   qproperty-brush: black;
+}
+NeedleValve[state="Open"] #icon {
+    qproperty-brush: #00FF00;
+}
+NeedleValve[state="PressureControl"] #icon {
+    qproperty-brush: blue;
+}
+NeedleValve[state="ManualControl"] #icon {
+    qproperty-brush: purple;
+}
+/*################################*/
+/* Pumps */
+/*################################*/
+
+/* Turbo Pump - ptm */
+
+TurboPump[interlocked="true"] #icon {
+    border: 2px solid black;
+    qproperty-penColor: black;
+}
+TurboPump[interlocked="false"] #icon {
+    border: 0px;
+}
+TurboPump[state="RUNNING"] #icon {
+    qproperty-centerBrush: #00FF00;
+    qproperty-brush: #00FF00;
+}
+TurboPump[state="STOPPING"] #icon {
+    qproperty-centerBrush: orange;
+    qproperty-brush: orange;
+}
+TurboPump[state="STARTING"] #icon {
+    qproperty-centerBrush: yellow;
+    qproperty-brush: yellow;
+}
+TurboPump[state="STOPPED"] #icon {
+    qproperty-centerBrush: gray;
+    qproperty-brush: gray;
+}
+TurboPump[state="FAULT"] #icon {
+    qproperty-centerBrush: red;
+    qproperty-brush: red;
+}
+TurboPump[error="TRUE"] #icon {
+    qproperty-penColor: #E01010;
+    qproperty-centerBrush: red;
+}
+TurboPump[error="FALSE"] #icon {
+    qproperty-penColor: black;
+}
+
+/*################################*/
+
+/* Scroll Pump - pro */
+
+ScrollPump[interlocked="true"] #icon {
+    border: 2px solid black;
+}
+ScrollPump[interlocked="false"] #icon {
+    border: 0px;
+}
+ScrollPump[state="RUNNING"] #icon {
+    qproperty-centerBrush: #00FF00;
+    qproperty-brush: #00FF00;
+}
+ScrollPump[state="STOPPING"] #icon {
+    qproperty-centerBrush: orange;
+    qproperty-brush: orange;
+}
+ScrollPump[state="STARTING"] #icon {
+    qproperty-centerBrush: yellow;
+    qproperty-brush: yellow;
+}
+ScrollPump[state="STOPPED"] #icon {
+    qproperty-centerBrush: gray;
+    qproperty-brush: gray;
+}
+ScrollPump[state="FAULT"] #icon {
+    qproperty-centerBrush: red;
+    qproperty-brush: red;
+}
+ScrollPump[error="TRUE"] #icon {
+    qproperty-centerBrush: red;
+    qproperty-penColor: #E01010;
+}
+
+ScrollPump[error="FALSE"] #icon {
+    qproperty-penColor: black;
+}
+
+/*################################*/
+
+/* Ion Pump - pip*/
+
+IonPump #pressure{
+    color: blue;
+    border: 1px solid black;
+    background-color : white;
+}
+IonPump[state="STOPPED"] #pressure{
+    color: gray;
+    border: 1px;
+}
+IonPump[error="TRUE"] #pressure{
+    color: gray;
+    border: 1px;
+}
+
+IonPump[interlocked="true"] #icon {
+    border: 2px solid black;
+    qproperty-penColor: black;
+}
+IonPump[interlocked="false"] #icon {
+    border: 0px;
+}
+IonPump[state="RUNNING"] #icon {
+    qproperty-brush: #00FF00;
+}
+IonPump[state="STOPPING"] #icon {
+    qproperty-brush: orange;
+}
+IonPump[state="STARTING"] #icon {
+    qproperty-brush: yellow;
+}
+IonPump[state="STOPPED"] #icon {
+    qproperty-brush: gray;
+}
+IonPump[state="FAULT"] #icon {
+    qproperty-brush: red;
+}
+IonPump[error="TRUE"] #icon {
+    qproperty-penColor: #E01010;
+}
+IonPump[error="FALSE"] #icon {
+    qproperty-penColor: black;
+}
+
+/*################################*/
+/* Gauges */
+/*################################*/
+
+/* Rough Gauge - gpi */
+
+
+RoughGauge #pressure{
+    color: blue;
+    border: 1px solid black;
+    background-color : white
+}
+RoughGauge[state="GaugeDisconnected"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+RoughGauge[state="Off"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+RoughGauge[state="PressInvalid"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+RoughGauge[interlocked="true"] #icon{
+    border: 2px solid black;
+    qproperty-brush: black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+RoughGauge[state="Off"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+RoughGauge[state="GaugeDisconnected"] #icon {
+    qproperty-penColor: gray;
+    qproperty-brush: black;
+}
+RoughGauge[state="OoR"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+RoughGauge[state="PressInvalid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+RoughGauge[state="Valid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+RoughGauge[state="ValidLo"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+RoughGauge[state="ValidHi"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+
+/*################################*/
+
+/* Cold Cathode - gcc */
+
+ColdCathodeGauge #pressure{
+    color: blue;
+    border: 1px solid black;
+    background-color : white
+}
+ColdCathodeGauge[state="GaugeDisconnected"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+ColdCathodeGauge[state="Off"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+ColdCathodeGauge[state="PressInvalid"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+ColdCathodeGauge[interlocked="true"] #icon {
+    border: 2px solid black;
+}
+ColdCathodeGauge[interlocked="false"] #icon {
+    border: 0px;
+}
+ColdCathodeGauge[state="Off"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+ColdCathodeGauge[state="GaugeDisconnected"] #icon {
+    qproperty-penColor: gray;
+    qproperty-brush: black;
+}
+ColdCathodeGauge[state="OoR"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+ColdCathodeGauge[state="PressInvalid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+ColdCathodeGauge[state="Starting"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: yellow;
+}
+ColdCathodeGauge[state="Valid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+ColdCathodeGauge[state="ValidLo"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+ColdCathodeGauge[state="ValidHi"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+
+/*###################################*/
+
+/* Hot Cathode - ghc */
+
+HotCathodeGauge #pressure{
+    color: blue;
+    border: 1px solid black;
+    background-color : white
+}
+HotCathodeGauge[state="GaugeDisconnected"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+HotCathodeGauge[state="Off"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+HotCathodeGauge[state="PressInvalid"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+HotCathodeGauge[interlocked="true"] #icon {
+    border: 2px solid black;
+}
+HotCathodeGauge[interlocked="false"] #icon {
+    border: 0px;
+}
+HotCathodeGauge[state="Off"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+HotCathodeGauge[state="GaugeDisconnected"] #icon {
+    qproperty-penColor: gray;
+    qproperty-brush: black;
+}
+HotCathodeGauge[state="OoR"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+HotCathodeGauge[state="PressInvalid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+HotCathodeGauge[state="Starting"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: yellow;
+}
+HotCathodeGauge[state="Valid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+HotCathodeGauge[state="ValidLo"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+HotCathodeGauge[state="ValidHi"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}

--- a/typhos/tests/utils/tiny_stylesheet.qss
+++ b/typhos/tests/utils/tiny_stylesheet.qss
@@ -1,0 +1,2 @@
+/* tiny test stylesheet for the test */
+QLineEdit { color: red }

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -315,7 +315,7 @@ def compose_stylesheets(stylesheets: Iterable[str | pathlib.Path]) -> str:
     style_parts = []
     for sheet in stylesheets:
         path = pathlib.Path(sheet)
-        if isinstance(sheet, pathlib.Path) or path.suffix == "qss":
+        if isinstance(sheet, pathlib.Path) or path.suffix == ".qss":
             with path.open() as fd:
                 style_parts.append(fd.read())
         elif isinstance(sheet, str):

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -308,16 +308,20 @@ def compose_stylesheets(stylesheets: Iterable[str | pathlib.Path]) -> str:
     Raises
     ------
     OSError
-        If any error is encountered while reading a file.
+        If any error is encountered while reading a file
+    TypeError
+        If the input is not a valid type
     """
     style_parts = []
     for sheet in stylesheets:
         path = pathlib.Path(sheet)
-        if path.suffix == "qss":
+        if isinstance(sheet, pathlib.Path) or path.suffix == "qss":
             with path.open() as fd:
                 style_parts.append(fd.read())
-        else:
+        elif isinstance(sheet, str):
             style_parts.append(sheet)
+        else:
+            raise TypeError(f"Invalid input {sheet} of type {type(sheet)}")
     return "\n".join(reversed(style_parts))
 
 

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -281,9 +281,10 @@ def compose_stylesheets(
     widget: QtWidgets.QWidget | None = None,
 ) -> None:
     """
-    Apply all the stylesheets at once.
+    Apply all the stylesheets at once, along with the Fusion style.
 
     Stylesheets applied later will override stylesheets applied earlier.
+    The Fusion style can only be applied to a QApplication.
 
     Applies stylesheets in the following order:
     - PyDM's built-in stylesheet, if PYDM_STYLESHEET_INCLUDE_DEFAULT is set.
@@ -306,6 +307,9 @@ def compose_stylesheets(
         The widget to apply the stylesheet to.
         If omitted, apply to the whole QApplication.
     """
+    if isinstance(widget, QtWidgets.QApplication):
+        widget.setStyle(QtWidgets.QStyleFactory.create('Fusion'))
+
     style_parts = []
 
     if include_pydm and PYDM_INCLUDE_DEFAULT:

--- a/typhos/utils.py
+++ b/typhos/utils.py
@@ -292,12 +292,13 @@ def compose_stylesheets(stylesheets: Iterable[str | pathlib.Path]) -> str:
 
     Parameters
     ----------
-    stylesheets : list of str or pathlib.Path
-        A list of the stylesheets to combine. Each element of the list
-        can either be a fully-loaded stylesheet or a full path to a
-        stylesheet. Stylesheet paths must end in the .qss suffix.
+    stylesheets : iterable of str or pathlib.Path
+        An itetable, such as a list, of the stylesheets to combine.
+        Each element can either be a fully-loaded stylesheet or a full path to
+        a stylesheet. Stylesheet paths must end in the .qss suffix.
         In the unlikely event that a string is both a valid path
-        and a valid stylesheet, it will be interpretted as a path.
+        and a valid stylesheet, it will be interpretted as a path,
+        even if no file exists at that path.
 
     Returns
     -------
@@ -334,9 +335,6 @@ def apply_standard_stylesheets(
     """
     Apply all the stylesheets at once, along with the Fusion style.
 
-    Stylesheets applied later will override stylesheets applied earlier.
-    The Fusion style can only be applied to a QApplication.
-
     Applies stylesheets with the following priority order:
     - Any existing stylesheet data on the widget
     - User stylesheets in the paths argument
@@ -344,12 +342,14 @@ def apply_standard_stylesheets(
     - Typhos's stylesheet (either the dark or the light variant)
     - PyDM's built-in stylesheet, if PYDM_STYLESHEET_INCLUDE_DEFAULT is set.
 
+    The Fusion style can only be applied to a QApplication.
+
     Parameters
     ----------
     dark : bool, optional
         Whether or not to use the QDarkStyleSheet theme. By default the light
         theme is chosen.
-    paths : str, optional
+    paths : iterable of str, optional
         User-provided paths to stylesheets to apply.
     include_pydm : bool, optional
         Whether or not to use the stylesheets defined in the pydm environment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- Include the normal stylesheets that load when `pydm` loads.
- Re-implement the stylesheet loading and composition rather than using `pydm`'s utilities to enforce a specific order.
- Include a way to add a stylesheet in CLI instead of the previous version which only had a way to override all stylesheets.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #540

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test, tested interactively with the case I cared about

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings, comments, and sphinx docs updating.
Later: release notes