### PR TITLE
BLD: unpin jinja, satiate dependabot

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 caproto
 flake8
 ipython>=7.16
-jinja2<3.1
+jinja2
 line_profiler
 pcdsdevices>=8.4.0
 pytest

--- a/docs/source/upcoming_release_notes/618-bld_jinja_bump.rst
+++ b/docs/source/upcoming_release_notes/618-bld_jinja_bump.rst
@@ -1,0 +1,22 @@
+618 bld_jinja_bump
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- unpin jinja, sphinx no longer incompatible
+
+Contributors
+------------
+- tangkong


### PR DESCRIPTION
## Description
Unpin jinja, dependabot keeps sending me emails

## Motivation and Context
leave my inbox alone

## How Has This Been Tested?
Let's see if the previously stated incompatibility with sphinx is still an issue

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
