### PR TITLE
Added an optional signal parameters to SignalConnection.__init__

### DIFF
--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -69,6 +69,11 @@ class SignalConnection(PyDMConnection):
     signal will expect and emit. It is expected that this type is static
     through the execution of the application.
 
+    In most cases, the default behavior is desired: to retrieve the
+    signal from the ``signal_registry``. However if the optional
+    parameter *signal* is provided then this Signal object will be
+    used instead.
+
     Attributes
     ----------
     signal : ophyd.Signal

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -76,14 +76,17 @@ class SignalConnection(PyDMConnection):
     """
     supported_types = [int, float, str, np.ndarray]
 
-    def __init__(self, channel, address, protocol=None, parent=None):
+    def __init__(self, channel, address, protocol=None, parent=None, signal=None):
         # Create base connection
         super().__init__(channel, address, protocol=protocol, parent=parent)
         self._connection_open = True
         self.signal_type = None
         self.is_float = False
         # Collect our signal
-        self.signal = signal_registry[address]
+        if signal is not None:
+            self.signal = signal
+        else:
+            self.signal = signal_registry[address]
         # Subscribe to updates from Ophyd
         self.value_cid = self.signal.subscribe(
             self.send_new_value,

--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -98,7 +98,7 @@ def test_metadata_with_explicit_signal(qapp, qtbot):
     assert widget.enum_strings == ('a', 'b', 'c')
     assert widget._unit == 'urad'
     assert widget._prec == 2
-    
+
 
 MISSING = object()
 

--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -85,6 +85,21 @@ def test_metadata(qapp, qtbot):
     assert widget._prec == 2
 
 
+def test_metadata_with_explicit_signal(qapp, qtbot):
+    widget = PyDMLineEdit()
+    qtbot.addWidget(widget)
+    widget.channel = 'sig://md_signal'
+    listener = widget.channels()[0]
+    # Create a signal and attach our listener
+    sig = RichSignal(name='md_signal', value=1)
+    _ = SignalConnection(listener, 'md_signal', signal=sig)
+    qapp.processEvents()
+    # Check that metadata the metadata got there
+    assert widget.enum_strings == ('a', 'b', 'c')
+    assert widget._unit == 'urad'
+    assert widget._prec == 2
+    
+
 MISSING = object()
 
 

--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -85,14 +85,19 @@ def test_metadata(qapp, qtbot):
     assert widget._prec == 2
 
 
-def test_metadata_with_explicit_signal(qapp, qtbot):
+def test_find_signal(qapp, qtbot):
     widget = PyDMLineEdit()
     qtbot.addWidget(widget)
     widget.channel = 'sig://md_signal'
     listener = widget.channels()[0]
-    # Create a signal and attach our listener
+    # Override the signal getter method to test
     sig = RichSignal(name='md_signal', value=1)
-    _ = SignalConnection(listener, 'md_signal', signal=sig)
+
+    class CustomConnection(SignalConnection):
+        def find_signal(self, address):
+            return sig
+
+    _ = CustomConnection(listener, 'md_signal')
     qapp.processEvents()
     # Check that metadata the metadata got there
     assert widget.enum_strings == ('a', 'b', 'c')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

In the __init__ method of `typhos.core.SignalConnection` class, it looks up the signal corresponding to its address in the signal_registry dictionary. This PR adds an optional ``signal=None`` argument to the SignalConnection.__init__() method. If *signal* is ``None`` (default), then the behavior is the same as before. However, if a *signal* is provided, it will be used for the rest of the connection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This makes the SignalConnection class more flexible, and allows it to be used with other registries. In my case, I want to look up signals from the [ophyd-registry package](https://pypi.org/project/ophyd-registry/) since the dictionary style registry used by Typhos doesn't meet all my use-cases. To do that, I will subclass the ``SignalConnection`` and ``SignalPlugin`` classes.

In its current implementation I have to vendor in the entire __init__ method since ``self.signal`` is written half-way through and then used immediately. Vendoring in __init__ is not desirable since future updates to this method will not be available making the code less maintainable.

With this proposed change, I can use super() instead:

```python
class MySignalConnection(SignalConnection):
    def __init__(self, channel, address, protocol=None, parent=None, signal=None):
        # Assume *my_registry* is an instance of ``ophydregistry.Registry()``
        signal = my_registry.find(address)
        # Now call the original SignalConnection __init__ so we get all the Typhos goodness
        super().__init__(channel=channel, address=address, protocol=protocol, parent=parent, signal=signal)

```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To ensure existing behavior is not affected, the tests in ``typhos/tests/plugins/test_core.py`` were run before and after this change, passing in both cases.

To test the new behavior, a new test was added to test_core.py, similar to the existing ``test_metadata()`` but where the signal object is not added to ``signal_registry`` and is instead passed in with the *signal* parameter.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

The docstring for SignalConnection has been updated to describe the new parameter. It now includes:

> In most cases, the default behavior is desired: to retrieve the
    signal from the ``signal_registry``. However if the optional
    parameter *signal* is provided then this Signal object will be
    used instead.

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
