### PR TITLE
FIX: set message crash with long error message

### DIFF
--- a/docs/source/upcoming_release_notes/622-fix_long_pos_msg_crash.rst
+++ b/docs/source/upcoming_release_notes/622-fix_long_pos_msg_crash.rst
@@ -1,0 +1,23 @@
+622 fix_long_pos_msg_crash
+##########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fix an issue where long status messages from positioner widget moves
+  would fail to display in certain circumstances.
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- zllentz

--- a/typhos/positioner.py
+++ b/typhos/positioner.py
@@ -801,7 +801,7 @@ class TyphosPositionerWidget(
                 tooltip = f"{text}: {tooltip}"
             else:
                 tooltip = text
-            text = message.text[:max_length] + '...'
+            text = text[:max_length] + '...'
         self.ui.status_label.setText(text)
         if tooltip and "\n" not in tooltip:
             # Force rich text, qt auto line wraps if it detects rich text

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -298,5 +298,6 @@ def test_positioner_widget_long_status_text(motor_widget, qtbot):
         ),
         max_length=50,
     )
+    text = widget.ui.status_label.text()
     assert text.endswith("...")
     assert len(text) < 60

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -277,8 +277,8 @@ def test_positioner_widget_move_error(motor_widget, qtbot):
 
 
 @pytest.mark.no_gc
-def test_positioner_widget_long_status_text(motor_widget, qtbot):
-    motor, widget = motor_widget
+def test_positioner_widget_long_status_text(motor_widget):
+    _, widget = motor_widget
 
     assert widget.ui.status_label.text() == ''
 

--- a/typhos/tests/test_positioner.py
+++ b/typhos/tests/test_positioner.py
@@ -20,7 +20,7 @@ from ophyd.utils.errors import LimitError, UnknownStatusFailure
 
 from typhos.alarm import KindLevel
 from typhos.positioner import TyphosPositionerWidget
-from typhos.status import TyphosStatusResult
+from typhos.status import TyphosStatusMessage, TyphosStatusResult
 from typhos.utils import SignalRO
 
 from .conftest import RichSignal, show_widget
@@ -274,3 +274,29 @@ def test_positioner_widget_move_error(motor_widget, qtbot):
         assert 'LimitError' in widget.ui.status_label.text()
 
     qtbot.waitUntil(has_limit_error, timeout=1000)
+
+
+@pytest.mark.no_gc
+def test_positioner_widget_long_status_text(motor_widget, qtbot):
+    motor, widget = motor_widget
+
+    assert widget.ui.status_label.text() == ''
+
+    widget._set_status_text("Oh no! " * 1000, max_length=50)
+
+    text = widget.ui.status_label.text()
+    assert text.endswith("...")
+    assert len(text) < 60
+
+    widget._set_status_text("")
+    assert widget.ui.status_label.text() == ''
+
+    widget._set_status_text(
+        TyphosStatusMessage(
+            "Error! " * 1000,
+            tooltip="Test suite giant error string!",
+        ),
+        max_length=50,
+    )
+    assert text.endswith("...")
+    assert len(text) < 60


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Fix an issue where the "text is too long" branch of the positioner widget's _set_status_text method would not work if the input was a string. There was an implementation error where we checked the input type but did not fully leverage it.
- Add a test for regression coverage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Tong ran into an issue today where an exception was being raised for what ended up being a limit error, but since the text for the limit error was very long it ended up triggering this bug.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively via hotfix + here via unit test

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Adding pre-release notes

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
