### PR TITLE
ENH: add `--screenshot` to the typhos CLI

### DIFF
--- a/docs/source/upcoming_release_notes/566-screenshot.rst
+++ b/docs/source/upcoming_release_notes/566-screenshot.rst
@@ -1,0 +1,27 @@
+566 screenshot
+#################
+
+API Changes
+-----------
+- Added ``TyphosSuite.save_screenshot`` which takes a screenshot of the entire
+  suite as-displayed.
+- Added ``TyphosSuite.save_device_screenshots`` which takes individual
+  screenshots of each device display in the suite and saves them to the
+  provided formatted filename.
+
+Features
+--------
+- Add ``typhos --screenshot filename_pattern`` to take screenshots of typhos
+  displays prior to exiting early (in combination with ``--exit-after``).
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -1,4 +1,6 @@
 """This module defines the ``typhos`` command line utility"""
+from __future__ import annotations
+
 import argparse
 import ast
 import inspect
@@ -6,6 +8,8 @@ import logging
 import re
 import signal
 import sys
+import types
+import typing
 from typing import Optional
 
 import coloredlogs
@@ -24,6 +28,31 @@ from typhos.utils import (apply_standard_stylesheets, compose_stylesheets,
                           nullcontext)
 
 logger = logging.getLogger(__name__)
