### PR TITLE
MNT: add TyphosDisplaySwitcher to positioner_row.ui

### DIFF
--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -116,7 +116,7 @@
       </widget>
      </item>
      <item>
-      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
+      <widget class="TyphosDisplaySwitcher" name="switcher">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
          <horstretch>0</horstretch>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -115,6 +115,19 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="TyphosDisplaySwitcher" name="TyphosDisplaySwitcher">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -1258,14 +1271,19 @@ Screen</string>
    <header>typhos.alarm</header>
   </customwidget>
   <customwidget>
-   <class>TyphosNotesEdit</class>
-   <extends>QLineEdit</extends>
-   <header>typhos.notes</header>
+   <class>TyphosDisplaySwitcher</class>
+   <extends>QFrame</extends>
+   <header>typhos.display</header>
   </customwidget>
   <customwidget>
    <class>TyphosRelatedSuiteButton</class>
    <extends>QPushButton</extends>
    <header>typhos.related_display</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosNotesEdit</class>
+   <extends>QLineEdit</extends>
+   <header>typhos.notes</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
## Description
Adds TyphosDisplaySwitcher to row positioner widget.

This only required changes to the .ui file, to my complete amazement.  👏 

## Motivation and Context
closes #580 in this case, but not the general one.

## How Has This Been Tested?
Clicking through all the other templates available to me, and I never got stuck

## Where Has This Been Documented?
This PR

<img width="1127" alt="image" src="https://github.com/pcdshub/typhos/assets/35379409/254ac1be-89cb-4a08-9409-e10565cbf4dc">