### PR TITLE
Add long names

### DIFF
--- a/docs/source/upcoming_release_notes/625-fix_add_device_behavior_with_custom_displays.rst
+++ b/docs/source/upcoming_release_notes/625-fix_add_device_behavior_with_custom_displays.rst
@@ -1,0 +1,23 @@
+625 fix add_device behavior with custom displays
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Allows custom displays with "add_device" methods to hook typhos correctly
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- ZLLentz
+- aberges-SLAC

--- a/docs/source/upcoming_release_notes/627-Add_long_name_for_SignalPanel.rst
+++ b/docs/source/upcoming_release_notes/627-Add_long_name_for_SignalPanel.rst
@@ -1,0 +1,22 @@
+627 Add long_name for SignalPanel
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add `long_name` support for `device.signal` or `device.component.signal` that replace `label_text` for rows in `SignalPanel`
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- aberges-SLAC

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -250,7 +250,7 @@ class SignalPanel(QtWidgets.QGridLayout):
         tooltip: str
             Doc string to add to signal
         long_name: str, optional
-            Long form (human readable) name to use for the signal row label text.    
+            Long form (human readable) name to use for the signal row label text.
         """
         if long_name:
             label_text = long_name
@@ -268,7 +268,7 @@ class SignalPanel(QtWidgets.QGridLayout):
 
     def _get_long_name(self, device, attr, dotted_name) -> str:
         """
-        Check the signal for its long_name, if it exists. 
+        Check the signal for its long_name, if it exists.
         Until Ophyd makes it a standard signal, need to manually check
         the device and its components for the name.
 
@@ -294,7 +294,6 @@ class SignalPanel(QtWidgets.QGridLayout):
             if hasattr(getattr(device, dotted_name), 'long_name'):
                 long_name = getattr(device, dotted_name).long_name
         return long_name
-
 
     def add_signal(self, signal, name=None, long_name=None, *, tooltip=None):
         """
@@ -328,7 +327,7 @@ class SignalPanel(QtWidgets.QGridLayout):
             return
 
         logger.debug("Adding signal %s (%s)", signal.name, name)
-        
+
         label = self._create_row_label(attr=name, dotted_name=name, long_name=long_name, tooltip=tooltip)
         loading = utils.TyphosLoading(
             timeout_message='Connection timed out.'

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -266,7 +266,7 @@ class SignalPanel(QtWidgets.QGridLayout):
             label.setToolTip(_tooltip)
         return label
 
-    def _get_long_name(self, device, attr, dotted_name) -> str:
+    def _get_long_name(self, device, attr, dotted_name):
         """
         Check the signal for its long_name, if it exists.
         Until Ophyd makes it a standard signal, need to manually check

--- a/typhos/panel.py
+++ b/typhos/panel.py
@@ -285,15 +285,13 @@ class SignalPanel(QtWidgets.QGridLayout):
         --------
             str or None
         """
-        long_name = None
         try:
             if hasattr(getattr(device, attr), 'long_name'):
-                long_name = getattr(device, attr).long_name
+                return getattr(device, attr).long_name
         except AttributeError:
             # Then maybe we have a nested component and can't touch the signal
             if hasattr(getattr(device, dotted_name), 'long_name'):
-                long_name = getattr(device, dotted_name).long_name
-        return long_name
+                return getattr(device, dotted_name).long_name
 
     def add_signal(self, signal, name=None, long_name=None, *, tooltip=None):
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Made changes to `SignalPanel` class  in `display` module to support `long_names` for device signals. This approach should be _pretty_ close to compatible with https://github.com/bluesky/ophyd/pull/1187, so if & when that comes through we should only need minimal changes.

## Motivation and Context
Have you ever had a screen with 30+ signals and maybe multiple subcomponent devices with identical signal names?  Maybe you wanted alternative signal labels for cleaner GUI that end users can play with?

Figured some of the work I did in https://github.com/pcdshub/pcdsdevices/pull/1320 could be generalized in `typhos` and potentially trim the fat out of my screen scripts. 

Long names lets you use an optional string to replace the `label_text` in a `signal row` object added to your grid of signals. When you use a `long_name`, it will add the signal's `dotted_name` to the tooltip so you can still hover and get hutch python context.

## How Has This Been Tested?
I didn't have any unit tests to run, per se, but I did test this on a variety of devices for screens we've got out in prod (and some I'm cooking in a different PR). 

I was able to open the entire CRIXS MODS screen without everything crashing and burning, so that's gotta amount to something, right?

https://github.com/user-attachments/assets/845e1877-e2c5-4409-9680-1f46b9946226

## Where Has This Been Documented?
This PR! And in the code itself

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
