### PR TITLE
PERF: set text size on resize event, not on paint event, to avoid 100% cpu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,4 @@ ENV/
 # Editors
 *.swp
 *~
+.vscode

--- a/docs/source/upcoming_release_notes/604-perf_resize_text.rst
+++ b/docs/source/upcoming_release_notes/604-perf_resize_text.rst
@@ -1,0 +1,22 @@
+604 perf_resize_text
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where the row positioner widget's resizing would peg the cpu to 100%
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/dynamic_font.py
+++ b/typhos/dynamic_font.py
@@ -119,7 +119,7 @@ def patch_widget(
         maximum font size. Content margin settings determine the content
         rectangle, and this padding is applied as a percentage on top of that.
     """
-    def paintEvent(event: QtGui.QPaintEvent) -> None:
+    def resizeEvent(event: QtGui.QResizeEvent) -> None:
         font = widget.font()
         font_size = get_widget_maximum_font_size(
             widget, widget.text(),
@@ -129,27 +129,27 @@ def patch_widget(
         if abs(font.pointSizeF() - font_size) > 0.1:
             font.setPointSizeF(font_size)
             widget.setFont(font)
-        return orig_paint_event(event)
+        return orig_resize_event(event)
 
     def minimumSizeHint() -> QtCore.QSize:
-        # Do not give any size hint as it it changes during paintEvent
+        # Do not give any size hint as it it changes during resizeEvent
         return QtWidgets.QWidget.minimumSizeHint(widget)
 
     def sizeHint() -> QtCore.QSize:
-        # Do not give any size hint as it it changes during paintEvent
+        # Do not give any size hint as it it changes during resizeEvent
         return QtWidgets.QWidget.sizeHint(widget)
 
-    if hasattr(widget.paintEvent, "_patched_methods_"):
+    if hasattr(widget.resizeEvent, "_patched_methods_"):
         return
 
-    orig_paint_event = widget.paintEvent
+    orig_resize_event = widget.resizeEvent
 
-    paintEvent._patched_methods_ = (
-        widget.paintEvent,
+    resizeEvent._patched_methods_ = (
+        widget.resizeEvent,
         widget.sizeHint,
         widget.minimumSizeHint,
     )
-    widget.paintEvent = paintEvent
+    widget.resizeEvent = resizeEvent
     widget.sizeHint = sizeHint
     widget.minimumSizeHint = minimumSizeHint
 
@@ -163,14 +163,14 @@ def unpatch_widget(widget: QtWidgets.QWidget) -> None:
     widget : QtWidgets.QWidget
         The widget to unpatch.
     """
-    if not hasattr(widget.paintEvent, "_patched_methods_"):
+    if not hasattr(widget.resizeEvent, "_patched_methods_"):
         return
 
     (
-        widget.paintEvent,
+        widget.resizeEvent,
         widget.sizeHint,
         widget.minimumSizeHint,
-    ) = widget.paintEvent._patched_methods_
+    ) = widget.resizeEvent._patched_methods_
 
 
 def is_patched(widget: QtWidgets.QWidget) -> bool:
@@ -187,4 +187,4 @@ def is_patched(widget: QtWidgets.QWidget) -> bool:
     bool
         True if the widget has been patched.
     """
-    return hasattr(widget.paintEvent, "_patched_methods_")
+    return hasattr(widget.resizeEvent, "_patched_methods_")

--- a/typhos/tests/test_dynamic_font.py
+++ b/typhos/tests/test_dynamic_font.py
@@ -33,13 +33,17 @@ def test_patching(
     )
     print("Starting font size", original_font_size)
 
-    event = QtGui.QPaintEvent(QtCore.QRect(0, 0, widget.width(), widget.height()))
+    old_size = widget.size()
+    event = QtGui.QResizeEvent(
+        QtCore.QSize(old_size.width() * 2, old_size.height() * 2),
+        old_size,
+    )
 
     assert not is_patched(widget)
     patch_widget(widget)
     assert is_patched(widget)
 
-    widget.paintEvent(event)
+    widget.resizeEvent(event)
     new_font_size = widget.font().pointSizeF()
     print("Patched font size", new_font_size)
     assert original_font_size != new_font_size


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Move the dynamic text resizing to resize event so it doesn't happen every frame and use the entire cpu

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-5143

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively to observe the usage
Tests slightly adjusted so they still pass (previously was looking for the paint event)

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here and in release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
