### PR TITLE
ENH: positioner row widget sizing usability fixes and tweaks

### DIFF
--- a/docs/source/upcoming_release_notes/611-enh_positioner_resizing.rst
+++ b/docs/source/upcoming_release_notes/611-enh_positioner_resizing.rst
@@ -7,8 +7,10 @@ API Breaks
 
 Features
 --------
-- Implement dynamic resizing in all directions for positioner widgets.
-- Make positioner widgets more vertically compact.
+- Rework the design, sizing, and font scaling of the positioner row widget to address
+  concerns about readability and poor use of space for positioners that don't need
+  all of the widget components.
+- Implement dynamic resizing in all directions for positioner row widgets.
 
 Bugfixes
 --------

--- a/docs/source/upcoming_release_notes/611-enh_positioner_resizing.rst
+++ b/docs/source/upcoming_release_notes/611-enh_positioner_resizing.rst
@@ -1,0 +1,23 @@
+611 enh_positioner_resizing
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Implement dynamic resizing in all directions for positioner widgets.
+- Make positioner widgets more vertically compact.
+
+Bugfixes
+--------
+- Fix various issues that cause font clipping for specific motors using the positioner row widget.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/dynamic_font.py
+++ b/typhos/dynamic_font.py
@@ -3,9 +3,12 @@ Dynamic font size helper utilities:
 
 Dynamically set widget font size based on its current size.
 """
+import logging
 
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import QRectF, Qt
+
+logger = logging.getLogger(__name__)
 
 
 def get_widget_maximum_font_size(
@@ -119,7 +122,7 @@ def patch_widget(
         maximum font size. Content margin settings determine the content
         rectangle, and this padding is applied as a percentage on top of that.
     """
