### PR TITLE
BUG/MNT: add value opt to pyqtgraph.parametertree.Parameter and its subclasses

### DIFF
--- a/docs/source/upcoming_release_notes/635-bug_parametertree_value.rst
+++ b/docs/source/upcoming_release_notes/635-bug_parametertree_value.rst
@@ -1,0 +1,22 @@
+635 bug_parametertree_value
+###########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Ensures value is provided at __init__ for all subclasses of pyqtgraph.parametertree.Parameter
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/typhos/suite.py
+++ b/typhos/suite.py
@@ -53,6 +53,8 @@ class SidebarParameter(parametertree.Parameter):
     sigEmbed = QtCore.Signal(object)
 
     def __init__(self, devices=None, embeddable=None, **opts):
+        if "value" not in opts:
+            opts["value"] = None
         super().__init__(**opts)
         self.embeddable = embeddable
         self.devices = list(devices) if devices else []
@@ -266,7 +268,7 @@ class TyphosSuite(TyphosBase):
 
         self._tree = parametertree.ParameterTree(parent=self, showHeader=False)
         self._tree.setAlternatingRowColors(False)
-        self._save_action = ptypes.ActionParameter(name='Save Suite')
+        self._save_action = ptypes.ActionParameter(name='Save Suite', value=None)
         self._tree.addParameters(self._save_action)
         self._save_action.sigActivated.connect(self.save)
 
@@ -895,7 +897,7 @@ class TyphosSuite(TyphosBase):
                 group = self.top_level_groups[category]
             else:
                 logger.debug("Creating new category %r ...", category)
-                group = ptypes.GroupParameter(name=category)
+                group = ptypes.GroupParameter(name=category, value=None)
                 self._tree.addParameters(group)
                 self._tree.sortItems(0, QtCore.Qt.AscendingOrder)
             logger.debug("Adding %r to category %r ...",

--- a/typhos/tests/test_log.py
+++ b/typhos/tests/test_log.py
@@ -1,5 +1,6 @@
 from ophyd import Device
 
+from typhos.tests import conftest
 from typhos.tools import TyphosLogDisplay
 
 
@@ -18,3 +19,5 @@ def test_log_display(qtbot):
     dev2 = Device(name='blah')
     log_tool.add_device(dev2)
     assert log_tool.logdisplay.handler in get_handlers(dev2)
+    for device in (dev, dev2):
+        conftest.clear_handlers(device)


### PR DESCRIPTION
## Description
- Ensures `value` is provided at `__init__` for all subclasses of `pyqtgraph.parametertree.Parameter`

## Motivation and Context
Gotta love those breaking updates!  In fairness this was as deprecation warning we didn't clock, and they've just deprecated it a month early.

We subclass `Parameter` once, so there we set a `value=None` as default.  In other places where we use built-in types, we initialize `value=None` as well.

## How Has This Been Tested?
By getting the test suite to pass. 

I've also checked in the test suite that the values we collect are the same, by inspecting the `items` dictionary from [here](https://github.com/pcdshub/typhos/blob/master/typhos/suite.py#L875).  both before and after this patch, the form of the dictionary is the same (only the object ids change)

## Where Has This Been Documented?
This PR, and pre-release notes

## Pre-merge checklist
- [x] Code works interactively
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Code has been checked for threading issues (no blocking tasks in GUI thread)
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
