### PR TITLE
MAINT: switch typhos cli defaults to embedded/vertical by popular demand

### DIFF
--- a/docs/source/upcoming_release_notes/595-maint_cli_defaults.rst
+++ b/docs/source/upcoming_release_notes/595-maint_cli_defaults.rst
@@ -1,0 +1,25 @@
+595 maint_cli_defaults
+######################
+
+API Breaks
+----------
+- Default typhos suites to "embedded" displays arranged "vertically" instead of
+  "detailed" displays arranged "horizontally" to more naturally match how typhos is
+  used at present.
+
+Features
+--------
+- N/A
+
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/cli.py
+++ b/typhos/cli.py
@@ -70,11 +70,11 @@ parser.add_argument(
 )
 parser.add_argument(
     '--layout',
-    default='horizontal',
+    default='vertical',
     help=(
         'Select a alternate layout for suites of many '
-        'devices. Valid options are "horizontal" (default), '
-        '"vertical", "grid", "flow", and any unique '
+        'devices. Valid options are "horizontal", '
+        '"vertical" (default), "grid", "flow", and any unique '
         'shortenings of those options.'
     ),
 )
@@ -89,11 +89,11 @@ parser.add_argument(
 )
 parser.add_argument(
     '--display-type',
-    default='detailed',
+    default='embedded',
     help=(
         'The kind of display to open for each device at '
-        'initial load. Valid options are "embedded", '
-        '"detailed" (default), "engineering", and any '
+        'initial load. Valid options are "embedded" (default), '
+        '"detailed", "engineering", and any '
         'unique shortenings of those options.'
     ),
 )

--- a/typhos/tests/test_cli.py
+++ b/typhos/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from qtpy.QtWidgets import QLabel
 
 import typhos
 from typhos.cli import typhos_cli
@@ -33,19 +34,20 @@ def test_cli_no_entry(qtbot, happi_cfg):
 
 def test_cli_stylesheet(qapp, qtbot, happi_cfg):
     with open('test.qss', 'w+') as handle:
-        handle.write(
-            "TyphosDeviceDisplay {qproperty-force_template: 'test.ui'}")
+        handle.write("QLabel {color: red}")
     try:
         style = qapp.styleSheet()
         window = typhos_cli(['test_motor', '--stylesheet', 'test.qss',
                              '--happi-cfg', happi_cfg])
         qtbot.addWidget(window)
         suite = window.centralWidget()
-        dev_display = suite.get_subdisplay(suite.devices[0])
-        assert dev_display.force_template == 'test.ui'
-        qtbot.add_widget(dev_display)
-        qapp.setStyleSheet(style)
+        qtbot.addWidget(suite)
+        some_label = suite.findChild(QLabel)
+        assert isinstance(some_label, QLabel)
+        color = some_label.palette().color(some_label.foregroundRole())
+        assert color.red() == 255
     finally:
+        qapp.setStyleSheet(style)
         os.remove('test.qss')
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
When launching a typhos suite via the CLI, set the default look/feel to the embedded/vertical mode.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In recent months we've revamped the most-used embedded templates (motors) to be row widgets, which give a much better screen in general if stacked vertically.

In the past prior to these changes, there was already clamoring for embedded as the default for screen space saving (closes #532)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

Motors open up in neat row-by-row line widgets
Larger devices (somehow?) open up as they always have (TODO investigate)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only here

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
