### PR TITLE
ENH/MNT/TST: make auto scrollable functional again

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
   - python >=3.9
   - pip
+  - setuptools
   - setuptools_scm
   host:
   - python >=3.9

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,9 +22,6 @@ requirements:
   - pip
   - setuptools
   - setuptools_scm
-  host:
-  - python >=3.9
-  - pip
   run:
   - python >=3.9
   - coloredlogs

--- a/docs/source/upcoming_release_notes/620-fix_auto_scrollable.rst
+++ b/docs/source/upcoming_release_notes/620-fix_auto_scrollable.rst
@@ -1,0 +1,25 @@
+620 fix_auto_scrollable
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where detailed tree screens would automatically load without
+  scrollbars. Now, the "auto" scrollbar setting is based primarily on the
+  apparent display type of the screen, not of the originally requested
+  display type, which may not be used if no such template exists.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -257,7 +257,7 @@ class TyphosSuite(TyphosBase):
         *,
         pin: bool = False,
         content_layout: QtWidgets.QLayout | None = None,
-        default_display_type: DisplayTypes = DisplayTypes.detailed_screen,
+        default_display_type: DisplayTypes = DisplayTypes.embedded_screen,
         scroll_option: ScrollOptions = ScrollOptions.auto,
     ):
         super().__init__(parent=parent)

--- a/typhos/tests/test_display.py
+++ b/typhos/tests/test_display.py
@@ -95,6 +95,7 @@ def test_display_without_md(motor, display):
 
 def test_display_with_md(motor, display):
     screen = 'engineering_screen.ui'
+    display.display_type = DisplayTypes.detailed_screen
     display.add_device(
         motor, macros={'detailed_screen': screen})
     display.load_best_template()
@@ -156,6 +157,7 @@ def test_display_device_name_property(motor, display, qtbot):
 def test_display_with_py_file(display, motor, qtbot):
     qtbot.add_widget(display)
     py_file = str(conftest.MODULE_PATH / 'utils' / 'display.py')
+    display.display_type = DisplayTypes.detailed_screen
     display.add_device(motor, macros={'detailed_screen': py_file})
     display.load_best_template()
     assert isinstance(display.display_widget, Display)

--- a/typhos/tests/test_display.py
+++ b/typhos/tests/test_display.py
@@ -187,16 +187,22 @@ def test_display_with_sig_template(display, device, qapp, qtbot):
         (Path("user/module/Potato.embedded.ui"), DisplayTypes.embedded_screen),
         (Path("user/module/Potato.detailed.ui"), DisplayTypes.detailed_screen),
         (Path("user/module/Potato.engineering.ui"), DisplayTypes.engineering_screen),
+    ]
+)
+def test_get_template_display_type_good(path: Path, expected: DisplayTypes):
+    assert get_template_display_type(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
         (Path("user/module/enigma.ui"), ValueError),
         (Path("user/module/not_very_detailed.ui"), ValueError),
     ]
 )
-def test_get_template_display_type(path: Path, expected: DisplayTypes | Exception):
-    if issubclass(expected, Exception):
-        with pytest.raises(expected):
-            get_template_display_type(path)
-    else:
-        assert get_template_display_type(path) == expected
+def test_get_template_display_type_bad(path: Path, expected: type[Exception]):
+    with pytest.raises(expected):
+        get_template_display_type(path)
 
 
 def test_display_effective_display_type(display, device, qapp, qtbot):

--- a/typhos/tests/test_display.py
+++ b/typhos/tests/test_display.py
@@ -190,7 +190,7 @@ def test_display_with_sig_template(display, device, qapp, qtbot):
     ]
 )
 def test_get_template_display_type(path: Path, expected: DisplayTypes | Exception):
-    if isinstance(expected, Exception):
+    if issubclass(expected, Exception):
         with pytest.raises(expected):
             get_template_display_type(path)
     else:

--- a/typhos/tests/test_display.py
+++ b/typhos/tests/test_display.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
 import ophyd
 import pytest
 from pydm import Display
 
 import typhos.display
 from typhos import utils
+from typhos.display import DisplayTypes, get_template_display_type
 
 from . import conftest
 from .conftest import show_widget
@@ -166,3 +171,40 @@ def test_display_with_sig_template(display, device, qapp, qtbot):
         device.setpoint.put(num)
         qapp.processEvents()
         assert display.display_widget.ui.setpoint.text() == str(num)
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        (Path("typhos/ui/core/detailed_screen.ui"), DisplayTypes.detailed_screen),
+        (Path("typhos/ui/core/detailed_tree.ui"), DisplayTypes.detailed_screen),
+        (Path("typhos/ui/core/embedded_screen.ui"), DisplayTypes.embedded_screen),
+        (Path("typhos/ui/core/engineering_screen.ui"), DisplayTypes.engineering_screen),
+        (Path("typhos/ui/devices/PositionerBase.detailed.ui"), DisplayTypes.detailed_screen),
+        (Path("typhos/ui/devices/PositionerBase.embedded.ui"), DisplayTypes.embedded_screen),
+        (Path("user/module/Potato.embedded.ui"), DisplayTypes.embedded_screen),
+        (Path("user/module/Potato.detailed.ui"), DisplayTypes.detailed_screen),
+        (Path("user/module/Potato.engineering.ui"), DisplayTypes.engineering_screen),
+        (Path("user/module/enigma.ui"), ValueError),
+        (Path("user/module/not_very_detailed.ui"), ValueError),
+    ]
+)
+def test_get_template_display_type(path: Path, expected: DisplayTypes | Exception):
+    if isinstance(expected, Exception):
+        with pytest.raises(expected):
+            get_template_display_type(path)
+    else:
+        assert get_template_display_type(path) == expected
+
+
+def test_display_effective_display_type(display, device, qapp, qtbot):
+    qtbot.add_widget(display)
+    assert display.effective_display_type == display.display_type
+    display.force_template = str(conftest.MODULE_PATH / 'utils' / 'sig.ui')
+    assert display.effective_display_type == display.display_type
+    display.force_template = str(conftest.MODULE_PATH.parent / 'ui' / 'core' / 'embedded_screen.ui')
+    assert display.effective_display_type == DisplayTypes.embedded_screen
+    display.force_template = str(conftest.MODULE_PATH.parent / 'ui' / 'core' / 'detailed_tree.ui')
+    assert display.effective_display_type == DisplayTypes.detailed_screen
+    display.force_template = str(conftest.MODULE_PATH.parent / 'ui' / 'core' / 'engineering_screen.ui')
+    assert display.effective_display_type == DisplayTypes.engineering_screen


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Make scrollable=auto choose to include the scollbar or not based on the chosen template's display type. Previously, it was the selected type, even if that loaded a differently typed template. This means that "embedded" displays that open up large trees will now automatically be given scrollbars.
- Add some helpers to accomplish the above
- Add some tests to verify the above
- Switch display/suite defaults to match the cli defaults

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #599 
as part of https://jira.slac.stanford.edu/browse/ECS-6333

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added some tests and ran some devices interactively.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only here so far, and in the pre-release notes.
I was going to rewrite the cli help text but the original text more closely matches the new behavior than the old behavior.
```
parser.add_argument(
    '--scrollable',
    default='auto',
    help=(
        'Whether or not to include the scrollbar. '
        'Valid options are "auto", "true", "false", '
        'and any unique shortenings of those options. '
        'Selecting "auto" will include a scrollbar for '
        'non-embedded layouts.'
    ),
)
```

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
