### PR TITLE
ENH: improved wait status and positioner timeout messages

### DIFF
--- a/docs/source/upcoming_release_notes/606-enh_wait_status.rst
+++ b/docs/source/upcoming_release_notes/606-enh_wait_status.rst
@@ -1,0 +1,28 @@
+606 enh_wait_status
+###################
+
+API Breaks
+----------
+- ``TyphosStatusThread`` now has a dramatically different signal API.
+  This is an improved version but if you were using this class take note
+  of the changes.
+
+Features
+--------
+- Make the timeout messages friendlier and more accurate when the
+  timeouts come from the ``TyphosPositionerWidget``.
+- Make error messages in general (including status timeouts) clearer
+  when they come from the positioner device class controlled by the
+  ``TyphosPositionerWidget``.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Refactor ``TyphosStatusThread`` to facilitate timeout message changes.
+
+Contributors
+------------
+- zllentz

--- a/typhos/func.py
+++ b/typhos/func.py
@@ -592,12 +592,9 @@ class TyphosMethodButton(QPushButton, TyphosDesignerMixin):
 
             self._status_thread.status_started.connect(status_started)
             self._status_thread.status_finished.connect(status_finished)
+            # Re-enable the button if it's taking too long
+            self._status_thread.status_timeout.connect(status_finished)
 
