### PR TITLE
FIX: signal prec default

### DIFF
--- a/docs/source/upcoming_release_notes/592-fix_signal_prec_default.rst
+++ b/docs/source/upcoming_release_notes/592-fix_signal_prec_default.rst
@@ -1,0 +1,24 @@
+592 fix_signal_prec_default
+###########################
+
+API Changes
+-----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where ophyd signals with floats would always display with a
+  precision of 0 without special manual configuration. Floating-point signals
+  now default to a precision of 3.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ file = "LICENSE.md"
 typhos = "typhos.cli:main"
 
 [tool.setuptools_scm]
-write_to = "typhos/_version.py"
+version_file = "typhos/_version.py"
 
 [project.entry-points."pydm.widget"]
 TyphosAlarmCirclePlugin = "typhos.alarm:TyphosAlarmCircle"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ file = "LICENSE.md"
 typhos = "typhos.cli:main"
 
 [tool.setuptools_scm]
-version_file = "typhos/_version.py"
+write_to = "typhos/_version.py"
 
 [project.entry-points."pydm.widget"]
 TyphosAlarmCirclePlugin = "typhos.alarm:TyphosAlarmCircle"

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -189,6 +189,10 @@ class SignalConnection(PyDMConnection):
             self.connection_state_signal.emit(connected)
         if write_access is not None:
             self.write_access_signal.emit(write_access)
+        if self.is_float and precision == 0:
+            # Help the user a bit by replacing a clear design error
+            # with a sensible default
+            precision = 3
         if precision is not None:
             self.prec_signal.emit(precision)
         if units is not None:
@@ -222,6 +226,14 @@ class SignalConnection(PyDMConnection):
                              "from signal %r to initialize %r",
                              self.signal.name, channel)
             return
+        if isinstance(signal_val, (float, np.floating)):
+            # Precision is commonly omitted from non-epics signals
+            # Pick a sensible default for displaying floats
+            self.is_float = True
+            signal_meta.setdefault("precision", 3)
+        else:
+            self.is_float = False
+
         # Report new value
         self.send_new_value(signal_val)
         self.send_new_meta(**signal_meta)

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -189,10 +189,15 @@ class SignalConnection(PyDMConnection):
             self.connection_state_signal.emit(connected)
         if write_access is not None:
             self.write_access_signal.emit(write_access)
-        if self.is_float and precision <= 0:
+        if precision <= 0:
             # Help the user a bit by replacing a clear design error
             # with a sensible default
-            precision = 3
+            if self.is_float:
+                # Float precision at 0 is unhelpful
+                precision = 3
+            else:
+                # Integer precision can't be negative
+                precision = 0
         if precision is not None:
             self.prec_signal.emit(precision)
         if units is not None:

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -81,6 +81,7 @@ class SignalConnection(PyDMConnection):
         super().__init__(channel, address, protocol=protocol, parent=parent)
         self._connection_open = True
         self.signal_type = None
+        self.is_float = False
         # Collect our signal
         self.signal = signal_registry[address]
         # Subscribe to updates from Ophyd

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -235,7 +235,11 @@ class SignalConnection(PyDMConnection):
             # Precision is commonly omitted from non-epics signals
             # Pick a sensible default for displaying floats
             self.is_float = True
+            # precision might be missing entirely
             signal_meta.setdefault("precision", 3)
+            # precision might be None, which is code for unset
+            if signal_meta["precision"] is None:
+                signal_meta["precision"] = 3
         else:
             self.is_float = False
 

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -189,7 +189,7 @@ class SignalConnection(PyDMConnection):
             self.connection_state_signal.emit(connected)
         if write_access is not None:
             self.write_access_signal.emit(write_access)
-        if self.is_float and precision == 0:
+        if self.is_float and precision <= 0:
             # Help the user a bit by replacing a clear design error
             # with a sensible default
             precision = 3

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -189,16 +189,16 @@ class SignalConnection(PyDMConnection):
             self.connection_state_signal.emit(connected)
         if write_access is not None:
             self.write_access_signal.emit(write_access)
