### PR TITLE
BLD: pin pcdsdevices to try to fix CI

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -60,7 +60,7 @@ test:
   - ipython>=7.16
   - jinja2<3.1
   - line_profiler
-  - pcdsdevices
+  - pcdsdevices>=8.4.0
   - pytest
   - pytest-benchmark
   - pytest-qt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ flake8
 ipython>=7.16
 jinja2<3.1
 line_profiler
-pcdsdevices
+pcdsdevices>=8.4.0
 pytest
 pytest-benchmark
 pytest-cov

--- a/docs/source/upcoming_release_notes/615-maint_fix_ci.rst
+++ b/docs/source/upcoming_release_notes/615-maint_fix_ci.rst
@@ -1,0 +1,22 @@
+615 maint_fix_ci
+################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- In dev/test requirements, pin pcdsdevices to current latest to fix the CI builds.
+
+Contributors
+------------
+- zllentz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
pin pcdsdevices to latest in tests to avoid older versions being picked

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
the github actions on the merge of #611 failed because of some environment changes in the python ecosystem related to numpy 2.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
this is tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I'll add a pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] ~Code works interactively~
- [ ] ~Code contains descriptive docstrings, including context and API~
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [ ] ~Code has been checked for threading issues (no blocking tasks in GUI thread)~
- [ ] ~Test suite passes locally~
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