-            # Connect the finished signal so that even in the worst case
-            # scenario, we re-enable the button. Almost always the button will
-            # be ended by the status_finished signal
-            self._status_thread.finished.connect(partial(status_finished,
-                                                         True))
             logger.debug("Starting TyphosStatusThread ...")
             self._status_thread.start()
 

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -275,10 +275,11 @@ class TyphosPositionerWidget(
             acc_time = 0
         else:
             acc_time = acc_sig.get()
+        units = pos_sig.metadata.get("units", "egu")
         # This time is always greater than the kinematic calc
         return (
             rescale * (abs(delta/speed) + 2 * abs(acc_time)) + abs(settle_time),
-            "dist {delta} / velo {speed} + 2 * acc_time {acc_time} + margin",
+            f"{rescale}*({abs(delta):.2f}{units}/{speed:.2f}{units}/s) + 2*{acc_time:.2f}s + {settle_time}s",
         )
 
     def _set(self, value):
@@ -742,14 +743,15 @@ class TyphosPositionerWidget(
         self.moving = True
         self.err_is_timeout = False
 
-    def _set_status_text(self, text: str, *, max_length: int = 60) -> None:
+    def _set_status_text(self, text: str, *, max_length: int | None = 60) -> None:
         """Set the status text label to ``text``."""
-        if len(text) >= max_length:
+        if max_length is None:
+            self.ui.status_label.setToolTip(text)
+        elif len(text) >= max_length:
             self.ui.status_label.setToolTip(text)
             text = text[:max_length] + '...'
         else:
             self.ui.status_label.setToolTip('')
-
         self.ui.status_label.setText(text)
 
     def _status_finished(self, result: TyphosStatusResult | Exception) -> None:
@@ -1035,7 +1037,7 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
     def new_error_message(self, value, *args, **kwargs):
         self.update_status_visibility(error_message=value)
 
-    def _set_status_text(self, text, *, max_length=80):
+    def _set_status_text(self, text, *, max_length=None):
         super()._set_status_text(text, max_length=max_length)
         self.update_status_visibility(status_text=text)
 

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -750,7 +750,6 @@ class TyphosPositionerWidget(
         """Called when a move is begun"""
         logger.debug("Begin showing move in TyphosPositionerWidget")
         self.moving = True
-        self.err_is_timeout = False
 
     def _set_status_text(
         self,

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -859,6 +859,7 @@ class _TyphosPositionerRowUI(_TyphosPositionerUI):
     notes_edit: TyphosNotesEdit
     status_container_widget: QtWidgets.QFrame
     extended_signal_panel: Optional[TyphosSignalPanel]
+    status_error_prefix: QtWidgets.QLabel
     error_prefix: QtWidgets.QLabel
     switcher: TyphosDisplaySwitcher
 
@@ -1057,8 +1058,10 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
         The goal here to make an illusion that there is only one label in
         in this space when only one of the labels has text.
 
-        If both are empty, we also want to put "something" there to fill the
+        If both are empty, we want to put "something" there to fill the
         void, so we opt for a friendly message or an alarm reminder.
+
+        If both are populated, we want to do some best-effort deduplication.
         """
         if error_message is not None:
             self._error_message = error_message
@@ -1078,7 +1081,14 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
             else:
                 self.ui.status_label.setText('Check alarm')
             has_status = True
+        has_status_error = False
+        if has_status and has_error:
+            # We want to avoid having duplicate information (low effort try)
+            if error_message in status_text:
+                has_error = False
+                has_status_error = True
         self.ui.status_label.setVisible(has_status)
+        self.ui.status_error_prefix.setVisible(has_status_error)
         self.ui.error_label.setVisible(has_error)
         self.ui.error_prefix.setVisible(has_error)
 

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -278,12 +278,13 @@ class TyphosPositionerWidget(
         else:
             acc_time = acc_sig.get()
         units = pos_sig.metadata.get("units", "egu")
-        # This time is always greater than the kinematic calc
+        # Some friendly names for the f-string tooltip reporting
         dist = abs(delta)
         speed = abs(speed)
         mult = rescale
+        # This time is always greater than the kinematic calc
         return (
-            math.ceil(rescale * (delta/speed + 2 * abs(acc_time)) + abs(settle_time)),
+            math.ceil(rescale * (dist/speed + 2 * abs(acc_time)) + abs(settle_time)),
             ("an upper bound on the expected time based on the speed, distance traveled, "
              "and acceleration time. Numerically, this is "
              f"{mult=}*({dist=:.2f}{units}/{speed=:.2f}{units}/s) + "

--- a/typhos/status.py
+++ b/typhos/status.py
@@ -100,9 +100,9 @@ class TyphosStatusThread(QThread):
             self.status.wait(timeout=timeout)
         except WaitTimeoutError as ex:
             # Status doesn't have a timeout, but this thread does
-            errmsg = f"{self.error_context} taking longer than expected, > {timeout}s"
+            errmsg = f"{self.error_context} taking longer than expected, >{timeout:.2f}s"
             if self.timeout_calc:
-                errmsg += f": {self.timeout_calc}"
+                errmsg += f", calculated as {self.timeout_calc}"
             logger.debug(errmsg)
             self.error_message.emit(errmsg)
             self.status_timeout.emit()
@@ -110,7 +110,7 @@ class TyphosStatusThread(QThread):
             return TyphosStatusResult.timeout
         except StatusTimeoutError as ex:
             # Status has an intrinsic timeout, and it's failing now
-            errmsg = f"{self.error_context} failed with timeout, > {self.status.timeout}s"
+            errmsg = f"{self.error_context} failed with timeout, >{self.status.timeout:.2f}s"
             logger.debug(errmsg)
             self.error_message.emit(errmsg)
             self.status_exc.emit(ex)

--- a/typhos/status.py
+++ b/typhos/status.py
@@ -110,7 +110,7 @@ class TyphosStatusThread(QThread):
             # Status doesn't have a timeout, but this thread does
             errmsg = f"{self.error_context} taking longer than expected, >{timeout}s"
             if self.timeout_calc:
-                tooltip = f"calculated as {self.timeout_calc}"
+                tooltip = f"Calculated as {self.timeout_calc}"
             else:
                 tooltip = ""
             self.error_message.emit(

--- a/typhos/status.py
+++ b/typhos/status.py
@@ -31,10 +31,29 @@ class TyphosStatusThread(QThread):
     Thread which monitors an ophyd Status object and emits start/stop signals.
 
     The ``status_started`` signal may be emitted after ``start_delay`` seconds,
-    unless the status has already completed.
+    unless the status has already completed, in which case it will not be
+    emitted.
 
-    The ``status_finished`` signal is guaranteed to be emitted with a status
-    boolean indicating success or failure, or timeout.
+    The ``status_timeout`` signal will be emitted if the status starts and the
+    timeout supplied to the ``TyphosStatusThread`` expires. This is distinct
+    from an internal timeout from a status object, which is an error.
+    The ``status_timeout`` is advisory rather than perscriptive and does not
+    necessarily indicate a severe problem. If you want a status to be marked
+    as failing after a timeout, pass the timeout to the status's constructor.
+
+    The ``status_finished`` signal is guaranteed to be emitted after the status
+    completes or fails, with a ``TyphosStatusResult`` enum set to
+    ``success`` or to ``failure``.
+
+    The ``error_message`` signal emits some information that could be useful
+    for a GUI to display an error. This is a ``TyphosStatusMessage`` which
+    contains a short error under ``.text`` and a longer message under
+    ``.tooltip``, intended for e.g. a label and its mouseover tooltip text.
+    This will not be emitted if the status succeeds.
+
+    The ``status_exc`` signal emits the literal exception object from a
+    status failure. This will not be emitted if the status succeeds.
+    This can be useful for customizing what to do in the case of failure.
 
     Parameters
     ----------

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -10,6 +10,7 @@ from ophyd.utils.errors import LimitError, UnknownStatusFailure
 
 from typhos.alarm import KindLevel
 from typhos.positioner import TyphosPositionerWidget
+from typhos.status import TyphosStatusResult
 from typhos.utils import SignalRO
 
 from .conftest import RichSignal, show_widget
@@ -158,7 +159,7 @@ def test_positioner_widget_last_move(motor_widget):
     motor, widget = motor_widget
     assert not widget.successful_move
     assert not widget.failed_move
-    widget._status_finished(True)
+    widget._status_finished(TyphosStatusResult.success)
     assert widget.successful_move
     assert not widget.failed_move
     widget._status_finished(Exception())

--- a/typhos/tests/test_status.py
+++ b/typhos/tests/test_status.py
@@ -2,9 +2,11 @@ from unittest.mock import Mock
 
 import pytest
 from ophyd.status import Status
+from ophyd.utils import (StatusTimeoutError, UnknownStatusFailure,
+                         WaitTimeoutError)
 from qtpy.QtWidgets import QWidget
 
-from typhos.status import TyphosStatusThread
+from typhos.status import TyphosStatusResult, TyphosStatusThread
 
 
 class Listener(QWidget):
@@ -13,7 +15,10 @@ class Listener(QWidget):
     def __init__(self):
         super().__init__()
         self.started = Mock()
+        self.timeout = Mock()
         self.finished = Mock()
+        self.err_msg = Mock()
+        self.exc = Mock()
 
 
 @pytest.fixture(scope='function')
@@ -33,31 +38,119 @@ def listener(qtbot, status):
 def thread(qtbot, status, listener):
     thread = TyphosStatusThread(status)
     thread.status_started.connect(listener.started)
+    thread.status_timeout.connect(listener.timeout)
     thread.status_finished.connect(listener.finished)
+    thread.error_message.connect(listener.err_msg)
+    thread.status_exc.connect(listener.exc)
     yield thread
     if thread.isRunning():
         thread.quit()
 
 
 def test_previously_done_status_in_thread(listener, status, thread):
+    """
+    Expected behavior: thread finishes without starting if already done
+    """
     status.set_finished()
     status.wait()
     thread.run()
     assert not listener.started.called
+    assert not listener.timeout.called
     assert listener.finished.called
+    assert not listener.err_msg.called
+    assert not listener.exc.called
 
 
 def test_status_thread_completed(qtbot, listener, status, thread):
+    """
+    Expected behavior: thread doesn't finish until status does
+    """
     thread.start()
     qtbot.waitUntil(lambda: listener.started.called, timeout=2000)
     status.set_finished()
     qtbot.waitUntil(lambda: listener.finished.called, timeout=2000)
+    assert not listener.timeout.called
+    assert not listener.err_msg.called
+    assert not listener.exc.called
+    res, = listener.finished.call_args[0]
+    assert res == TyphosStatusResult.success
 
 
-def test_status_thread_timeout(listener, thread, status):
-    thread.timeout = 0.01
-    thread.run()
-    assert listener.started.called
+def test_status_thread_wait_timeout(qtbot, listener, thread, status):
+    """
+    Expected behavior: thread times out but doesn't outright fail
+    """
+    thread.timeout = 0.1
+    thread.start()
+    qtbot.waitUntil(lambda: listener.started.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.timeout.called, timeout=2000)
+    msg, = listener.err_msg.call_args[0]
+    exc, = listener.exc.call_args[0]
+    assert "taking longer than expected" in msg
+    assert isinstance(exc, WaitTimeoutError)
+    assert not listener.finished.called
+    # and now we should be able to finish
+    status.set_finished()
+    qtbot.waitUntil(lambda: listener.finished.called, timeout=2000)
+    res, = listener.finished.call_args[0]
+    assert res == TyphosStatusResult.success
 
-    ex, = listener.finished.call_args[0]
-    assert isinstance(ex, TimeoutError)
+
+def test_status_thread_status_timeout(qtbot, listener, thread):
+    """
+    Expected behavior: the status fails, so the thread does too
+    """
+    status = Status(timeout=0.1)
+    thread.status = status
+    thread.start()
+    qtbot.waitUntil(lambda: listener.started.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.err_msg.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.exc.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.finished.called, timeout=2000)
+    res, = listener.finished.call_args[0]
+    msg, = listener.err_msg.call_args[0]
+    exc, = listener.exc.call_args[0]
+    assert res == TyphosStatusResult.failure
+    assert "failed with timeout" in msg
+    assert isinstance(exc, StatusTimeoutError)
+    assert not listener.timeout.called
+
+
+def test_status_thread_unk_failure(qtbot, listener, status, thread):
+    """
+    Expected behavior: the thread fails when the status does
+    """
+    thread.start()
+    qtbot.waitUntil(lambda: listener.started.called, timeout=2000)
+    status._finished(success=False)
+    qtbot.waitUntil(lambda: listener.err_msg.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.exc.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.finished.called, timeout=2000)
+    res, = listener.finished.call_args[0]
+    msg, = listener.err_msg.call_args[0]
+    exc, = listener.exc.call_args[0]
+    assert res == TyphosStatusResult.failure
+    assert "failed with no reason" in msg
+    assert isinstance(exc, UnknownStatusFailure)
+    assert not listener.timeout.called
+
+
+def test_status_thread_specific_failure(qtbot, listener, status, thread):
+    """
+    Expected behavior: the thread fails when the status does
+    """
+    thread.start()
+    qtbot.waitUntil(lambda: listener.started.called, timeout=2000)
+    status.set_exception(Exception("test_error"))
+    qtbot.waitUntil(lambda: listener.err_msg.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.exc.called, timeout=2000)
+    qtbot.waitUntil(lambda: listener.finished.called, timeout=2000)
+    res, = listener.finished.call_args[0]
+    msg, = listener.err_msg.call_args[0]
+    exc, = listener.exc.call_args[0]
+    assert res == TyphosStatusResult.failure
+    assert "test_error" in msg
+    assert not isinstance(exc, WaitTimeoutError)
+    assert not isinstance(exc, StatusTimeoutError)
+    assert not isinstance(exc, UnknownStatusFailure)
+    assert not listener.timeout.called

--- a/typhos/tests/test_status.py
+++ b/typhos/tests/test_status.py
@@ -86,7 +86,7 @@ def test_status_thread_wait_timeout(qtbot, listener, thread, status):
     qtbot.waitUntil(lambda: listener.timeout.called, timeout=2000)
     msg, = listener.err_msg.call_args[0]
     exc, = listener.exc.call_args[0]
-    assert "taking longer than expected" in msg
+    assert "taking longer than expected" in msg.text
     assert isinstance(exc, WaitTimeoutError)
     assert not listener.finished.called
     # and now we should be able to finish
@@ -111,7 +111,7 @@ def test_status_thread_status_timeout(qtbot, listener, thread):
     msg, = listener.err_msg.call_args[0]
     exc, = listener.exc.call_args[0]
     assert res == TyphosStatusResult.failure
-    assert "failed with timeout" in msg
+    assert "failed with timeout" in msg.text
     assert isinstance(exc, StatusTimeoutError)
     assert not listener.timeout.called
 
@@ -130,7 +130,7 @@ def test_status_thread_unk_failure(qtbot, listener, status, thread):
     msg, = listener.err_msg.call_args[0]
     exc, = listener.exc.call_args[0]
     assert res == TyphosStatusResult.failure
-    assert "failed with no reason" in msg
+    assert "failed with no reason" in msg.text
     assert isinstance(exc, UnknownStatusFailure)
     assert not listener.timeout.called
 
@@ -149,7 +149,7 @@ def test_status_thread_specific_failure(qtbot, listener, status, thread):
     msg, = listener.err_msg.call_args[0]
     exc, = listener.exc.call_args[0]
     assert res == TyphosStatusResult.failure
-    assert "test_error" in msg
+    assert "test_error" in msg.text
     assert not isinstance(exc, WaitTimeoutError)
     assert not isinstance(exc, StatusTimeoutError)
     assert not isinstance(exc, UnknownStatusFailure)

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -1145,7 +1145,7 @@ Screen</string>
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
+               <string notr="true">QLabel { color: black; background-color: none;   border-radius: 0px; }</string>
               </property>
               <property name="text">
                <string> (Status label)</string>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -1118,7 +1118,7 @@ Screen</string>
              <string> (Status label)</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="indent">
              <number>0</number>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -1091,39 +1091,74 @@ Screen</string>
           <property name="spacing">
            <number>3</number>
           </property>
-          <item alignment="Qt::AlignVCenter">
-           <widget class="QLabel" name="status_label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>25</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>25</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
-            </property>
-            <property name="text">
-             <string> (Status label)</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-            <property name="indent">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <property name="topMargin">
              <number>0</number>
             </property>
-           </widget>
+            <item>
+             <widget class="QLabel" name="status_error_prefix">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: red</string>
+              </property>
+              <property name="text">
+               <string>Error: </string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="status_label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
+              </property>
+              <property name="text">
+               <string> (Status label)</string>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+              <property name="indent">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Refactor TyphosStatusThread to give clearer and more detailed information (may count as API break)
- Change status thread behavior: thread timeout doesn't count as a failure, thread will continue to watch status until it eventually succeeds or fails.
- Adjust timeout messages to be more friendly (a positioner widget timeout doesn't mean your system is broken)
- Adjust timeout messages to disappear once a successful move completes
- More consistently pass through status failure exception messages to the positioner widget
- Give more detailed information about the timeout when it occurs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Some motors in prod here are timing out and scaring/confusing people consistently
- There are always lots of questions about what the timeout is or where it comes from
- https://jira.slac.stanford.edu/browse/ECS-5454

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Interactively, extensively, using a sim IOC
- Added/adjusted unit tests
- Asked for opinions on the slack channel

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

## Screenshots (if appropriate):
Friendly (doesn't say error) and verbose (says the timeout in tooltip) timeout message
![image](https://github.com/pcdshub/typhos/assets/10647860/44172bcb-caa8-4636-aa7e-d8c08cf2d542)

Goes away once the move completes
![image](https://github.com/pcdshub/typhos/assets/10647860/c513db39-6039-4b14-ab3b-93ab44b9b8f1)

Normal errors propagate from the status if available
![image](https://github.com/pcdshub/typhos/assets/10647860/4d7ede07-089e-4cd5-9e25-49ebeb81d5c0)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
