### PR TITLE
BLD: Pin back pydm to avoid test suite segfaults/recursion-depth-errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -23,11 +23,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.11.5
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   - ophyd >=1.5.0
   - pcdsutils
   - platformdirs
-  - pydm >=1.19.1
+  - pydm >=1.19.1,<1.26.0
   - pyqt =5
   - pyqtgraph
   - pyyaml

--- a/docs/source/upcoming_release_notes/629-tst_recursion_depth.rst
+++ b/docs/source/upcoming_release_notes/629-tst_recursion_depth.rst
@@ -1,0 +1,22 @@
+629 tst_recursion_depth
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Pin pydm to avoid segfaults in test suite
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ophyd
 pcdsutils
 platformdirs
 PyQt5
-pydm>=1.19.1
+pydm>=1.19.1,<1.26.0
 pyqtgraph
 pyyaml
 qdarkstyle


### PR DESCRIPTION
## Description
I saw some failures in the env builds and wanted to track them down.  Turns out pydm has updated something that breaks our test suite.

For now, I'm going to pin this back.  I'll spend some limited amount of time trying to track down the failure, but pydm is not the most stable at the moment, it seems

## Motivation and Context
tests pls pass

## How Has This Been Tested?
CI, and locally for more detail

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