+
+
+class TyphosArguments(types.SimpleNamespace):
+    """Type hints for ``typhos`` CLI entrypoint arguments."""
+
+    devices: list[str]
+    layout: str
+    cols: int
+    display_type: str
+    scrollable: str
+    size: Optional[str]
+    hide_displays: bool
+    happi_cfg: Optional[str]
+    fake_device: bool
+    version: bool
+    verbose: bool
+    dark: bool
+    stylesheet_override: Optional[list[str]]
+    stylesheet_add: Optional[list[str]]
+    profile_modules: Optional[list[str]]
+    profile_output: Optional[str]
+    benchmark: Optional[list[str]]
+    exit_after: Optional[float]
+    screenshot_filename: Optional[str]
+
 
 # Argument Parser Setup
 parser = argparse.ArgumentParser(
@@ -179,6 +208,14 @@ parser.add_argument(
     help=(
         "(For profiling purposes) Exit typhos after the provided number of "
         "seconds"
+    ),
+)
+parser.add_argument(
+    '--screenshot',
+    dest="screenshot_filename",
+    help=(
+        "Save a screenshot of the generated display(s) prior to exiting to "
+        "this filename"
     ),
 )
 
@@ -484,7 +521,8 @@ def typhos_run(
     initial_size: Optional[str] = None,
     show_displays: bool = True,
     exit_after: Optional[float] = None,
-) -> QtWidgets.QMainWindow:
+    screenshot_filename: Optional[str] = None,
+) -> Optional[QtWidgets.QMainWindow]:
     """
     Run the central typhos part of typhos.
 
@@ -516,6 +554,8 @@ def typhos_run(
     show_displays : bool, optional
         If True (default), open all the included device displays.
         If False, do not open any of the displays.
+    screenshot_filename : str, optional
+        Save a screenshot to this file prior to exiting early.
 
     Returns
     -------
@@ -534,34 +574,42 @@ def typhos_run(
             scroll_option=scroll_option,
             show_displays=show_displays,
         )
-    if suite:
-        if initial_size is not None:
-            try:
-                initial_size = QtCore.QSize(
-                    *(int(opt) for opt in initial_size.split(','))
-                )
-            except TypeError as exc:
-                raise ValueError(
-                    "Invalid --size argument. Expected a two-element pair "
-                    "of comma-separated integers, e.g. --size 1000,1000"
-                ) from exc
 
-        def exit_early():
-            logger.warning(
-                "Exiting typhos early due to --exit-after=%s CLI argument.",
-                exit_after
+    if suite is None:
+        logger.debug("Suite creation failure")
+        return None
+
+    if initial_size is not None:
+        try:
+            initial_size = QtCore.QSize(
+                *(int(opt) for opt in initial_size.split(','))
             )
-            sys.exit(0)
+        except TypeError as exc:
+            raise ValueError(
+                "Invalid --size argument. Expected a two-element pair "
+                "of comma-separated integers, e.g. --size 1000,1000"
+            ) from exc
 
-        if exit_after is not None and exit_after >= 0:
-            QtCore.QTimer.singleShot(exit_after * 1000.0, exit_early)
+    def exit_early():
+        logger.warning(
+            "Exiting typhos early due to --exit-after=%s CLI argument.",
+            exit_after
+        )
 
-        return launch_suite(suite, initial_size=initial_size)
+        if screenshot_filename is not None:
+            suite.save_device_screenshots(screenshot_filename)
+
+        sys.exit(0)
+
+    if exit_after is not None and exit_after >= 0:
+        QtCore.QTimer.singleShot(exit_after * 1000.0, exit_early)
+
+    return launch_suite(suite, initial_size=initial_size)
 
 
 def typhos_cli(args):
     """Command Line Application for Typhos."""
-    args = parser.parse_args(args)
+    args = typing.cast(TyphosArguments, parser.parse_args(args))
 
     if args.version:
         print(f'Typhos: Version {typhos.__version__} from {typhos.__file__}')
@@ -602,6 +650,7 @@ def typhos_cli(args):
                 initial_size=args.size,
                 show_displays=not args.hide_displays,
                 exit_after=args.exit_after,
+                screenshot_filename=args.screenshot_filename,
             )
 
         return suite

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -9,7 +9,6 @@ import re
 import signal
 import sys
 import types
-import typing
 from typing import Optional
 
 import coloredlogs
@@ -609,7 +608,7 @@ def typhos_run(
 
 def typhos_cli(args):
     """Command Line Application for Typhos."""
-    args = typing.cast(TyphosArguments, parser.parse_args(args))
+    args = parser.parse_args(args, TyphosArguments())
 
     if args.version:
         print(f'Typhos: Version {typhos.__version__} from {typhos.__file__}')

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -213,8 +213,10 @@ parser.add_argument(
     '--screenshot',
     dest="screenshot_filename",
     help=(
-        "Save a screenshot of the generated display(s) prior to exiting to "
-        "this filename"
+        "Save screenshot(s) of all contained TyphosDeviceDisplay instances to "
+        "this filename pattern prior to exiting early. This name may contain "
+        "f-string style variables, including: suite_title, widget_title, "
+        "device, and name."
     ),
 )
 
@@ -554,7 +556,10 @@ def typhos_run(
         If True (default), open all the included device displays.
         If False, do not open any of the displays.
     screenshot_filename : str, optional
-        Save a screenshot to this file prior to exiting early.
+        Save screenshot(s) of all contained TyphosDeviceDisplay instances to
+        this filename pattern prior to exiting early. This name may contain
+        f-string style variables,  including: suite_title, widget_title,
+        device, and name.
 
     Returns
     -------

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1405,6 +1405,9 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         self.macros = self._build_macros_from_device(device, macros=macros)
         self.load_best_template()
 
+        if not self.windowTitle():
+            self.setWindowTitle(getattr(device, "name", ""))
+
     def search_for_templates(self):
         """Search the filesystem for device-specific templates."""
         device = self.device

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -776,7 +776,6 @@ class TyphosSuite(TyphosBase):
         image = utils.take_widget_screenshot(self)
         if image is None:
             logger.warning("Failed to take screenshot")
-
             return False
 
         logger.info(

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -384,7 +384,7 @@ class TyphosSuite(TyphosBase):
 
         Parameters
         ----------
-        display :str or Device
+        display : str or Device
             Name of screen or device
 
         Returns
@@ -766,6 +766,59 @@ class TyphosSuite(TyphosBase):
 
     # Add the template to the docstring
     save.__doc__ += textwrap.indent('\n' + utils.saved_template, '\t\t')
+
+    def save_screenshot(
+        self,
+        filename: str,
+    ) -> bool:
+        """Save a screenshot of this widget to ``filename``."""
+
+        image = utils.take_widget_screenshot(self)
+        if image is None:
+            logger.warning("Failed to take screenshot")
+
+            return False
+
+        logger.info(
+            "Saving screenshot of suite titled '%s' to '%s'",
+            self.windowTitle(), filename,
+        )
+        image.save(filename)
+        return True
+
+    def save_device_screenshots(
+        self,
+        filename_format: str,
+    ) -> bool:
+        """Save screenshot(s) of devices to ``filename_format``."""
+
+        for device in self.devices:
+            display = self.get_subdisplay(device)
+
+            if hasattr(display, "to_image"):
+                image = display.to_image()
+            else:
+                # This is a fallback for if/when we don't have a TyphosDisplay
+                image = utils.take_widget_screenshot(display)
+
+            if image is None:
+                logger.warning("Failed to take screenshot")
+                return False
+
+            suite_title = self.windowTitle()
+            widget_title = display.windowTitle()
+            filename = filename_format.format(
+                suite_title=suite_title,
+                widget_title=widget_title,
+                device=device,
+                name=device.name,
+            )
+            logger.info(
+                "Saving screenshot of '%s': '%s' to '%s'",
+                suite_title, widget_title, filename,
+            )
+            image.save(filename)
+            return True
 
     def _get_sidebar(self, widget):
         items = {}

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -789,9 +789,10 @@ class TyphosSuite(TyphosBase):
     def save_device_screenshots(
         self,
         filename_format: str,
-    ) -> bool:
+    ) -> dict[str, str]:
         """Save screenshot(s) of devices to ``filename_format``."""
 
+        filenames = {}
         for device in self.devices:
             display = self.get_subdisplay(device)
 
@@ -801,12 +802,15 @@ class TyphosSuite(TyphosBase):
                 # This is a fallback for if/when we don't have a TyphosDisplay
                 image = utils.take_widget_screenshot(display)
 
-            if image is None:
-                logger.warning("Failed to take screenshot")
-                return False
-
             suite_title = self.windowTitle()
             widget_title = display.windowTitle()
+            if image is None:
+                logger.warning(
+                    "Failed to take screenshot of device: %s in %s",
+                    device.name, suite_title,
+                )
+                continue
+
             filename = filename_format.format(
                 suite_title=suite_title,
                 widget_title=widget_title,
@@ -818,7 +822,8 @@ class TyphosSuite(TyphosBase):
                 suite_title, widget_title, filename,
             )
             image.save(filename)
-            return True
+            filenames[device.name] = filename
+        return filenames
 
     def _get_sidebar(self, widget):
         items = {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Add `typhos --screenshot filename_pattern` to take screenshots of typhos displays prior to exiting early (in combination with `--exit-after`).

## Motivation and Context
Larger changes to layouts coming in #563 
We should check screenshots from the current master and compare them with #563 to ensure that the latter is strictly an improvement

## How Has This Been Tested?
Test suite and interactively

## Where Has This Been Documented?
This PR text and pre-release notes

## Screenshots

```
$ typhos --fake-device ophyd.EpicsMotor[] --screenshot "{device.name}.png" --exit-after 1
[2023-08-09 09:40:41] - WARNING - Exiting typhos early due to --exit-after=1.0 CLI argument.
[2023-08-09 09:40:41] - INFO - Saving screenshot of 'Typhos Suite - EpicsMotor': 'EpicsMotor' to 'EpicsMotor.png'
```

![EpicsMotor](https://github.com/pcdshub/typhos/assets/5139267/f58acc20-de86-45ec-80ed-925fcc98e9a2)