### PR TITLE
ENH: switch lim colors to blk/org from yel/yel

### DIFF
--- a/docs/source/upcoming_release_notes/600-enh_lim_colors.rst
+++ b/docs/source/upcoming_release_notes/600-enh_lim_colors.rst
@@ -1,0 +1,23 @@
+600 enh_lim_colors
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Change position widget limit colors from yellow off/yellow on to
+  dark gray off/orange on for better contrast.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -128,16 +128,16 @@
             </property>
             <property name="onColor" stdset="0">
              <color>
-              <red>239</red>
-              <green>246</green>
-              <blue>20</blue>
+              <red>255</red>
+              <green>150</green>
+              <blue>0</blue>
              </color>
             </property>
             <property name="offColor" stdset="0">
              <color>
-              <red>178</red>
-              <green>188</green>
-              <blue>17</blue>
+              <red>50</red>
+              <green>50</green>
+              <blue>50</blue>
              </color>
             </property>
             <property name="showLabels" stdset="0">
@@ -595,16 +595,16 @@ Screen</string>
             </property>
             <property name="onColor" stdset="0">
              <color>
-              <red>239</red>
-              <green>246</green>
-              <blue>20</blue>
+              <red>255</red>
+              <green>150</green>
+              <blue>0</blue>
              </color>
             </property>
             <property name="offColor" stdset="0">
              <color>
-              <red>178</red>
-              <green>188</green>
-              <blue>17</blue>
+              <red>50</red>
+              <green>50</green>
+              <blue>50</blue>
              </color>
             </property>
             <property name="orientation" stdset="0">

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -483,16 +483,16 @@
           </property>
           <property name="onColor" stdset="0">
            <color>
-            <red>239</red>
-            <green>246</green>
-            <blue>20</blue>
+            <red>255</red>
+            <green>150</green>
+            <blue>0</blue>
            </color>
           </property>
           <property name="offColor" stdset="0">
            <color>
-            <red>178</red>
-            <green>188</green>
-            <blue>17</blue>
+            <red>50</red>
+            <green>50</green>
+            <blue>50</blue>
            </color>
           </property>
           <property name="showLabels" stdset="0">
@@ -779,16 +779,16 @@
           </property>
           <property name="onColor" stdset="0">
            <color>
-            <red>239</red>
-            <green>246</green>
-            <blue>20</blue>
+            <red>255</red>
+            <green>150</green>
+            <blue>0</blue>
            </color>
           </property>
           <property name="offColor" stdset="0">
            <color>
-            <red>178</red>
-            <green>188</green>
-            <blue>17</blue>
+            <red>50</red>
+            <green>50</green>
+            <blue>50</blue>
            </color>
           </property>
           <property name="orientation" stdset="0">
@@ -1276,14 +1276,14 @@ Screen</string>
    <header>typhos.display</header>
   </customwidget>
   <customwidget>
-   <class>TyphosRelatedSuiteButton</class>
-   <extends>QPushButton</extends>
-   <header>typhos.related_display</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosNotesEdit</class>
    <extends>QLineEdit</extends>
    <header>typhos.notes</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosRelatedSuiteButton</class>
+   <extends>QPushButton</extends>
+   <header>typhos.related_display</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Switch the limit indicator colors to something more visible for the positioner widgets.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Many justified complaints about yellow -> brighter yellow being impossible to see for many users/screens

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
slack thread, so far, release notes later


## Screenshots (if appropriate):

old:
![old_lims](https://github.com/pcdshub/typhos/assets/10647860/1779e6ed-73ef-414c-a7df-83388f4eb4bd)
new:
![new_lims](https://github.com/pcdshub/typhos/assets/10647860/812812d9-cbf3-4595-b677-eac7590e89bd)
![image](https://github.com/pcdshub/typhos/assets/10647860/1a06142d-aef6-4f06-9172-881131c8666d)

## Pre-merge checklist
- [x] Code works interactively
- [ ] ~Code contains descriptive docstrings, including context and API~
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [ ] ~Code has been checked for threading issues (no blocking tasks in GUI thread)~
- [ ] ~Test suite passes locally~
- [ ] ~Test suite passes on GitHub Actions~
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
