### PR TITLE
FIX: formalize hotfix for resizing empty comboboxes

### DIFF
--- a/docs/source/upcoming_release_notes/621-fix_combobox_resize_crash.rst
+++ b/docs/source/upcoming_release_notes/621-fix_combobox_resize_crash.rst
@@ -1,0 +1,23 @@
+621 fix_combobox_resize_crash
+#############################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where dynamic font scaling applied to a combobox
+  with no entries would raise an exception and close typhos.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/dynamic_font.py
+++ b/typhos/dynamic_font.py
@@ -276,6 +276,8 @@ def patch_combo_widget(
             )
             for text in combo_options
         ]
+        if not font_sizes:
+            return
         set_font_common(
             widget=widget,
             font_size=min(font_sizes),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This is a hotfix we've been using for a while at LCLS.
It helps us avoid raising an exception the dynamic font rescaling function when it is applied to a combobox with no entries.

The normal logic flow here is to calculate the maximum allowable font size for each possible combobox entry, then take the minimum of these results so that any of the entries would fit in the combobox.

When there are no entries, we can't take the `min` of an empty list, leading to an exception.
Instead, the code will now exit since there's no reason to resize anything if there is no text.

This is an incomplete fix, the complete version would also include a dynamic resize when the combobox options are changed.
The reason this fix was never completed is that, after the IOC that caused this problem was fixed, we no longer had a test case to develop further code against. This test case also never yielded us valid enum strings to work with, so the only part that could be verified is the part that stopped the screen from completely crashing on the exception.

This was deemed "good enough" because it stops the screen from crashing at least. I think it's also good enough to be included in the default branch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This prevents these edge case malformed enum cases from crashing screens (instead: empty combobox).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively and in production at LCLS for many months.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [ ] ~New/changed functions and methods are covered in the test suite where possible~
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
