### PR TITLE
FIX: metadata handling for enums

### DIFF
--- a/docs/source/upcoming_release_notes/616-fix_enum_handling.rst
+++ b/docs/source/upcoming_release_notes/616-fix_enum_handling.rst
@@ -1,0 +1,23 @@
+616 fix_enum_handling
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix various issues with enum handling in the SignalPlugin.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- canismarko
+- zllentz

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -80,10 +80,10 @@ class SignalConnection(PyDMConnection):
     def __init__(self, channel, address, protocol=None, parent=None):
         # Create base connection
         super().__init__(channel, address, protocol=protocol, parent=parent)
-        self._connection_open = True
-        self.signal_type = None
-        self.is_float = False
-        self.enum_strs = ()
+        self._connection_open: bool = True
+        self.signal_type: type | None = None
+        self.is_float: bool = False
+        self.enum_strs: tuple[str, ...] = ()
 
         # Collect our signal
         self.signal = self.find_signal(address)
@@ -161,7 +161,9 @@ class SignalConnection(PyDMConnection):
                 except (TypeError, ValueError):
                     value = str(value)
             else:
-                raise TypeError(f"Invalid combination: {self.enum_strs=} with {self.signal_type=}")
+                raise TypeError(
+                    f"Invalid combination: enum_strs={self.enum_strs} with signal_type={self.signal_type}"
+                )
         elif self.signal_type is np.ndarray:
             value = np.asarray(value)
         else:

--- a/typhos/tests/plugins/test_core.py
+++ b/typhos/tests/plugins/test_core.py
@@ -252,7 +252,9 @@ def test_enum_casts(qapp):
     assert conn.cast(2) == 2
 
     # Try str next
-    conn.signal_type = str
+    conn.signal_type = None
+    sig.put("2")
+    qapp.processEvents()
 
     assert conn.cast("1") == "1"
     assert conn.cast("2") == "2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix three issues related to enum/metadata handling in the `SignalConnection` part of the `SignalPlugin` and implement simplified unit tests for these cases.

- Switch the order of the metadata/value setup for new listeners to ensure widgets have the correct contextual information. This is exactly the fix proposed by @canismarko in #605.
- Fix an issue where string=True enum EpicsSignals would reliably break on casting in cases where the enum strings were numerically the same as other indices in the enum_strs tuple. This builds upon the fix proposed by @canismarko in #608
- Fix a related (unreported) issue where the previous point could also break for string=False EpicsSignals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #605 
closes #608 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests were added. I originally tried to make a larger unit test where I instantiated real/fake EpicsSignal instances and connected them to the combobox widgets as reported in the issues, but I couldn't get this to work properly in a unit testing context. Rather than dump additional dev hours into this, I came up with simpler tests, possibly these could be better.

I will need to test with a real EPICS PV too.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I need to write some release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
