### PR TITLE
FIX: patch over positioner `limits = (None, None)` issue

### DIFF
--- a/docs/source/upcoming_release_notes/565-poslimits.rst
+++ b/docs/source/upcoming_release_notes/565-poslimits.rst
@@ -1,0 +1,23 @@
+565 poslimits
+#############
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Avoid uncaught ``TypeError`` when ``None`` is present in a positioner
+  ``.limits``.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -314,7 +314,11 @@ class TyphosPositionerWidget(
         except Exception:
             ...
         else:
-            if low_limit < high_limit:
+            if low_limit is None or high_limit is None:
+                # Some devices may erroneously report `None` limits.
+                # TyphosPositioner will hide the limit labels in this scenario.
+                ...
+            elif low_limit < high_limit:
                 self.ui.low_limit.setText(str(low_limit))
                 self.ui.high_limit.setText(str(high_limit))
                 return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* `obj.limits` can be `(None, None)` in some (perhaps?) disconnected/misconfigured devices.
* These limits may not have an associated component, and may be derived directly from the control layer (i.e., EPICS CA PV low/high limits)
* This PR detects the presence of `None` and *currently* hides the limits

For discussion: on connection, it's possible those limits could go to an actual not-`None` value. In that scenario, this PR would have already hidden the limit widgets and they would not be displayed later. 

## Motivation and Context
Aims to close #565

## How Has This Been Tested?
With the "all device screenshot test" mentioned in side channels

## Where Has This Been Documented?
Issue and PR text