-    def resizeEvent(event: QtGui.QResizeEvent) -> None:
+    def set_font_size() -> None:
         font = widget.font()
         font_size = get_widget_maximum_font_size(
             widget, widget.text(),
@@ -129,6 +132,9 @@ def patch_widget(
         if abs(font.pointSizeF() - font_size) > 0.1:
             font.setPointSizeF(font_size)
             widget.setFont(font)
+
+    def resizeEvent(event: QtGui.QResizeEvent) -> None:
+        set_font_size()
         return orig_resize_event(event)
 
     def minimumSizeHint() -> QtCore.QSize:
@@ -152,6 +158,7 @@ def patch_widget(
     widget.resizeEvent = resizeEvent
     widget.sizeHint = sizeHint
     widget.minimumSizeHint = minimumSizeHint
+    set_font_size()
 
 
 def unpatch_widget(widget: QtWidgets.QWidget) -> None:

--- a/typhos/dynamic_font.py
+++ b/typhos/dynamic_font.py
@@ -213,7 +213,7 @@ def patch_text_widget(
 
     resizeEvent._patched_methods_ = (
         widget.resizeEvent,
-        widget.setText
+        widget.setText,
     )
     widget.resizeEvent = resizeEvent
     widget.setText = setText
@@ -238,8 +238,8 @@ def patch_combo_widget(
         font_sizes = [
             get_max_font_size_cached(
                 text,
-                widget.height(),
                 widget.width(),
+                widget.height(),
             )
             for text in combo_options
         ]
@@ -298,13 +298,9 @@ def unpatch_widget(widget: QtWidgets.QWidget) -> None:
     if not hasattr(widget.resizeEvent, "_patched_methods_"):
         return
     if isinstance(widget, QtWidgets.QComboBox):
-        return unpatch_combo_widget(
-            widget=widget,
-        )
+        return unpatch_combo_widget(widget)
     elif hasattr(widget, "setText") and hasattr(widget, "text"):
-        return unpatch_text_widget(
-            widget=widget,
-        )
+        return unpatch_text_widget(widget)
     else:
         raise TypeError("Somehow, we have a patched widget that is unpatchable.")
 

--- a/typhos/dynamic_font.py
+++ b/typhos/dynamic_font.py
@@ -131,6 +131,12 @@ def patch_widget(
     min_size : float or None, optional
         The minimum font point size we're allowed to apply to the widget.
     """
+    if "font-size" in widget.styleSheet():
+        logger.warning(
+            f"Widget named {widget.objectName()} has a fixed size from its "
+            "stylesheet, and cannot be resized dynamically."
+        )
+
     def set_font_size() -> None:
         font = widget.font()
         font_size = get_max_font_size_cached(

--- a/typhos/dynamic_font.py
+++ b/typhos/dynamic_font.py
@@ -201,8 +201,7 @@ def unpatch_widget(widget: QtWidgets.QWidget) -> None:
 
     (
         widget.resizeEvent,
-        widget.sizeHint,
-        widget.minimumSizeHint,
+        widget.setText,
     ) = widget.resizeEvent._patched_methods_
 
 

--- a/typhos/dynamic_font.py
+++ b/typhos/dynamic_font.py
@@ -118,6 +118,15 @@ def patch_widget(
     """
     Patch the widget to dynamically change its font.
 
+    This picks between patch_text_widget and patch_combo_widget as appropriate.
+
+    Depending on which is chosen, different methods may be patched to ensure
+    that the widget will always have the maximum size font that fits within
+    the bounding box.
+
+    Regardless of which method is chosen, the font will be dynamically
+    resized for the first time before this function returns.
+
     Parameters
     ----------
     widget : QtWidgets.QWidget
@@ -162,7 +171,13 @@ def patch_text_widget(
     min_size: float | None = None,
 ):
     """
-    Specific patching for widgets with text() and setText() methods
+    Specific patching for widgets with text() and setText() methods.
+
+    This replaces resizeEvent and setText methods with versions that will
+    set the font size to the maximum fitting value when the widget is
+    resized or the text is updated.
+
+    The text is immediately resized for the first time during this function call.
     """
     def set_font_size() -> None:
         font = widget.font()
@@ -228,7 +243,13 @@ def patch_combo_widget(
     min_size: float | None = None,
 ):
     """
-    Specific patching for combobox widgets
+    Specific patching for combobox widgets.
+
+    This replaces resizeEvent with a version that will
+    set the font size to the maximum fitting value
+    when the widget is resized.
+
+    The text is immediately resized for the first time during this function call.
     """
     def set_font_size() -> None:
         font = widget.font()

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -865,11 +865,30 @@ class TyphosSignalPanel(TyphosBase, TyphosDesignerMixin, SignalOrder):
         menu = self.generate_context_menu()
         menu.exec_(self.mapToGlobal(ev.pos()))
 
-    def resizeEvent(self, event: QtGui.QResizeEvent):
+    def maybe_fix_parent_size(self):
         if self.nested_panel:
-            # force this widget's container to give it enough space!
+            # force this widget's containers to give it enough space!
             self.parent().setMinimumHeight(self.parent().minimumSizeHint().height())
+
+    def resizeEvent(self, event: QtGui.QResizeEvent):
+        """
+        Fix the parent container's size whenever our size changes.
+
+        This also runs when we add or filter rows.
+        """
+        self.maybe_fix_parent_size()
         return super().resizeEvent(event)
+
+    def setVisible(self, visible: bool):
+        """
+        Fix the parent container's size whenever we switch visibility.
+
+        This also runs when we toggle a row visibility using the title
+        and when all signal rows get filtered all at once.
+        """
+        rval = super().setVisible(visible)
+        self.maybe_fix_parent_size()
+        return rval
 
 
 class CompositeSignalPanel(SignalPanel):

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -513,10 +513,7 @@ class TyphosPositionerWidget(
             self.ui.set_value.setAlignment(QtCore.Qt.AlignCenter)
             self.ui.set_value.returnPressed.connect(self.set)
 
-        self.ui.set_value.setSizePolicy(
-            QtWidgets.QSizePolicy.Fixed,
-            QtWidgets.QSizePolicy.Fixed,
-        )
+        self.ui.set_value.setSizePolicy(self.ui.user_setpoint.sizePolicy())
         self.ui.set_value.setMinimumWidth(
             self.ui.user_setpoint.minimumWidth()
         )

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -516,15 +516,6 @@ class TyphosPositionerWidget(
             self.ui.set_value.activated.connect(self.set)
             self.ui.set_value.setMinimumContentsLength(20)
             self.ui.tweak_widget.setVisible(False)
-            # Consume the space left by removing the tweak widget
-            self.ui.set_value.setMinimumHeight(
-                self.ui.user_setpoint.minimumHeight()
-                + self.ui.tweak_value.minimumHeight()
-            )
-            self.ui.set_value.setMaximumHeight(
-                self.ui.user_setpoint.maximumHeight()
-                + self.ui.tweak_value.maximumHeight()
-            )
         else:
             self.ui.set_value = QtWidgets.QLineEdit()
             self.ui.set_value.setAlignment(QtCore.Qt.AlignCenter)
@@ -1081,7 +1072,8 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
             self._show_lowtrav,
             self._show_hightrav,
         )):
-            # Hide the limit sections and expand the setpoint widget
+            # Hide the limit sections
+            # Expand the setpoint widget horizontally
             # Typically a combobox
             self.ui.low_limit_frame.hide()
             self.ui.high_limit_frame.hide()
@@ -1094,6 +1086,12 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
                 + high_policy.horizontalStretch()
             )
             self.ui.setpoint_frame.setSizePolicy(setpoint_policy)
+            self.ui.set_value.setMinimumWidth(
+                self.ui.set_value.minimumWidth()
+                + self.ui.low_limit.minimumWidth()
+                + self.ui.high_limit.minimumWidth()
+                + 2 * self.ui.row_frame.layout().spacing()
+            )
 
     def _get_tooltip(self):
         """Update the tooltip based on device information."""
@@ -1137,6 +1135,15 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
         if isinstance(self.ui.set_value, QtWidgets.QComboBox):
             # Pad extra to avoid intersecting drop-down arrow
             dynamic_font.patch_widget(self.ui.set_value, pad_percent=0.18, min_size=4)
+            # Consume the vertical space left by the missing tweak widgets
+            self.ui.set_value.setMinimumHeight(
+                self.ui.user_setpoint.minimumHeight()
+                + self.ui.tweak_value.minimumHeight()
+            )
+            self.ui.set_value.setMaximumHeight(
+                self.ui.user_setpoint.maximumHeight()
+                + self.ui.tweak_value.maximumHeight()
+            )
         else:
             dynamic_font.patch_widget(self.ui.set_value, pad_percent=0.1, min_size=4)
 

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -1024,7 +1024,7 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
         if self.device is None:
             return None
 
-        return RowDetails(row=self)
+        return RowDetails(row=self, parent=self, flags=QtCore.Qt.Window)
 
     def _expand_layout(self) -> None:
         """Toggle the expansion of the signal panel."""
@@ -1192,8 +1192,8 @@ class RowDetails(QtWidgets.QWidget):
     row: TyphosPositionerRowWidget
     resize_timer: QtCore.QTimer
 
-    def __init__(self, row: TyphosPositionerRowWidget, parent: QtWidgets.QWidget | None = None):
-        super().__init__(parent=parent)
+    def __init__(self, row: TyphosPositionerRowWidget, parent: QtWidgets.QWidget | None = None, **kwargs):
+        super().__init__(parent=parent, **kwargs)
         self.row = row
 
         self.label = QtWidgets.QLabel()

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -508,6 +508,15 @@ class TyphosPositionerWidget(
             self.ui.set_value.activated.connect(self.set)
             self.ui.set_value.setMinimumContentsLength(20)
             self.ui.tweak_widget.setVisible(False)
+            # Consume the space left by removing the tweak widget
+            self.ui.set_value.setMinimumHeight(
+                self.ui.user_setpoint.minimumHeight()
+                + self.ui.tweak_value.minimumHeight()
+            )
+            self.ui.set_value.setMaximumHeight(
+                self.ui.user_setpoint.maximumHeight()
+                + self.ui.tweak_value.maximumHeight()
+            )
         else:
             self.ui.set_value = QtWidgets.QLineEdit()
             self.ui.set_value.setAlignment(QtCore.Qt.AlignCenter)
@@ -985,7 +994,12 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
         omit_signals = self.all_linked_signals
         to_keep_signals = [
             getattr(device, attr, None)
-            for attr in (self.velocity_attribute, self.acceleration_attribute)
+            for attr in (
+                self.velocity_attribute,
+                self.acceleration_attribute,
+                self.high_limit_travel_attribute,
+                self.low_limit_travel_attribute,
+            )
         ]
         for sig in to_keep_signals:
             if sig in omit_signals:
@@ -1086,6 +1100,14 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
 
     def new_error_message(self, value, *args, **kwargs):
         self.update_status_visibility(error_message=value)
+
+    def _define_setpoint_widget(self):
+        super()._define_setpoint_widget()
+        if isinstance(self.ui.set_value, QtWidgets.QComboBox):
+            # Pad extra to avoid intersecting drop-down arrow
+            dynamic_font.patch_widget(self.ui.set_value, pad_percent=0.18, min_size=4)
+        else:
+            dynamic_font.patch_widget(self.ui.set_value, pad_percent=0.1, min_size=4)
 
     def _set_status_text(
         self,

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -185,7 +185,7 @@ class TyphosPositionerWidget(
         self.show_expert_button = False
         self._after_set_moving(False)
 
-        dynamic_font.patch_widget(self.ui.user_readback, pad_percent=0.01)
+        dynamic_font.patch_widget(self.ui.user_readback, pad_percent=0.05, min_size=6)
 
     def _clear_status_thread(self):
         """Clear a previous status thread."""
@@ -932,6 +932,8 @@ class TyphosPositionerRowWidget(TyphosPositionerWidget):
         self._alarm_level = AlarmLevel.DISCONNECTED
 
         super().__init__(*args, **kwargs)
+        dynamic_font.patch_widget(self.ui.low_limit, pad_percent=0.01, max_size=12, min_size=4)
+        dynamic_font.patch_widget(self.ui.high_limit, pad_percent=0.01, max_size=12, min_size=4)
 
         for idx in range(self.layout().count()):
             item = self.layout().itemAt(idx)

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -395,7 +395,6 @@ class TyphosPositionerWidget(
         # False = Red, True = Green, None = no box (in motion is yellow)
         if not self._last_move:
             self._last_move = None
-        utils.reload_widget_stylesheet(self, cascade=True)
 
     def _get_position(self):
         if not self._readback:

--- a/typhos/tests/test_dynamic_font.py
+++ b/typhos/tests/test_dynamic_font.py
@@ -75,7 +75,7 @@ def test_wide_label(
     assert widget.font().pointSizeF() == 16.0
 
     patch_widget(widget)
-    widget.setFixedSize(162.36, 34.65)
+    widget.setFixedSize(162, 34)
     for _ in range(3):
         qapp.processEvents()
     assert widget.font().pointSizeF() == get_widget_maximum_font_size(widget, widget.text())

--- a/typhos/tests/test_dynamic_font.py
+++ b/typhos/tests/test_dynamic_font.py
@@ -87,6 +87,7 @@ def test_wide_label(
     assert widget.font().pointSizeF() == get_widget_maximum_font_size(widget, widget.text())
 
 
+@pytest.mark.no_gc
 def test_positioner_label(
     qapp: QtWidgets.QApplication,
     qtbot: pytestqt.qtbot.QtBot,

--- a/typhos/tests/test_dynamic_font.py
+++ b/typhos/tests/test_dynamic_font.py
@@ -9,7 +9,8 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 from typhos.tests import conftest
 
-from ..dynamic_font import is_patched, patch_widget, unpatch_widget
+from ..dynamic_font import (is_patched, patch_style_font_size, patch_widget,
+                            unpatch_style_font_size, unpatch_widget)
 
 logger = logging.getLogger(__name__)
 
@@ -74,3 +75,27 @@ def test_patching(
         widget,
         f"{request.node.name}_{cls.__name__}_dynamic_font_size",
     )
+
+
+@pytest.mark.parametrize(
+    "stylesheet",
+    [
+        "",
+        "background: red",
+        "QLabel { background: blue }",
+        "QWidget { font-size: 12 pt }",
+    ]
+)
+def test_style_patching(stylesheet: str, qtbot: pytestqt.qtbot.QtBot):
+    widget = QtWidgets.QWidget()
+    qtbot.add_widget(widget)
+    widget.setStyleSheet(stylesheet)
+
+    expected_text = "font-size: 16 pt"
+    assert expected_text not in widget.styleSheet()
+    patch_style_font_size(widget=widget, font_size=16)
+    assert expected_text in widget.styleSheet()
+    unpatch_style_font_size(widget=widget)
+    assert expected_text not in widget.styleSheet()
+
+    assert widget.styleSheet() == stylesheet

--- a/typhos/tests/test_dynamic_font.py
+++ b/typhos/tests/test_dynamic_font.py
@@ -60,7 +60,6 @@ def test_patching(
 
 
 def test_wide_label(
-    qapp: QtWidgets.QApplication,
     qtbot: pytestqt.qtbot.QtBot,
 ):
     """
@@ -76,6 +75,9 @@ def test_wide_label(
 
     patch_widget(widget)
     widget.setFixedSize(162, 34)
-    for _ in range(3):
-        qapp.processEvents()
+    event = QtGui.QResizeEvent(
+        QtCore.QSize(162, 34),
+        widget.size(),
+    )
+    widget.resizeEvent(event)
     assert widget.font().pointSizeF() == get_widget_maximum_font_size(widget, widget.text())

--- a/typhos/tests/test_dynamic_font.py
+++ b/typhos/tests/test_dynamic_font.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
     [
         QtWidgets.QLabel,
         QtWidgets.QPushButton,
+        QtWidgets.QComboBox,
         PyDMLabel,
     ]
 )
@@ -28,7 +29,10 @@ def test_patching(
     qtbot: pytestqt.qtbot.QtBot,
 ) -> None:
     widget = cls()
-    widget.setText("Test\ntext")
+    if isinstance(widget, QtWidgets.QComboBox):
+        widget.addItems(["test", "text"])
+    else:
+        widget.setText("Test\ntext")
     widget.setFixedSize(500, 500)
     qtbot.add_widget(widget)
 
@@ -55,11 +59,12 @@ def test_patching(
     logger.debug(f"ResizeEvent patched font size is {resized_font_size}")
     assert original_font_size != resized_font_size
 
-    # Font size case 2: text is updated
-    widget.setText(widget.text()*100)
-    new_text_font_size = widget.font().pointSizeF()
-    logger.debug(f"setText patched font size is {new_text_font_size}")
-    assert resized_font_size != new_text_font_size
+    # Font size case 2: text is updated (not supported in combobox yet)
+    if not isinstance(widget, QtWidgets.QComboBox):
+        widget.setText(widget.text()*100)
+        new_text_font_size = widget.font().pointSizeF()
+        logger.debug(f"setText patched font size is {new_text_font_size}")
+        assert resized_font_size != new_text_font_size
 
     assert is_patched(widget)
     unpatch_widget(widget)

--- a/typhos/tests/test_dynamic_font.py
+++ b/typhos/tests/test_dynamic_font.py
@@ -6,7 +6,8 @@ from qtpy import QtCore, QtGui, QtWidgets
 
 from typhos.tests import conftest
 
-from ..dynamic_font import is_patched, patch_widget, unpatch_widget
+from ..dynamic_font import (get_widget_maximum_font_size, is_patched,
+                            patch_widget, unpatch_widget)
 
 
 @pytest.mark.parametrize(
@@ -56,3 +57,25 @@ def test_patching(
         widget,
         f"{request.node.name}_{cls.__name__}_dynamic_font_size",
     )
+
+
+def test_wide_label(
+    qapp: QtWidgets.QApplication,
+    qtbot: pytestqt.qtbot.QtBot,
+):
+    """
+    Replicate the wide label text in RIXS that clips
+    """
+    widget = QtWidgets.QLabel()
+    qtbot.add_widget(widget)
+    widget.setText("143252.468 urad")
+    font = widget.font()
+    font.setPointSizeF(16.0)
+    widget.setFont(font)
+    assert widget.font().pointSizeF() == 16.0
+
+    patch_widget(widget)
+    widget.setFixedSize(162.36, 34.65)
+    for _ in range(3):
+        qapp.processEvents()
+    assert widget.font().pointSizeF() == get_widget_maximum_font_size(widget, widget.text())

--- a/typhos/ui/devices/PositionerBase.embedded.ui
+++ b/typhos/ui/devices/PositionerBase.embedded.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>872</width>
-    <height>58</height>
+    <width>681</width>
+    <height>125</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -46,6 +46,18 @@
    </property>
    <item>
     <widget class="TyphosPositionerRowWidget" name="TyphosPositionerRowWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>681</width>
+       <height>125</height>
+      </size>
+     </property>
      <property name="toolTip">
       <string/>
      </property>

--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -165,7 +165,7 @@
              <string/>
             </property>
             <property name="styleSheet">
-             <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
+             <string notr="true">background-color: None; color: None;</string>
             </property>
             <property name="text">
              <string>low_limit</string>
@@ -638,7 +638,7 @@ Screen</string>
              <string/>
             </property>
             <property name="styleSheet">
-             <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
+             <string notr="true">background-color: None; color: None;</string>
             </property>
             <property name="text">
              <string>high_limit</string>

--- a/typhos/ui/widgets/positioner.ui
+++ b/typhos/ui/widgets/positioner.ui
@@ -173,6 +173,9 @@
             <property name="alignment">
              <set>Qt::AlignCenter</set>
             </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>false</bool>
+            </property>
            </widget>
           </item>
          </layout>
@@ -219,6 +222,9 @@
     </string>
             </property>
             <property name="alarmSensitiveContent" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
              <bool>false</bool>
             </property>
             <property name="onColor" stdset="0">
@@ -354,6 +360,9 @@ Screen</string>
           <property name="showUnits" stdset="0">
            <bool>true</bool>
           </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
+          </property>
          </widget>
         </item>
         <item alignment="Qt::AlignHCenter">
@@ -381,6 +390,9 @@ Screen</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
@@ -510,6 +522,9 @@ Screen</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
+          </property>
+          <property name="alarmSensitiveBorder" stdset="0">
+           <bool>false</bool>
           </property>
           <property name="displayFormat" stdset="0">
            <enum>PyDMLabel::String</enum>
@@ -645,6 +660,9 @@ Screen</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
+            </property>
+            <property name="alarmSensitiveBorder" stdset="0">
+             <bool>false</bool>
             </property>
            </widget>
           </item>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>824</width>
+    <width>655</width>
     <height>162</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+   <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -150,7 +150,7 @@
        <height>64</height>
       </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,4,1,2,1,0,0">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0">
       <property name="spacing">
        <number>3</number>
       </property>
@@ -377,96 +377,120 @@
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <property name="spacing">
-         <number>0</number>
+       <widget class="QFrame" name="user_readback_frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>4</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <item alignment="Qt::AlignVCenter">
-         <widget class="PyDMLabel" name="user_readback">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>16</pointsize>
-            <weight>50</weight>
-            <italic>false</italic>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="whatsThis">
-           <string/>
-          </property>
-          <property name="styleSheet">
-           <string notr="true"/>
-          </property>
-          <property name="text">
-           <string>user_readback</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="showUnits" stdset="0">
-           <bool>true</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item alignment="Qt::AlignVCenter">
+          <widget class="PyDMLabel" name="user_readback">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>50</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>50</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+             <weight>50</weight>
+             <italic>false</italic>
+             <bold>false</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>user_readback</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="showUnits" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="low_limit_layout">
-        <property name="spacing">
-         <number>0</number>
+       <widget class="QFrame" name="low_limit_frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-         <widget class="PyDMByteIndicator" name="low_limit_switch">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>25</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="whatsThis">
-           <string>
+        <layout class="QVBoxLayout" name="low_limit_layout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+          <widget class="PyDMByteIndicator" name="low_limit_switch">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>25</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>25</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
     Widget for graphical representation of bits from an integer number
     with support for Channels and more from PyDM
 
@@ -477,87 +501,88 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="onColor" stdset="0">
-           <color>
-            <red>255</red>
-            <green>150</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="offColor" stdset="0">
-           <color>
-            <red>50</red>
-            <green>50</green>
-            <blue>50</blue>
-           </color>
-          </property>
-          <property name="showLabels" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="circles" stdset="0">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignVCenter">
-         <widget class="PyDMLabel" name="low_limit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>8</pointsize>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: None; color: None;</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="precision" stdset="0">
-           <number>1</number>
-          </property>
-          <property name="precisionFromPV" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="onColor" stdset="0">
+            <color>
+             <red>255</red>
+             <green>150</green>
+             <blue>0</blue>
+            </color>
+           </property>
+           <property name="offColor" stdset="0">
+            <color>
+             <red>50</red>
+             <green>50</green>
+             <blue>50</blue>
+            </color>
+           </property>
+           <property name="showLabels" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="circles" stdset="0">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignVCenter">
+          <widget class="PyDMLabel" name="low_limit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>40</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">background-color: None; color: None;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="precision" stdset="0">
+            <number>1</number>
+           </property>
+           <property name="precisionFromPV" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
        <widget class="QFrame" name="setpoint_frame">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
+          <horstretch>2</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
@@ -715,38 +740,54 @@
        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="high_limit_layout">
-        <property name="spacing">
-         <number>0</number>
+       <widget class="QFrame" name="high_limit_frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-         <widget class="PyDMByteIndicator" name="high_limit_switch">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>25</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="whatsThis">
-           <string>
+        <layout class="QVBoxLayout" name="high_limit_layout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+          <widget class="PyDMByteIndicator" name="high_limit_switch">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>25</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>25</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
     Widget for graphical representation of bits from an integer number
     with support for Channels and more from PyDM
 
@@ -757,90 +798,91 @@
     init_channel : str, optional
         The channel to be used by the widget.
     </string>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">margin: 0px;</string>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="onColor" stdset="0">
-           <color>
-            <red>255</red>
-            <green>150</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="offColor" stdset="0">
-           <color>
-            <red>50</red>
-            <green>50</green>
-            <blue>50</blue>
-           </color>
-          </property>
-          <property name="orientation" stdset="0">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="showLabels" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="circles" stdset="0">
-           <bool>true</bool>
-          </property>
-          <property name="shift" stdset="0">
-           <number>0</number>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignVCenter">
-         <widget class="PyDMLabel" name="high_limit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>8</pointsize>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: None; color: None;</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="precision" stdset="0">
-           <number>1</number>
-          </property>
-          <property name="precisionFromPV" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">margin: 0px;</string>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="onColor" stdset="0">
+            <color>
+             <red>255</red>
+             <green>150</green>
+             <blue>0</blue>
+            </color>
+           </property>
+           <property name="offColor" stdset="0">
+            <color>
+             <red>50</red>
+             <green>50</green>
+             <blue>50</blue>
+            </color>
+           </property>
+           <property name="orientation" stdset="0">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="showLabels" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="circles" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="shift" stdset="0">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignVCenter">
+          <widget class="PyDMLabel" name="high_limit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>40</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">background-color: None; color: None;</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="precision" stdset="0">
+            <number>1</number>
+           </property>
+           <property name="precisionFromPV" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="alarmSensitiveBorder" stdset="0">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -379,7 +379,7 @@
       <item>
        <widget class="QFrame" name="user_readback_frame">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
           <horstretch>4</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -445,7 +445,7 @@
       <item>
        <widget class="QFrame" name="low_limit_frame">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
           <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -581,7 +581,7 @@
       <item>
        <widget class="QFrame" name="setpoint_frame">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
           <horstretch>2</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -742,7 +742,7 @@
       <item>
        <widget class="QFrame" name="high_limit_frame">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
           <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>720</width>
-    <height>160</height>
+    <height>162</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -416,7 +416,7 @@
            <string/>
           </property>
           <property name="styleSheet">
-           <string notr="true">font: 16pt</string>
+           <string notr="true"/>
           </property>
           <property name="text">
            <string>user_readback</string>
@@ -532,7 +532,7 @@
            <string/>
           </property>
           <property name="styleSheet">
-           <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
+           <string notr="true">background-color: None; color: None;</string>
           </property>
           <property name="text">
            <string/>
@@ -834,7 +834,7 @@
            <string/>
           </property>
           <property name="styleSheet">
-           <string notr="true">font-size: 8pt; background-color: None; color: None;</string>
+           <string notr="true">background-color: None; color: None;</string>
           </property>
           <property name="text">
            <string/>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -392,13 +392,13 @@
           <property name="minimumSize">
            <size>
             <width>150</width>
-            <height>55</height>
+            <height>50</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>16777215</width>
-            <height>55</height>
+            <height>50</height>
            </size>
           </property>
           <property name="font">
@@ -595,13 +595,13 @@
             <number>0</number>
            </property>
            <property name="leftMargin">
-            <number>25</number>
+            <number>0</number>
            </property>
            <property name="topMargin">
             <number>0</number>
            </property>
            <property name="rightMargin">
-            <number>25</number>
+            <number>0</number>
            </property>
            <item>
             <widget class="PyDMLineEdit" name="user_setpoint">
@@ -1017,7 +1017,7 @@ Screen</string>
       </property>
       <item>
        <layout class="QHBoxLayout" name="clear_error_layout">
-        <item>
+        <item alignment="Qt::AlignTop">
          <widget class="QPushButton" name="expand_button">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -1205,7 +1205,7 @@ Screen</string>
           </item>
          </layout>
         </item>
-        <item>
+        <item alignment="Qt::AlignTop">
          <widget class="QPushButton" name="clear_error_button">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -659,7 +659,7 @@
           <widget class="QWidget" name="setpoint_widget" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>4</horstretch>
+             <horstretch>1</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>720</width>
+    <width>824</width>
     <height>162</height>
    </rect>
   </property>
@@ -150,7 +150,7 @@
        <height>64</height>
       </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,4,1,2,1,0,0">
       <property name="spacing">
        <number>3</number>
       </property>
@@ -392,13 +392,13 @@
           <property name="minimumSize">
            <size>
             <width>150</width>
-            <height>35</height>
+            <height>55</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>16777215</width>
-            <height>35</height>
+            <height>55</height>
            </size>
           </property>
           <property name="font">
@@ -503,10 +503,10 @@
           </property>
          </widget>
         </item>
-        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+        <item alignment="Qt::AlignVCenter">
          <widget class="PyDMLabel" name="low_limit">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -519,7 +519,7 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>40</width>
+            <width>16777215</width>
             <height>25</height>
            </size>
           </property>
@@ -551,34 +551,12 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QWidget" name="widget" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item>
        <widget class="QFrame" name="setpoint_frame">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -591,7 +569,7 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>150</width>
+          <width>16777215</width>
           <height>16777215</height>
          </size>
         </property>
@@ -617,15 +595,15 @@
             <number>0</number>
            </property>
            <property name="leftMargin">
-            <number>0</number>
+            <number>25</number>
            </property>
            <property name="topMargin">
             <number>0</number>
            </property>
            <property name="rightMargin">
-            <number>0</number>
+            <number>25</number>
            </property>
-           <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+           <item>
             <widget class="PyDMLineEdit" name="user_setpoint">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -636,13 +614,13 @@
              <property name="minimumSize">
               <size>
                <width>100</width>
-               <height>25</height>
+               <height>30</height>
               </size>
              </property>
              <property name="maximumSize">
               <size>
-               <width>100</width>
-               <height>25</height>
+               <width>16777215</width>
+               <height>30</height>
               </size>
              </property>
              <property name="toolTip">
@@ -694,6 +672,12 @@
             </item>
             <item>
              <widget class="QLineEdit" name="tweak_value">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>100</width>
@@ -702,7 +686,7 @@
               </property>
               <property name="maximumSize">
                <size>
-                <width>100</width>
+                <width>16777215</width>
                 <height>25</height>
                </size>
               </property>
@@ -732,6 +716,9 @@
       </item>
       <item>
        <layout class="QVBoxLayout" name="high_limit_layout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <property name="topMargin">
          <number>0</number>
         </property>
@@ -808,7 +795,7 @@
         <item alignment="Qt::AlignVCenter">
          <widget class="PyDMLabel" name="high_limit">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -821,7 +808,7 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>40</width>
+            <width>16777215</width>
             <height>25</height>
            </size>
           </property>
@@ -850,28 +837,6 @@
           </property>
           <property name="alarmSensitiveBorder" stdset="0">
            <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="widget_3" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
           </property>
          </widget>
         </item>
@@ -1251,13 +1216,13 @@ Screen</string>
           <property name="minimumSize">
            <size>
             <width>143</width>
-            <height>42</height>
+            <height>25</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>143</width>
-            <height>42</height>
+            <height>25</height>
            </size>
           </property>
           <property name="font">

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>655</width>
-    <height>162</height>
+    <width>681</width>
+    <height>125</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>655</width>
-    <height>0</height>
+    <width>0</width>
+    <height>125</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -45,396 +45,238 @@
     <number>0</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="device_name_layout">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item alignment="Qt::AlignLeft">
-      <widget class="QLabel" name="device_name_label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>60</width>
-         <height>35</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>35</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>12</pointsize>
-         <weight>75</weight>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>${name}</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="margin">
-        <number>0</number>
-       </property>
-       <property name="indent">
-        <number>0</number>
-       </property>
-      </widget>
-     </item>
-     <item alignment="Qt::AlignLeft">
-      <widget class="TyphosNotesEdit" name="notes_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>250</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
-       <property name="readOnly">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="TyphosDisplaySwitcher" name="switcher">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QFrame" name="row_frame">
+    <widget class="QWidget" name="device_name_row_widget" native="true">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
+       <verstretch>1</verstretch>
       </sizepolicy>
      </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>64</height>
+       <height>26</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="device_name_layout">
+      <property name="topMargin">
+       <number>1</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="device_name_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>60</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>12</pointsize>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>${name}</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <property name="indent">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="TyphosNotesEdit" name="notes_edit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>250</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="readOnly">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item alignment="Qt::AlignBottom">
+       <widget class="TyphosDisplaySwitcher" name="switcher">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="main_info_row_widget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>2</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>52</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>64</height>
+       <height>16777215</height>
       </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0,0,0">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0">
       <property name="spacing">
        <number>3</number>
       </property>
       <property name="leftMargin">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="topMargin">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="rightMargin">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="bottomMargin">
-       <number>0</number>
+       <number>1</number>
       </property>
       <item>
-       <layout class="QVBoxLayout" name="alarm_layout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-         <widget class="TyphosAlarmRectangle" name="alarm_circle">
-          <property name="minimumSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="penWidth" stdset="0">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignVCenter">
-         <widget class="QLabel" name="alarm_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>alarm</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QVBoxLayout" name="moving_indicator_layout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-         <widget class="PyDMByteIndicator" name="moving_indicator">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>30</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="whatsThis">
-           <string>
-    Widget for graphical representation of bits from an integer number
-    with support for Channels and more from PyDM
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-          </property>
-          <property name="alarmSensitiveContent" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="alarmSensitiveBorder" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="PyDMToolTip" stdset="0">
-           <string/>
-          </property>
-          <property name="channel" stdset="0">
-           <string/>
-          </property>
-          <property name="onColor" stdset="0">
-           <color>
-            <red>20</red>
-            <green>100</green>
-            <blue>239</blue>
-           </color>
-          </property>
-          <property name="offColor" stdset="0">
-           <color>
-            <red>60</red>
-            <green>60</green>
-            <blue>60</blue>
-           </color>
-          </property>
-          <property name="showLabels" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="bigEndian" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="circles" stdset="0">
-           <bool>false</bool>
-          </property>
-          <property name="numBits" stdset="0">
-           <number>1</number>
-          </property>
-          <property name="shift" stdset="0">
-           <number>0</number>
-          </property>
-          <property name="labels" stdset="0">
-           <stringlist>
-            <string>Bit 0</string>
-           </stringlist>
-          </property>
-         </widget>
-        </item>
-        <item alignment="Qt::AlignVCenter">
-         <widget class="QLabel" name="moving_indicator_label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>motion</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="widget_4" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QFrame" name="user_readback_frame">
+       <widget class="QWidget" name="alarm_group_widget" native="true">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>4</horstretch>
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="minimumSize">
+         <size>
+          <width>42</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QVBoxLayout" name="alarm_layout">
          <property name="spacing">
-          <number>0</number>
+          <number>1</number>
          </property>
-         <item alignment="Qt::AlignVCenter">
-          <widget class="PyDMLabel" name="user_readback">
+         <property name="leftMargin">
+          <number>3</number>
+         </property>
+         <property name="topMargin">
+          <number>3</number>
+         </property>
+         <property name="rightMargin">
+          <number>3</number>
+         </property>
+         <property name="bottomMargin">
+          <number>3</number>
+         </property>
+         <item>
+          <widget class="TyphosAlarmCircle" name="alarm_circle">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
+             <verstretch>2</verstretch>
             </sizepolicy>
            </property>
            <property name="minimumSize">
             <size>
-             <width>150</width>
-             <height>50</height>
+             <width>30</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="penWidth" stdset="0">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="alarm_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>1</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>36</width>
+             <height>15</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>50</height>
+             <height>16777215</height>
             </size>
            </property>
-           <property name="font">
-            <font>
-             <pointsize>16</pointsize>
-             <weight>50</weight>
-             <italic>false</italic>
-             <bold>false</bold>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="whatsThis">
-            <string/>
-           </property>
-           <property name="styleSheet">
-            <string notr="true"/>
-           </property>
            <property name="text">
-            <string>user_readback</string>
+            <string>alarm</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
            </property>
-           <property name="showUnits" stdset="0">
-            <bool>true</bool>
-           </property>
-           <property name="alarmSensitiveBorder" stdset="0">
+           <property name="wordWrap">
             <bool>false</bool>
            </property>
           </widget>
@@ -443,47 +285,59 @@
        </widget>
       </item>
       <item>
-       <widget class="QFrame" name="low_limit_frame">
+       <widget class="QWidget" name="moving_group_widget" native="true">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <layout class="QVBoxLayout" name="low_limit_layout">
+        <property name="minimumSize">
+         <size>
+          <width>42</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QVBoxLayout" name="moving_indicator_layout">
          <property name="spacing">
-          <number>0</number>
+          <number>1</number>
          </property>
          <property name="leftMargin">
-          <number>0</number>
+          <number>3</number>
          </property>
          <property name="topMargin">
-          <number>0</number>
+          <number>3</number>
          </property>
          <property name="rightMargin">
-          <number>0</number>
+          <number>3</number>
          </property>
          <property name="bottomMargin">
-          <number>0</number>
+          <number>3</number>
          </property>
-         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-          <widget class="PyDMByteIndicator" name="low_limit_switch">
+         <item>
+          <widget class="PyDMByteIndicator" name="moving_indicator">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
+             <verstretch>2</verstretch>
             </sizepolicy>
            </property>
            <property name="minimumSize">
             <size>
-             <width>25</width>
-             <height>25</height>
+             <width>30</width>
+             <height>30</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>25</width>
-             <height>25</height>
+             <width>16777215</width>
+             <height>16777215</height>
             </size>
            </property>
            <property name="toolTip">
@@ -502,75 +356,81 @@
         The channel to be used by the widget.
     </string>
            </property>
+           <property name="alarmSensitiveContent" stdset="0">
+            <bool>false</bool>
+           </property>
            <property name="alarmSensitiveBorder" stdset="0">
             <bool>false</bool>
            </property>
+           <property name="PyDMToolTip" stdset="0">
+            <string/>
+           </property>
+           <property name="channel" stdset="0">
+            <string/>
+           </property>
            <property name="onColor" stdset="0">
             <color>
-             <red>255</red>
-             <green>150</green>
-             <blue>0</blue>
+             <red>20</red>
+             <green>100</green>
+             <blue>239</blue>
             </color>
            </property>
            <property name="offColor" stdset="0">
             <color>
-             <red>50</red>
-             <green>50</green>
-             <blue>50</blue>
+             <red>60</red>
+             <green>60</green>
+             <blue>60</blue>
             </color>
            </property>
            <property name="showLabels" stdset="0">
             <bool>false</bool>
            </property>
+           <property name="bigEndian" stdset="0">
+            <bool>false</bool>
+           </property>
            <property name="circles" stdset="0">
             <bool>true</bool>
            </property>
+           <property name="numBits" stdset="0">
+            <number>1</number>
+           </property>
+           <property name="shift" stdset="0">
+            <number>0</number>
+           </property>
+           <property name="labels" stdset="0">
+            <stringlist>
+             <string>Bit 0</string>
+            </stringlist>
+           </property>
           </widget>
          </item>
-         <item alignment="Qt::AlignVCenter">
-          <widget class="PyDMLabel" name="low_limit">
+         <item>
+          <widget class="QLabel" name="moving_indicator_label">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
+             <verstretch>1</verstretch>
             </sizepolicy>
            </property>
            <property name="minimumSize">
             <size>
-             <width>40</width>
-             <height>25</height>
+             <width>36</width>
+             <height>15</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
              <width>16777215</width>
-             <height>25</height>
+             <height>16777215</height>
             </size>
            </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">background-color: None; color: None;</string>
-           </property>
            <property name="text">
-            <string/>
+            <string>motion</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
            </property>
-           <property name="precision" stdset="0">
-            <number>1</number>
-           </property>
-           <property name="precisionFromPV" stdset="0">
-            <bool>false</bool>
-           </property>
-           <property name="alarmSensitiveBorder" stdset="0">
+           <property name="wordWrap">
             <bool>false</bool>
            </property>
           </widget>
@@ -579,17 +439,17 @@
        </widget>
       </item>
       <item>
-       <widget class="QFrame" name="setpoint_frame">
+       <widget class="PyDMLabel" name="user_readback">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>2</horstretch>
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>7</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="minimumSize">
          <size>
           <width>150</width>
-          <height>0</height>
+          <height>50</height>
          </size>
         </property>
         <property name="maximumSize">
@@ -598,9 +458,54 @@
           <height>16777215</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="setpoint_outer_layout">
+        <property name="font">
+         <font>
+          <pointsize>16</pointsize>
+          <weight>50</weight>
+          <italic>false</italic>
+          <bold>false</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="styleSheet">
+         <string notr="true"/>
+        </property>
+        <property name="text">
+         <string>user_readback</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="showUnits" stdset="0">
+         <bool>true</bool>
+        </property>
+        <property name="alarmSensitiveBorder" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="set_and_limits_widget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>5</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>248</width>
+          <height>0</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
          <property name="spacing">
-          <number>0</number>
+          <number>3</number>
          </property>
          <property name="leftMargin">
           <number>0</number>
@@ -615,121 +520,476 @@
           <number>0</number>
          </property>
          <item>
-          <layout class="QVBoxLayout" name="setpoint_layout" stretch="0">
-           <property name="spacing">
-            <number>0</number>
+          <widget class="QWidget" name="low_limit_widget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="PyDMLineEdit" name="user_setpoint">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>100</width>
-               <height>30</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>30</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignCenter</set>
-             </property>
-             <property name="alarmSensitiveBorder" stdset="0">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item alignment="Qt::AlignVCenter">
-          <widget class="QWidget" name="tweak_widget" native="true">
-           <layout class="QHBoxLayout" name="tweak_layout" stretch="0,0,0">
+           <layout class="QVBoxLayout" name="low_limit_layout">
             <property name="spacing">
              <number>0</number>
             </property>
-            <property name="sizeConstraint">
-             <enum>QLayout::SetDefaultConstraint</enum>
-            </property>
             <property name="leftMargin">
-             <number>0</number>
+             <number>3</number>
             </property>
             <property name="topMargin">
-             <number>1</number>
+             <number>3</number>
             </property>
             <property name="rightMargin">
-             <number>0</number>
+             <number>3</number>
             </property>
             <property name="bottomMargin">
-             <number>1</number>
+             <number>3</number>
             </property>
-            <item alignment="Qt::AlignTop">
-             <widget class="QToolButton" name="tweak_negative">
-              <property name="minimumSize">
-               <size>
-                <width>25</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>-</string>
-              </property>
-             </widget>
-            </item>
             <item>
-             <widget class="QLineEdit" name="tweak_value">
+             <widget class="PyDMByteIndicator" name="low_limit_switch">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                 <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
+                <verstretch>1</verstretch>
                </sizepolicy>
               </property>
               <property name="minimumSize">
                <size>
-                <width>100</width>
-                <height>25</height>
+                <width>25</width>
+                <height>23</height>
                </size>
               </property>
               <property name="maximumSize">
                <size>
                 <width>16777215</width>
-                <height>25</height>
+                <height>16777215</height>
                </size>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="whatsThis">
+               <string>
+    Widget for graphical representation of bits from an integer number
+    with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+              </property>
+              <property name="alarmSensitiveBorder" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="onColor" stdset="0">
+               <color>
+                <red>255</red>
+                <green>150</green>
+                <blue>0</blue>
+               </color>
+              </property>
+              <property name="offColor" stdset="0">
+               <color>
+                <red>50</red>
+                <green>50</green>
+                <blue>50</blue>
+               </color>
+              </property>
+              <property name="showLabels" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="circles" stdset="0">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QToolButton" name="tweak_positive">
+             <widget class="PyDMLabel" name="low_limit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
-                <width>25</width>
+                <width>40</width>
+                <height>23</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: None; color: None;</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="precision" stdset="0">
+               <number>1</number>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="alarmSensitiveBorder" stdset="0">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="setpoint_widget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>4</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>150</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <layout class="QVBoxLayout" name="setpoint_outer_layout">
+            <property name="spacing">
+             <number>1</number>
+            </property>
+            <property name="leftMargin">
+             <number>1</number>
+            </property>
+            <property name="topMargin">
+             <number>1</number>
+            </property>
+            <property name="rightMargin">
+             <number>1</number>
+            </property>
+            <property name="bottomMargin">
+             <number>1</number>
+            </property>
+            <item>
+             <widget class="QWidget" name="inner_setpoint_widget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+              <layout class="QVBoxLayout" name="setpoint_layout" stretch="0">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="PyDMLineEdit" name="user_setpoint">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>100</width>
+                   <height>24</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="toolTip">
+                  <string/>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="alarmSensitiveBorder" stdset="0">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item alignment="Qt::AlignVCenter">
+             <widget class="QWidget" name="tweak_widget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
                 <height>25</height>
                </size>
               </property>
+              <layout class="QHBoxLayout" name="tweak_layout" stretch="0,0,0">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="sizeConstraint">
+                <enum>QLayout::SetDefaultConstraint</enum>
+               </property>
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QToolButton" name="tweak_negative">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>1</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>25</width>
+                   <height>24</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>-</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="tweak_value">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>5</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>100</width>
+                   <height>24</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="tweak_positive">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>1</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>25</width>
+                   <height>24</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>+</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="high_limit_widget" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QVBoxLayout" name="high_limit_layout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>3</number>
+            </property>
+            <property name="topMargin">
+             <number>3</number>
+            </property>
+            <property name="rightMargin">
+             <number>3</number>
+            </property>
+            <property name="bottomMargin">
+             <number>3</number>
+            </property>
+            <item>
+             <widget class="PyDMByteIndicator" name="high_limit_switch">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>25</width>
+                <height>23</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="whatsThis">
+               <string>
+    Widget for graphical representation of bits from an integer number
+    with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">margin: 0px;</string>
+              </property>
+              <property name="alarmSensitiveBorder" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="onColor" stdset="0">
+               <color>
+                <red>255</red>
+                <green>150</green>
+                <blue>0</blue>
+               </color>
+              </property>
+              <property name="offColor" stdset="0">
+               <color>
+                <red>50</red>
+                <green>50</green>
+                <blue>50</blue>
+               </color>
+              </property>
+              <property name="orientation" stdset="0">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="showLabels" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="circles" stdset="0">
+               <bool>true</bool>
+              </property>
+              <property name="shift" stdset="0">
+               <number>0</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="PyDMLabel" name="high_limit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>40</width>
+                <height>23</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>8</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string/>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: None; color: None;</string>
+              </property>
               <property name="text">
-               <string>+</string>
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+              <property name="precision" stdset="0">
+               <number>1</number>
+              </property>
+              <property name="precisionFromPV" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="alarmSensitiveBorder" stdset="0">
+               <bool>false</bool>
               </property>
              </widget>
             </item>
@@ -740,16 +1000,198 @@
        </widget>
       </item>
       <item>
-       <widget class="QFrame" name="high_limit_frame">
+       <widget class="QWidget" name="widget" native="true">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>1</horstretch>
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>2</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <layout class="QVBoxLayout" name="high_limit_layout">
+        <property name="minimumSize">
+         <size>
+          <width>164</width>
+          <height>0</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="topMargin">
+          <number>9</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="stop_button">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>70</width>
+             <height>34</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
+           </property>
+           <property name="text">
+            <string>Stop</string>
+           </property>
+           <property name="autoDefault">
+            <bool>false</bool>
+           </property>
+           <property name="default">
+            <bool>false</bool>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="TyphosRelatedSuiteButton" name="expert_button">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>70</width>
+             <height>34</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Expert
+Screen</string>
+           </property>
+           <property name="icon">
+            <iconset theme="gear">
+             <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="status_container_widget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>26</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item alignment="Qt::AlignBottom">
+       <widget class="QPushButton" name="expand_button">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>25</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Expand Details</string>
+        </property>
+        <property name="text">
+         <string>&gt;</string>
+        </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="inner_error_widget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>14</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>26</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_7">
          <property name="spacing">
-          <number>0</number>
+          <number>3</number>
          </property>
          <property name="leftMargin">
           <number>0</number>
@@ -763,88 +1205,18 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-          <widget class="PyDMByteIndicator" name="high_limit_switch">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>25</width>
-             <height>25</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>25</width>
-             <height>25</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="whatsThis">
-            <string>
-    Widget for graphical representation of bits from an integer number
-    with support for Channels and more from PyDM
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-           </property>
-           <property name="styleSheet">
-            <string notr="true">margin: 0px;</string>
-           </property>
-           <property name="alarmSensitiveBorder" stdset="0">
-            <bool>false</bool>
-           </property>
-           <property name="onColor" stdset="0">
-            <color>
-             <red>255</red>
-             <green>150</green>
-             <blue>0</blue>
-            </color>
-           </property>
-           <property name="offColor" stdset="0">
-            <color>
-             <red>50</red>
-             <green>50</green>
-             <blue>50</blue>
-            </color>
-           </property>
-           <property name="orientation" stdset="0">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="showLabels" stdset="0">
-            <bool>false</bool>
-           </property>
-           <property name="circles" stdset="0">
-            <bool>true</bool>
-           </property>
-           <property name="shift" stdset="0">
-            <number>0</number>
-           </property>
-          </widget>
-         </item>
-         <item alignment="Qt::AlignVCenter">
-          <widget class="PyDMLabel" name="high_limit">
+         <item>
+          <widget class="QLabel" name="status_label">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
+             <horstretch>1</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
            <property name="minimumSize">
             <size>
-             <width>40</width>
-             <height>25</height>
+             <width>0</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
@@ -853,31 +1225,57 @@
              <height>25</height>
             </size>
            </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
+           <property name="styleSheet">
+            <string notr="true">QLabel { color: black; background-color: none;   border-radius: 0px; }</string>
+           </property>
+           <property name="text">
+            <string> (Status label)</string>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+           <property name="indent">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PyDMLabel" name="error_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>26</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>25</height>
+            </size>
            </property>
            <property name="toolTip">
             <string/>
            </property>
            <property name="styleSheet">
-            <string notr="true">background-color: None; color: None;</string>
+            <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
            </property>
            <property name="text">
             <string/>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
-           <property name="precision" stdset="0">
-            <number>1</number>
+           <property name="indent">
+            <number>0</number>
            </property>
-           <property name="precisionFromPV" stdset="0">
-            <bool>false</bool>
-           </property>
-           <property name="alarmSensitiveBorder" stdset="0">
-            <bool>false</bool>
+           <property name="displayFormat" stdset="0">
+            <enum>PyDMLabel::String</enum>
            </property>
           </widget>
          </item>
@@ -885,406 +1283,59 @@
        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="spacing">
-         <number>0</number>
+       <widget class="QWidget" name="clear_error_margin_widget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>2</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QPushButton" name="stop_button">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>70</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
-          </property>
-          <property name="text">
-           <string>Stop</string>
-          </property>
-          <property name="autoDefault">
-           <bool>false</bool>
-          </property>
-          <property name="default">
-           <bool>false</bool>
-          </property>
-          <property name="flat">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="widget_5" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="TyphosRelatedSuiteButton" name="expert_button">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>70</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="styleSheet">
-           <string notr="true"/>
-          </property>
-          <property name="text">
-           <string>Expert
-Screen</string>
-          </property>
-          <property name="icon">
-           <iconset theme="gear">
-            <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="widget_6" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>70</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>70</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QWidget" name="status_container_widget" native="true">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <layout class="QVBoxLayout" name="status_text_layout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <layout class="QHBoxLayout" name="clear_error_layout">
-        <item alignment="Qt::AlignTop">
-         <widget class="QPushButton" name="expand_button">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>25</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>25</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Expand Details</string>
-          </property>
-          <property name="text">
-           <string>&gt;</string>
-          </property>
-          <property name="checkable">
-           <bool>false</bool>
-          </property>
-          <property name="flat">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="inner_error">
-          <property name="spacing">
-           <number>3</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="status_error_prefix">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">color: red</string>
-              </property>
-              <property name="text">
-               <string>Error: </string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="status_label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">QLabel { color: black; background-color: none;   border-radius: 0px; }</string>
-              </property>
-              <property name="text">
-               <string> (Status label)</string>
-              </property>
-              <property name="wordWrap">
-               <bool>false</bool>
-              </property>
-              <property name="indent">
-               <number>0</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="error_prefix">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">color: red</string>
-              </property>
-              <property name="text">
-               <string>Error: </string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="PyDMLabel" name="error_label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>25</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-              <property name="indent">
-               <number>0</number>
-              </property>
-              <property name="displayFormat" stdset="0">
-               <enum>PyDMLabel::String</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item alignment="Qt::AlignTop">
-         <widget class="QPushButton" name="clear_error_button">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>143</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>143</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <weight>75</weight>
-            <bold>true</bold>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="styleSheet">
-           <string notr="true"/>
-          </property>
-          <property name="text">
-           <string>Clear Error</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="clear_error_button">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>2</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>146</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Clear Error</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -1308,7 +1359,7 @@ Screen</string>
    <header>pydm.widgets.line_edit</header>
   </customwidget>
   <customwidget>
-   <class>TyphosAlarmRectangle</class>
+   <class>TyphosAlarmCircle</class>
    <extends>QWidget</extends>
    <header>typhos.alarm</header>
   </customwidget>

--- a/typhos/ui/widgets/positioner_row.ui
+++ b/typhos/ui/widgets/positioner_row.ui
@@ -1044,7 +1044,7 @@
             </font>
            </property>
            <property name="styleSheet">
-            <string notr="true">padding: 2px; margin: 0px; background-color: red</string>
+            <string notr="true">QPushButton { padding: 2px; margin: 0px; background-color: red }</string>
            </property>
            <property name="text">
             <string>Stop</string>
@@ -1263,7 +1263,7 @@ Screen</string>
             <string/>
            </property>
            <property name="styleSheet">
-            <string notr="true">color: black; background-color: none;   border-radius: 0px;</string>
+            <string notr="true">PyDMLabel { color: black; background-color: none;   border-radius: 0px; }</string>
            </property>
            <property name="text">
             <string/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Rework the design, sizing, and font scaling of the positioner row widget to address concerns about readability in RIX for devices with large position numbers, and to address issues with poorly used space in state devices.

### Full list of changes:

#### dynamic_font.py:
- Allow dynamic font scaling to be applied to comboboxes
- Allow dynamic font resizing widgets to optionally define a minimum and maximum font size.
- Let font size change by less than the delta if it is to snap to the minimum or maximum, making sizing more consistent at the edges.
- Minor caching optimizations related to dynamic font scaling (there could be more improvements here) 
- setText-based widgets with dynamic font scaling now also adjust their font size when their text contents change
- Remove sizing overrides for dynamic patched widgets because they are no longer needed now that we're not using paint events and they get in the way of implementing proper sizing elsewhere
- Set the font size prior to the first resize in case the widget is never resized.

#### panel.py
- Fix all known sizing issues related to recursive composite signal panels

#### positioner.py
- Remove `reload_widget_stylesheet` call from `clear_error` to avoid an issue where clicking `clear_error` would undo all dynamic font scaling and set it back to the default size.
- Include the possibility for the limit indicators to completely disappear to allow other widgets to use their space
- Remove references to fixed sizing to allow for the possibility of widget scaling
- Remove unused layout modifications now that the layouts are different
- Apply dynamic font sizing to every single widget with text in the positioner row widget
- Add the low/high limit position settings to the expandable panel below the row widget
- Allow the setpoint widget to expand into the space left by the tweak widget for the combobox case
- Rework/refactor the expandable signal panel to be a pop-out window (the new `RowDetails` widget) on top of the screen instead of inside of the main layout, because adding a huge widget to the layout causes serious issues with resizing.
- Remove references to static "Error" text that is removed in the row widget ui file

#### test_dynamic_font.py
- Make sure combobox font patching works

#### PositionerBase.embedded.ui
- Set minimum size, set size policy to be expanding so that the row is allowed to expand

#### positioner.ui
- Remove all instances of fixed font-size that interfere with dynamic text resizing
- Remove all alarm-sensitive borders because I had to disable a widget style reload earlier

#### positioner_row.ui
- Completely redesign this to be aesthetically scalable in all directions
- Small note: made the clear_error button smaller to save vertical space
- Small note: switched squares to circles because the square widgets resize terribly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Certain device screens, such as sp1k1 and the imagers, look kind of wonky due to sizing.
- https://jira.slac.stanford.edu/browse/ECS-5339

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- Added a little bit of testing
- In person test at RIX

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Need to revise the pre-release notes one more time

## Screenshots:
Before small:
![image](https://github.com/pcdshub/typhos/assets/10647860/364d968e-6df4-4d91-9763-6e396fbadc4f)

Before wide:
![image](https://github.com/pcdshub/typhos/assets/10647860/9b42e3be-f00f-4c75-ad89-5bdaf002ef16)

After small:
![image](https://github.com/pcdshub/typhos/assets/10647860/116a97e6-ef2d-4522-a21a-ce1e71ee6919)

After wide:
![image](https://github.com/pcdshub/typhos/assets/10647860/5d001c3a-3127-431a-ab16-4bd931c503ee)

After default size with default size/location expansion pop-outs:
![image](https://github.com/pcdshub/typhos/assets/10647860/70195ab2-2294-4c59-87b4-63d6904cea1f)


## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
