### PR TITLE
DOC: add checklist to Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,13 @@
 <!--
 ## Screenshots (if appropriate):
 -->
+
+## Pre-merge checklist
+- [ ] Code works interactively
+- [ ] Code contains descriptive docstrings, including context and API
+- [ ] New/changed functions and methods are covered in the test suite where possible
+- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
+- [ ] Test suite passes locally
+- [ ] Test suite passes on GitHub Actions
+- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
+- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate

--- a/docs/source/upcoming_release_notes/588-doc_checklist_prnotes.rst
+++ b/docs/source/upcoming_release_notes/588-doc_checklist_prnotes.rst
@@ -1,0 +1,23 @@
+588 doc_checklist_prnotes
+#########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- adds TyphosDisplaySwitcher to TyphosPositionerRowWidget
+- adds checklist to Pull Request Template
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
- Adds PR Checklist to PR Template
- adds pre-release notes for #587 

## Motivation and Context
I forgor and didn't want to again

## How Has This Been Tested?
N/A

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate