### PR TITLE
ENH: Zach's impressive 11 char fix to _update_children 

### DIFF
--- a/docs/source/upcoming_release_notes/625-fix_add_device_behavior_with_custom_displays.rst
+++ b/docs/source/upcoming_release_notes/625-fix_add_device_behavior_with_custom_displays.rst
@@ -1,0 +1,23 @@
+625 fix add_device behavior with custom displays
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Allows custom displays with "add_device" methods to hook typhos correctly
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz
+- aberges-SLAC

--- a/typhos/display.py
+++ b/typhos/display.py
@@ -1467,7 +1467,7 @@ class TyphosDeviceDisplay(utils.TyphosBase, widgets.TyphosDesignerMixin,
         designer = display.findChildren(widgets.TyphosDesignerMixin) or []
         bases = display.findChildren(utils.TyphosBase) or []
 
-        for widget in set(bases + designer):
+        for widget in set(bases + designer + [display]):
             if device and hasattr(widget, 'add_device'):
                 widget.add_device(device)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Make changes to _update_children to relink to a parent display so you can pass an ophyd.device to a custom pyqt screen. This allows you to run methods off the `.py` UIs and handle dynamic changes.

## Motivation and Context
Both (upcoming `pcdsdevices`) `SmarAct.detailed.py` and `SmarActTipTilt.embedded.py` required accessing device information that _should've_ been added when `typhos` does it's magic, but would skip over the `display` without this change.

## How Has This Been Tested?
Very minimal change, testament to Zach's brevity. I tested this out on my custom displays in my `pcdsdevices` repo and it worked splendidly. 

## Where Has This Been Documented?
This PR

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
