### PR TITLE
ENH: positioner timeout scaling

### DIFF
--- a/docs/source/upcoming_release_notes/582-enh_positioner_timeout_scale.rst
+++ b/docs/source/upcoming_release_notes/582-enh_positioner_timeout_scale.rst
@@ -1,0 +1,22 @@
+582 enh_positioner_timeout_scale
+################################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- Increase motor timeouts proportionally for longer moves.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Increase the motion timeout times proportionally for longer moves, to decrease the chances of a false positive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There were some complaints from MFX that their motors were timing out early.

Prior to this PR, the motion timeouts were:

- Minimum 5 second (settle_time)
- otherwise, slightly greater than the expected travel time (distance/speed + 2*acceleration time)

In some cases for longer moves, the expected time to get to the goal would be wrong by greater than 5 seconds.
This makes it so that these cases are less likely to frivolously error without compromising faster timeout feedback for the shorter moves. I toyed with increasing the base settle time from 5 to, say, 10, but that doesn't help these long moves enough and it delays the timeout message for motors that are expected to arrive "immediately".

I also considered including the motor's settle_time parameter but I wanted to get out a small PR without any unnecessary baggage and without needing more in-depth testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The tests all still pass and the code here is fairly simple

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added pre-release notes

<!--
## Screenshots (if appropriate):
-->
