### PR TITLE
BLD: force py312 compatible versions of line-profiler

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,7 +57,7 @@ test:
   - flake8
   - ipython>=7.16
   - jinja2<3.1
-  - line_profiler
+  - line_profiler>=4.1.2
   - pcdsdevices>=8.4.0
   - pytest
   - pytest-benchmark

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,9 +26,9 @@ requirements:
   - python >=3.9
   - coloredlogs
   - entrypoints
-  - numpy
+  - numpy <2.0.0
   - numpydoc
-  - ophyd >=1.5.0
+  - ophyd >=1.8.0
   - pcdsutils
   - platformdirs
   - pydm >=1.19.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ caproto
 flake8
 ipython>=7.16
 jinja2
-line_profiler
+line_profiler>=4.1.2
 pcdsdevices>=8.4.0
 pytest
 pytest-benchmark

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ coloredlogs
 entrypoints
 numpy
 numpydoc
-ophyd
+ophyd==1.7.0
 pcdsutils
 platformdirs
 PyQt5


### PR DESCRIPTION
## Description
A questionably correct change, but aimed primarily at trying to reproduce test suite failures in https://github.com/pcdshub/pcds-envs/pull/353

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
