### PR TITLE
FIX: ignore bonus unrelated modules found in py310 walk

### DIFF
--- a/docs/source/upcoming_release_notes/558-fix_py310_benchmark.rst
+++ b/docs/source/upcoming_release_notes/558-fix_py310_benchmark.rst
@@ -1,0 +1,23 @@
+558 fix_py310_benchmark
+#######################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix issues with running the CLI benchmarks in certain
+  conda installs, particularly python>=3.10.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/benchmark/utils.py
+++ b/typhos/benchmark/utils.py
@@ -167,8 +167,8 @@ def get_submodule_names(module_name):
         # This attr is missing if there are no submodules
         return submodule_names
 
-    for _, submodule_name, is_pkg in pkgutil.walk_packages(module_path):
-        if submodule_name != '__main__':
+    for info, submodule_name, is_pkg in pkgutil.walk_packages(module_path):
+        if submodule_name != '__main__' and info.path in module_path:
             full_submodule_name = module_name + '.' + submodule_name
             submodule_names.append(full_submodule_name)
             if is_pkg:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix an issue where the cli benchmark package walk could discover an anaconda tests module in addition to the expected typhos submodules.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed that our python 3.10 integration tests started failing for typhos with nonsensical import errors like typhos.tests.conda_env. It turns out that we were picking up site-packages/tests in the package walk starting from typhos:

<details>

```
In [3]: import typhos, pkgutil

In [4]: list(pkgutil.walk_packages(typhos.__path__))
Out[4]:
[ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='__main__', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='alarm', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='app', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='benchmark', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='cache', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='cli', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='display', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='examples', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='func', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='jira', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='panel', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='plugins', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='positioner', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='related_display', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='status', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='suite', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='tests', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests'), name='tests.conda_env', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env'), name='tests.conda_env.installers', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env/installers'), name='tests.conda_env.installers.test_pip', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env'), name='tests.conda_env.specs', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env/specs'), name='tests.conda_env.specs.test_base', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env/specs'), name='tests.conda_env.specs.test_binstar', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env/specs'), name='tests.conda_env.specs.test_requirements', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env/specs'), name='tests.conda_env.specs.test_yaml_file', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env'), name='tests.conda_env.test_cli', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env'), name='tests.conda_env.test_create', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env'), name='tests.conda_env.test_env', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env'), name='tests.conda_env.test_pip_util', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/miniconda3/envs/pcds-6.0.0/lib/python3.10/site-packages/tests/conda_env'), name='tests.conda_env.utils', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='textedit', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='tools', ispkg=True),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='tweakable', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='utils', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='variety', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='version', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='web', ispkg=False),
 ModuleInfo(module_finder=FileFinder('/cds/home/z/zlentz/github/typhos/typhos'), name='widgets', ispkg=False)]
```

</details>

This must be a pkgutil bug but I cba to do anything about it except switch to a better API for submodule discovery. I'm passively on the hunt for one now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively by making the unit tests pass again and verifying that the function output still looks correct.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a
<!--
## Screenshots (if appropriate):
-->
