### PR TITLE
FIX: make setpoint work for original positioner widget, adjust sizing

### DIFF
--- a/docs/source/upcoming_release_notes/585-fix_positioner_setpoint.rst
+++ b/docs/source/upcoming_release_notes/585-fix_positioner_setpoint.rst
@@ -1,0 +1,23 @@
+585 fix_positioner_setpoint
+###########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where setpoint widgets in the full positioner
+  widget had become zero-width.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -476,10 +476,6 @@ class TyphosPositionerWidget(
             self.ui.set_value.addItems(setpoint_signal.enum_strs)
             # Activated signal triggers only when the user selects an option
             self.ui.set_value.activated.connect(self.set)
-            self.ui.set_value.setSizePolicy(
-                QtWidgets.QSizePolicy.Expanding,
-                QtWidgets.QSizePolicy.Fixed,
-            )
             self.ui.set_value.setMinimumContentsLength(20)
             self.ui.tweak_widget.setVisible(False)
         else:
@@ -487,14 +483,23 @@ class TyphosPositionerWidget(
             self.ui.set_value.setAlignment(QtCore.Qt.AlignCenter)
             self.ui.set_value.returnPressed.connect(self.set)
 
+        self.ui.set_value.setSizePolicy(
+            QtWidgets.QSizePolicy.Fixed,
+            QtWidgets.QSizePolicy.Fixed,
+        )
+        self.ui.set_value.setMinimumWidth(
+            self.ui.user_setpoint.minimumWidth()
+        )
         self.ui.set_value.setMaximumWidth(
             self.ui.user_setpoint.maximumWidth()
         )
-
         self.ui.setpoint_layout.addWidget(
             self.ui.set_value,
             alignment=QtCore.Qt.AlignHCenter,
         )
+        self.ui.set_value.setObjectName('set_value')
+        # Because set_value is used instead
+        self.ui.user_setpoint.setVisible(False)
 
     @property
     def device(self):
@@ -1021,12 +1026,6 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
         self.ui.status_label.setVisible(has_status)
         self.ui.error_label.setVisible(has_error)
         self.ui.error_prefix.setVisible(has_error)
-
-    def _define_setpoint_widget(self):
-        super()._define_setpoint_widget()
-        if isinstance(self.ui.user_setpoint, QtWidgets.QLineEdit):
-            # Because set_value is used instead
-            self.ui.user_setpoint.setVisible(False)
 
 
 def clear_error_in_background(device):

--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>343</width>
-    <height>212</height>
+    <width>369</width>
+    <height>277</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -319,15 +319,21 @@ Screen</string>
         <item>
          <widget class="PyDMLabel" name="user_readback">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>0</width>
+            <width>201</width>
             <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>201</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="toolTip">
@@ -350,16 +356,31 @@ Screen</string>
           </property>
          </widget>
         </item>
-        <item>
+        <item alignment="Qt::AlignHCenter">
          <widget class="PyDMLineEdit" name="user_setpoint">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>201</width>
+            <height>25</height>
+           </size>
+          </property>
           <property name="maximumSize">
            <size>
-            <width>0</width>
-            <height>0</height>
+            <width>201</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="toolTip">
            <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -397,9 +418,21 @@ Screen</string>
            </item>
            <item>
             <widget class="QLineEdit" name="tweak_value">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
-               <width>60</width>
+               <width>125</width>
+               <height>25</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>125</width>
                <height>25</height>
               </size>
              </property>
@@ -473,7 +506,7 @@ Screen</string>
            <string/>
           </property>
           <property name="text">
-           <string>error_label</string>
+           <string/>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -719,16 +752,6 @@ Error</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosAlarmCircle</class>
-   <extends>QWidget</extends>
-   <header>typhos.alarm</header>
-  </customwidget>
-  <customwidget>
-   <class>TyphosRelatedSuiteButton</class>
-   <extends>QPushButton</extends>
-   <header>typhos.related_display</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
@@ -742,6 +765,16 @@ Error</string>
    <class>PyDMLineEdit</class>
    <extends>QLineEdit</extends>
    <header>pydm.widgets.line_edit</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosAlarmCircle</class>
+   <extends>QWidget</extends>
+   <header>typhos.alarm</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosRelatedSuiteButton</class>
+   <extends>QPushButton</extends>
+   <header>typhos.related_display</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fixes an issue where the setpoint widgets for the detailed views were coming up with zero width.

The root cause of the issue was that the sizing of the user_setpoint placeholder widget was set to the defaults, so the `setMinimumWidth` call was setting the minimum width of the combobox to 0.

The reason why these various widgets refuse to expand here despite having their size policy set to "Expanding" eludes me, so I've set them to fixed with.

This also incidentally combines some previously diverging code paths that fixes a sizing issue where the detailed view had a vestigial/unused pydm line edit taking up space.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #585 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I need to make a release notes docs entry

## Screenshots (if appropriate):
Master:
![image](https://github.com/pcdshub/typhos/assets/10647860/5bf4ae59-b8df-4ffc-ab59-37f697a9d658)


This PR:
![image](https://github.com/pcdshub/typhos/assets/10647860/6094cade-e0b8-4d6b-b8da-bce456f5a2c2)
