### PR TITLE
MNT: disconnect slots with destruction in mind

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -23,11 +23,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.11.5
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/docs/source/upcoming_release_notes/630-mnt_destroy.rst
+++ b/docs/source/upcoming_release_notes/630-mnt_destroy.rst
@@ -1,0 +1,22 @@
+630 mnt_destroy
+###############
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Clean up signal plugin with channel.disconnect(destroying=True), since channels are being deleted on test cleanup
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/typhos/plugins/core.py
+++ b/typhos/plugins/core.py
@@ -314,7 +314,7 @@ class SignalConnection(PyDMConnection):
         if channel.value_signal is not None and not destroying:
             for _typ in self.supported_types:
                 try:
-                    channel.value_signal[_typ].disconnect(self.put_value)
+                    channel.value_signal[_typ].disconnect(self.put_value, destroying)
                 except (KeyError, TypeError):
                     logger.debug("Unable to disconnect value_signal from %s "
                                  "for type %s", channel.address, _typ)

--- a/typhos/tests/conftest.py
+++ b/typhos/tests/conftest.py
@@ -427,7 +427,7 @@ def reset_signal_plugin():
     signal_registry.clear()
     plugin = plugin_for_address('sig://test')
     for channel in list(plugin.channels):
-        channel.disconnect()
+        channel.disconnect(destroying=True)
 
 
 @pytest.fixture(scope='function', autouse=True)


### PR DESCRIPTION
## Description
- Disconnect signals with `destroying=True` in the cleanup of our test suite channels/connections
- Pass around the `destroying` parameter to PyDMChannel's signal.disconnect methods for good measure (this didn't actually solve the issue)

## Motivation and Context
Test suite was segfaulting, and I prematurely blamed pydm and attempted to pin.  Turns out there was something to do on our side. 

PyDM recently started passing around the `destroying` parameter and acting on it more thoroughly, and a knock on effect of this was a break in our tests.  I think it has to do with https://github.com/slaclab/pydm/pull/1218, but the end result was that we were trying to destroy a bunch of signals with `destroying=False`, while qt/qtbot had already deleted them.

In more verbose terms, the previous failure mode was:
```
.    >> reset signal plugin
start cli stylesheet
... test output
end cli stylesheet
    >> PyDMPlugin.remove_connection: test_motor, True
        >> typhos SignalConnection.remove_listener: <PyDMChannel (sig://test_motor)> True
    >> PyDMPlugin.remove_connection: test_motor_setpoint, True
        >> typhos SignalConnection.remove_listener: <PyDMChannel (sig://test_motor_setpoint)> True
    >> PyDMPlugin.remove_connection: test_motor_velocity, True
        >> typhos SignalConnection.remove_listener: <PyDMChannel (sig://test_motor_velocity)> True
    >> PyDMPlugin.remove_connection: test_motor_acceleration, True
        >> typhos SignalConnection.remove_listener: <PyDMChannel (sig://test_motor_acceleration)> True
. (test teardown completed)

(starting next test)
>> reset signal plugin
>> rm_conn: test_motor_velocity, False
Fatal Python error: Segmentation fault
```

So in words, during the test teardown a bunch of signals get their connections removed through widget destruction.  When the next test starts, our `reset_signal_plugin` tries to clean up once again, going through and disconnecting all its channels.  However if it hits a widget that's already been deleted, we segfault.

## How Has This Been Tested?
Test suite passes

## Where Has This Been Documented?
This PR

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