-        if precision <= 0:
-            # Help the user a bit by replacing a clear design error
-            # with a sensible default
-            if self.is_float:
-                # Float precision at 0 is unhelpful
-                precision = 3
-            else:
-                # Integer precision can't be negative
-                precision = 0
         if precision is not None:
+            if precision <= 0:
+                # Help the user a bit by replacing a clear design error
+                # with a sensible default
+                if self.is_float:
+                    # Float precision at 0 is unhelpful
+                    precision = 3
+                else:
+                    # Integer precision can't be negative
+                    precision = 0
             self.prec_signal.emit(precision)
         if units is not None:
             self.unit_signal.emit(units)

--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -85,10 +85,14 @@ def test_metadata(qapp, qtbot):
     assert widget._prec == 2
 
 
+MISSING = object()
+
+
 @pytest.mark.parametrize(
     "sig_name,value,prec,expected",
     [
-        ("no_prec_signal_float", 1.5, None, 3),
+        ("none_prec_signal_float", 1.5, None, 3),
+        ("missing_prec_signal_float", 1.5, MISSING, 3),
         ("prec_signal_float", np.float32(2.718), 4, 4),
         ("prec_signal_np_float", np.float32(3.14), 5, 5),
         ("no_prec_signal_int", 1, None, 0),
@@ -120,6 +124,12 @@ def test_precision_defaults_at_startup(
     # Create a signal and attach our listener
     if prec is None:
         sig = Signal(name=sig_name, value=value)
+    elif prec is MISSING:
+        sig = RichSignal(
+            name=sig_name,
+            value=value,
+            metadata={},
+        )
     else:
         sig = RichSignal(
             name=sig_name,

--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -91,18 +91,27 @@ MISSING = object()
 @pytest.mark.parametrize(
     "sig_name,value,prec,expected",
     [
+        # float: None -> 3
         ("none_prec_signal_float", 1.5, None, 3),
+        # float: Missing -> 3
         ("missing_prec_signal_float", 1.5, MISSING, 3),
-        ("prec_signal_float", np.float32(2.718), 4, 4),
+        # float: 4 -> 4
+        ("prec_signal_float", 2.718, 4, 4),
+        # np float: 5 -> 5
         ("prec_signal_np_float", np.float32(3.14), 5, 5),
+        # int: None -> 0
         ("no_prec_signal_int", 1, None, 0),
+        # int: 2 -> 2
         ("prec_signal_int", 2, 2, 2),
+        # float: 0 -> 3
         ("zero_prec_float", 1.618, 0, 3),
+        # float: -2 -> 3
         ("neg_prec_float", 4.5, -2, 3),
+        # int: -30 -> 0
         ("neg_prec_int", 5, -30, 0),
     ],
 )
-def test_precision_defaults_at_startup(
+def test_precision_defaults(
     sig_name: str,
     value: int | float | np.floating,
     prec: int | None,
@@ -123,14 +132,17 @@ def test_precision_defaults_at_startup(
     listener = widget.channels()[0]
     # Create a signal and attach our listener
     if prec is None:
+        # Use normal signal defaults, incl precision=None
         sig = Signal(name=sig_name, value=value)
     elif prec is MISSING:
+        # Force a fully empty metadata dict
         sig = RichSignal(
             name=sig_name,
             value=value,
             metadata={},
         )
     else:
+        # Specify the precision precisely
         sig = RichSignal(
             name=sig_name,
             value=value,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When the core (signal) plugin receives a floating point value with no precision information or nonsensical precision information, set the precision metadata to a sensible default.

Manual precision setting at the device/signal level is still supported fully.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By default, we had/have the following cases:

Before:
`0.23` displays as `0`

After:
`0.23` displays as `0.230`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added targeted unit tests

Works interactively with state_velo, which is the signal that led us to this issue:

![image](https://github.com/pcdshub/typhos/assets/10647860/b236cb21-8df5-4c29-baa5-bafa0b1ba6a5)


## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
