### PR TITLE
ENH/FIX: display resizing when new templates are shown

### DIFF
--- a/docs/source/upcoming_release_notes/571-width_resizing.rst
+++ b/docs/source/upcoming_release_notes/571-width_resizing.rst
@@ -1,0 +1,22 @@
+571 width_resizing
+##################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- typhos suites will now resize in width to fit device displays.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- klauer

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -993,6 +993,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
     device_count_threshold = 0
     signal_count_threshold = 30
+    template_changed = QtCore.Signal(object)
 
     def __init__(
         self,
@@ -1287,6 +1288,16 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
 
         self._update_children()
         utils.reload_widget_stylesheet(self)
+        self.updateGeometry()
+        self.template_changed.emit(template)
+
+    def minimumSizeHint(self) -> QtCore.QSize:
+        if self._scroll_area is None:
+            return super().minimumSizeHint()
+        return QtCore.QSize(
+            self._scroll_area.viewportSizeHint().width(),
+            self.sizeHint().height(),
+        )
 
     @property
     def display_widget(self):

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1296,7 +1296,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
             return super().minimumSizeHint()
         return QtCore.QSize(
             self._scroll_area.viewportSizeHint().width(),
-            self.sizeHint().height(),
+            super().minimumSizeHint().height(),
         )
 
     @property

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import logging
 import os
+import pathlib
 import textwrap
 from functools import partial
+from typing import Optional
 
 import ophyd
 import pcdsutils.qt
@@ -461,6 +463,18 @@ class TyphosSuite(TyphosBase):
             self._content_frame.layout().setAlignment(
                 dock, QtCore.Qt.AlignTop
             )
+
+        self._new_template()
+        if isinstance(widget, TyphosDeviceDisplay):
+            widget.template_changed.connect(self._new_template)
+
+    def _new_template(self, template: Optional[pathlib.Path] = None) -> None:
+        if self.parent() is not None:
+            return
+
+        new_width = self.minimumSizeHint().width()
+        if self.width() < new_width:
+            self.resize(new_width, self.height())
 
     @QtCore.Slot(str)
     @QtCore.Slot(object)

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -8,7 +8,7 @@ import os
 import pathlib
 import textwrap
 from functools import partial
-from typing import Optional
+from typing import Optional, Union
 
 import ophyd
 import pcdsutils.qt
@@ -426,20 +426,29 @@ class TyphosSuite(TyphosBase):
 
     @QtCore.Slot(str)
     @QtCore.Slot(object)
-    def show_subdisplay(self, widget):
+    def show_subdisplay(
+        self,
+        widget: Union[QtWidgets.QWidget, SidebarParameter, str],
+    ) -> QtWidgets.QWidget:
         """
         Open a display in the dock system.
 
         Parameters
         ----------
-        widget: QWidget, SidebarParameter or str
+        widget : QWidget, SidebarParameter or str
             If given a ``SidebarParameter`` from the tree, the widget will be
             shown and the sidebar item update. Otherwise, the information is
             passed to :meth:`.get_subdisplay`
+
+        Returns
+        -------
+        widget : QWidget
+            The subdisplay that was shown.
         """
         # Grab true widget
         if not isinstance(widget, QtWidgets.QWidget):
             widget = self.get_subdisplay(widget)
+
         # Setup the dock
         dock = widgets.SubDisplay(self)
         # Set sidebar properly
@@ -467,8 +476,10 @@ class TyphosSuite(TyphosBase):
         self._new_template()
         if isinstance(widget, TyphosDeviceDisplay):
             widget.template_changed.connect(self._new_template)
+        return widget
 
     def _new_template(self, template: Optional[pathlib.Path] = None) -> None:
+        """Hook for when a new template is selected in a sub-display."""
         if self.parent() is not None:
             return
 

--- a/typhos/tests/test_suite.py
+++ b/typhos/tests/test_suite.py
@@ -8,10 +8,9 @@ from pyqtgraph.parametertree import ParameterTree
 from pyqtgraph.parametertree import parameterTypes as ptypes
 from qtpy import QtWidgets
 
-from typhos.display import TyphosDeviceDisplay
-from typhos.suite import DeviceParameter, TyphosSuite
-from typhos.utils import save_suite
-
+from ..display import DisplayTypes, TyphosDeviceDisplay
+from ..suite import DeviceParameter, TyphosSuite
+from ..utils import save_suite
 from .conftest import MockDevice, show_widget
 
 
@@ -185,3 +184,24 @@ def test_suite_save_cancel_smoke(suite: TyphosSuite, monkeypatch: pytest.MonkeyP
                         'getSaveFileName',
                         lambda *args: None)
     suite.save()
+
+
+def test_suite_resize(suite: TyphosSuite, monkeypatch: pytest.MonkeyPatch):
+    display = suite.show_subdisplay(suite.devices[0].name)
+    display_min_size = display.minimumSizeHint()
+    print("Suite width:", suite.width())
+    print("Display min size", display_min_size)
+    assert suite.width() >= display_min_size.width()
+
+    fixed_height = 100
+
+    for display_type in DisplayTypes:
+        suite.resize(10, fixed_height)
+        print("\nSwitched to template", display_type)
+        print("Suite shrunk to", suite.size())
+        display.display_type = display_type
+        display_min_size = display.minimumSizeHint()
+        print("New display min size", display_min_size)
+        assert suite.width() >= display.minimumSizeHint().width()
+        print("-> Suite width", suite.width())
+        assert suite.height() == fixed_height


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Automatically resize the typhos suite width when initially loaded or when a new template is loaded.

## Motivation and Context
* Horizontal scroll bars are annoying when loading up a new suite
* Aiming to alleviate that by better specifying minimum size hints and growing free-floating suites when new templates are selected

## How Has This Been Tested?
Interactively and with a small included test

## Where Has This Been Documented?
This PR text

## Screenshots (if appropriate):

<img width="791" alt="image" src="https://github.com/pcdshub/typhos/assets/5139267/50c768af-f4bd-4b33-b717-093a774cf925">
